### PR TITLE
feat: graceful shutdown and Wake-on-LAN power controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,18 @@ Copy `.env.example` to `.env` if needed:
 ### Adding a Spark
 
 1. Open the **+** tab.
-2. Set **Name**, **LAN IP** (required), optional **CX7 IP**, **SSH user**, and auth (key or password).
+2. Set **Name**, **LAN IP** (required), optional **CX7 IP**, optional **MAC address** (for Wake-on-LAN), **SSH user**, and auth (key or password).
 3. **Test Connection** for SSH + LLM reachability.
 4. Save — a tab appears and metrics start streaming.
+
+### Power controls (shutdown / Wake-on-LAN)
+
+- **Shutdown** (per Spark or **Shutdown All** on Overview) runs over SSH:  
+  `sudo -n /usr/local/bin/spark-shutdown`  
+  Install that script on each Spark and allow passwordless sudo for it only.
+- **Wake** / **Wake All** send a UDP magic packet (port 9) to the Spark’s MAC. Set **MAC Address** in Edit Spark. Broadcast is derived as `/24` from LAN IP, or `255.255.255.255` if LAN IP is missing.
+- Batch shutdown only targets **online** Sparks; offline nodes are skipped.
+- Same trust model as the rest of the API: **do not expose port 5555** beyond a trusted network — power actions are not separately authenticated.
 
 ### Themes
 
@@ -244,7 +253,8 @@ Choice is stored in `localStorage`.
 - **Target validation** rejects clearly unsafe IPv4 targets (link-local `169.254.0.0/16`, `0.0.0.0/8`, multicast/reserved ≥ 224). Private, loopback, and public addresses are allowed so LAN and remote Sparks work.
 - SSH and HTTP probes use short timeouts (about 5 s SSH connect, 3 s HTTP) so a hung host cannot stall the poll loop.
 - Prefer **SSH keys** over passwords.
-- Treat the dashboard as **LAN-trusted**: the API is intentionally unauthenticated for ease of use on a private network.
+- Treat the dashboard as **LAN-trusted**: the API is intentionally unauthenticated for ease of use on a private network. That includes **power APIs** (shutdown / Wake-on-LAN): anyone who can reach the dashboard can request fleet power actions.
+
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docker:prod": "docker compose up -d",
     "docker:rebuild": "docker compose up --build -d",
     "frontend": "npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test test/*.test.mjs"
   },
   "keywords": ["nvidia", "dgx-spark", "gb10", "monitoring", "dashboard", "gpu", "llm"],
   "author": "Mia'a AI Lab",

--- a/server/index.js
+++ b/server/index.js
@@ -7,9 +7,10 @@ import { fileURLToPath } from "url";
 import dotenv from "dotenv";
 import { SparkRegistry } from "./sparks/SparkRegistry.js";
 import { SparkMonitor } from "./sparks/SparkMonitor.js";
-import { sshTest, llmTest } from "./collectors/ssh.js";
+import { sshExec, sshTest, llmTest } from "./collectors/ssh.js";
 import { validateSparkTarget, createRateLimiter } from "./validate.js";
 import { getSettings, updateSettings, loadSettings } from "./settings.js";
+import { broadcastForLanIp, normalizeMac, sendWol } from "./wol.js";
 
 dotenv.config();
 
@@ -543,6 +544,113 @@ app.post("/api/sparks/:id/llm/bench", async (req, res) => {
     });
   } catch (err) {
     res.status(500).json({ ok: false, message: err.message });
+  }
+});
+
+// ─── Power management ────────────────────────────────────
+// Shutdown uses host script: sudo -n /usr/local/bin/spark-shutdown (passwordless).
+// These routes are unauthenticated like the rest of the LAN dashboard — do not
+// expose port 5555 beyond a trusted network.
+
+const SHUTDOWN_CMD = "sudo -n /usr/local/bin/spark-shutdown";
+
+function shutdownErrorStatus(msg) {
+  if (/timed out|connection refused|unreachable|no route/i.test(msg)) return 503;
+  return 500;
+}
+
+/** Batch routes first so they never collide with /:id/* if routing changes. */
+app.post("/api/sparks/shutdown-all", async (_req, res) => {
+  const results = [];
+  for (const spark of registry.sparks) {
+    const monitor = monitors.get(spark.id);
+    if (!monitor?.online) {
+      results.push({ id: spark.id, ok: false, skipped: true, error: "Offline — skipped" });
+      continue;
+    }
+    try {
+      await sshExec(spark, SHUTDOWN_CMD);
+      results.push({ id: spark.id, ok: true });
+    } catch (err) {
+      results.push({ id: spark.id, ok: false, error: err.message || String(err) });
+    }
+  }
+  res.json({ success: true, results });
+});
+
+app.post("/api/sparks/wake-all", async (_req, res) => {
+  const results = [];
+  for (const spark of registry.sparks) {
+    const cleanMac = normalizeMac(spark.macAddress);
+    if (!cleanMac) {
+      results.push({
+        id: spark.id,
+        ok: false,
+        error: spark.macAddress ? `Invalid MAC: ${spark.macAddress}` : "No MAC address configured",
+      });
+      continue;
+    }
+    try {
+      const broadcast = broadcastForLanIp(spark.lanIp);
+      const sent = await sendWol(cleanMac, broadcast);
+      results.push({ id: spark.id, ok: true, mac: sent.mac, broadcast: sent.broadcast });
+    } catch (err) {
+      results.push({ id: spark.id, ok: false, error: err.message || String(err) });
+    }
+  }
+  res.json({ success: true, results });
+});
+
+app.post("/api/sparks/:id/shutdown", async (req, res) => {
+  try {
+    const spark = registry.getSpark(req.params.id);
+    if (!spark) return res.status(404).json({ error: "Spark not found" });
+
+    try {
+      const result = await sshExec(spark, SHUTDOWN_CMD);
+      res.json({ success: true, message: "Shutdown initiated", output: result });
+    } catch (err) {
+      const msg = err.message || String(err);
+      res.status(shutdownErrorStatus(msg)).json({
+        error: shutdownErrorStatus(msg) === 503 ? `Spark unreachable: ${msg}` : msg,
+      });
+    }
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post("/api/sparks/:id/wake", async (req, res) => {
+  try {
+    const spark = registry.getSpark(req.params.id);
+    if (!spark) return res.status(404).json({ error: "Spark not found" });
+
+    const cleanMac = normalizeMac(spark.macAddress || req.body?.mac);
+    if (!cleanMac) {
+      if (!spark.macAddress && !req.body?.mac) {
+        return res.status(400).json({
+          error: "No MAC address configured. Set macAddress on the Spark or pass mac in the body.",
+        });
+      }
+      return res.status(400).json({
+        error: `Invalid MAC address: ${spark.macAddress || req.body?.mac}`,
+      });
+    }
+
+    const broadcast = broadcastForLanIp(spark.lanIp);
+    try {
+      const sent = await sendWol(cleanMac, broadcast);
+      res.json({
+        success: true,
+        message: `Magic packet sent to ${sent.mac} via ${sent.broadcast}`,
+        mac: sent.mac,
+        broadcast: sent.broadcast,
+      });
+    } catch (err) {
+      res.status(500).json({ error: `WoL send failed: ${err.message || String(err)}` });
+    }
+  } catch (err) {
+    res.status(500).json({ error: err.message });
   }
 });
 

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -285,6 +285,7 @@ export class SparkRegistry {
       name: config.name || config.id,
       lanIp: config.lanIp || "",
       cx7Ip: config.cx7Ip || null,
+      macAddress: config.macAddress || null,
       isLocal: Boolean(config.isLocal),
       ssh,
       llmPorts,

--- a/server/wol.js
+++ b/server/wol.js
@@ -1,0 +1,88 @@
+/**
+ * Wake-on-LAN helpers: MAC validation, /24 broadcast derivation, magic packet send.
+ */
+import dgram from "node:dgram";
+
+const MAC_RE = /^([0-9a-f]{2}[:\-]){5}[0-9a-f]{2}$/;
+
+/** @param {unknown} mac */
+export function normalizeMac(mac) {
+  if (mac == null) return null;
+  const clean = String(mac).trim().toLowerCase();
+  if (!MAC_RE.test(clean)) return null;
+  return clean;
+}
+
+/**
+ * Derive a /24 directed broadcast from an IPv4 address, else global broadcast.
+ * @param {unknown} lanIp
+ */
+export function broadcastForLanIp(lanIp) {
+  if (typeof lanIp === "string" && /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(lanIp.trim())) {
+    const parts = lanIp.trim().split(".");
+    const nums = parts.map((p) => Number(p));
+    if (nums.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)) {
+      return `${nums[0]}.${nums[1]}.${nums[2]}.255`;
+    }
+  }
+  return "255.255.255.255";
+}
+
+/**
+ * Build a WoL magic packet for a normalized MAC (aa:bb:… or aa-bb-…).
+ * @param {string} cleanMac
+ */
+export function buildMagicPacket(cleanMac) {
+  const macBytes = cleanMac.split(/[:\-]/).map((b) => parseInt(b, 16));
+  const magic = Buffer.alloc(6 + 16 * 6);
+  magic.fill(0xff, 0, 6);
+  for (let i = 0; i < 16; i++) {
+    for (let j = 0; j < 6; j++) {
+      magic[6 + i * 6 + j] = macBytes[j];
+    }
+  }
+  return magic;
+}
+
+/**
+ * Send one WoL magic packet. Settles exactly once (no hanging bind, no double settle).
+ * @param {string} cleanMac normalized MAC
+ * @param {string} [broadcastAddr]
+ * @param {number} [port=9]
+ * @returns {Promise<{ mac: string, broadcast: string }>}
+ */
+export function sendWol(cleanMac, broadcastAddr = "255.255.255.255", port = 9) {
+  const magic = buildMagicPacket(cleanMac);
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (err, result) => {
+      if (settled) return;
+      settled = true;
+      try {
+        sock.close();
+      } catch {
+        /* ignore */
+      }
+      if (err) reject(err);
+      else resolve(result);
+    };
+
+    const sock = dgram.createSocket("udp4");
+    sock.on("error", (err) => {
+      finish(err);
+    });
+
+    sock.bind(0, () => {
+      try {
+        sock.setBroadcast(true);
+        sock.send(magic, 0, magic.length, port, broadcastAddr, (err) => {
+          if (err) finish(err);
+          else finish(null, { mac: cleanMac, broadcast: broadcastAddr });
+        });
+      } catch (err) {
+        finish(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  });
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -170,6 +170,48 @@ export function updateLlmPort(
   });
 }
 
+// ─── Power management ────────────────────────────────────
+export interface PowerResult {
+  success: boolean;
+  message?: string;
+  output?: string;
+  mac?: string;
+  broadcast?: string;
+  error?: string;
+}
+
+export interface BatchPowerResult {
+  success: boolean;
+  results: {
+    id: string;
+    ok: boolean;
+    error?: string;
+    skipped?: boolean;
+    mac?: string;
+    broadcast?: string;
+  }[];
+}
+
+/** Gracefully shut down a single Spark (host script: spark-shutdown). */
+export function shutdownSpark(id: string): Promise<PowerResult> {
+  return apiFetch(`/api/sparks/${id}/shutdown`, { method: "POST" });
+}
+
+/** Send a Wake-on-LAN magic packet to a single Spark. */
+export function wakeSpark(id: string): Promise<PowerResult> {
+  return apiFetch(`/api/sparks/${id}/wake`, { method: "POST" });
+}
+
+/** Shut down Sparks that are currently online. */
+export function shutdownAllSparks(): Promise<BatchPowerResult> {
+  return apiFetch("/api/sparks/shutdown-all", { method: "POST" });
+}
+
+/** Send WoL to all registered Sparks that have a MAC configured. */
+export function wakeAllSparks(): Promise<BatchPowerResult> {
+  return apiFetch("/api/sparks/wake-all", { method: "POST" });
+}
+
 // ─── Global settings ──────────────────────────────────────
 export function fetchSettings(): Promise<Settings> {
   return apiFetch("/api/settings");

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -4,6 +4,8 @@ export interface SparkConfig {
   name: string;
   lanIp: string;
   cx7Ip?: string | null;
+  /** Ethernet MAC for Wake-on-LAN (aa:bb:cc:dd:ee:ff) */
+  macAddress?: string | null;
   isLocal: boolean;
   ssh: {
     host: string;

--- a/src/components/EditSparkDialog.tsx
+++ b/src/components/EditSparkDialog.tsx
@@ -197,6 +197,7 @@ export function EditSparkDialog({
         name: config.name,
         lanIp: config.lanIp,
         cx7Ip: config.cx7Ip,
+        macAddress: config.macAddress || null,
         isLocal: config.isLocal,
         ssh: {
           host: config.ssh.host || config.lanIp,
@@ -270,6 +271,17 @@ export function EditSparkDialog({
                 type="text"
                 value={config.cx7Ip || ""}
                 onChange={(e) => update({ cx7Ip: e.target.value || null })}
+                className="w-full rounded border border-border bg-surface-elevated px-3 py-1.5 text-xs text-text outline-none focus:border-accent"
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs text-muted">MAC Address (Wake-on-LAN)</label>
+              <input
+                type="text"
+                value={config.macAddress || ""}
+                onChange={(e) => update({ macAddress: e.target.value || null })}
+                placeholder="e.g. 00:1a:2b:3c:4d:5e"
                 className="w-full rounded border border-border bg-surface-elevated px-3 py-1.5 text-xs text-text outline-none focus:border-accent"
               />
             </div>

--- a/src/components/OverviewPage/OverviewPage.tsx
+++ b/src/components/OverviewPage/OverviewPage.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import type { SparkSnapshot } from "../../api/types";
+import { shutdownAllSparks, wakeAllSparks } from "../../api/client";
 import { MetricBar } from "../ui/MetricBar";
-import { ActivityIcon } from "../ui/icons";
+import { ActivityIcon, PowerOffIcon, PowerOnIcon } from "../ui/icons";
 
 interface OverviewPageProps {
   sparks: SparkSnapshot[];
@@ -212,6 +214,61 @@ function SparkCard({ spark, temperatureUnit, onSelect }: { spark: SparkSnapshot;
 
 export function OverviewPage({ sparks, hideOffline = false, temperatureUnit = "celsius", onSelectSpark }: OverviewPageProps) {
   const visibleSparks = hideOffline ? sparks.filter((s) => s.online) : sparks;
+  const [batchLoading, setBatchLoading] = useState(false);
+  const [batchMsg, setBatchMsg] = useState<{ text: string; tone: "ok" | "err" } | null>(null);
+
+  async function handleShutdownAll() {
+    const onlineCount = sparks.filter((s) => s.online).length;
+    if (onlineCount === 0) return;
+    if (!confirm(`Gracefully shut down all ${onlineCount} online Spark(s)? Offline nodes will be skipped.`)) {
+      return;
+    }
+    setBatchLoading(true);
+    setBatchMsg(null);
+    try {
+      const res = await shutdownAllSparks();
+      const ok = res.results.filter((r) => r.ok).length;
+      const fail = res.results.filter((r) => !r.ok && !r.skipped).length;
+      const skipped = res.results.filter((r) => r.skipped).length;
+      const parts = [`${ok} shut down`];
+      if (fail) parts.push(`${fail} failed`);
+      if (skipped) parts.push(`${skipped} skipped`);
+      setBatchMsg({
+        text: parts.join(", "),
+        tone: fail === 0 ? "ok" : "err",
+      });
+    } catch (err: unknown) {
+      setBatchMsg({
+        text: err instanceof Error ? err.message : "Batch shutdown failed",
+        tone: "err",
+      });
+    } finally {
+      setBatchLoading(false);
+      setTimeout(() => setBatchMsg(null), 6000);
+    }
+  }
+
+  async function handleWakeAll() {
+    setBatchLoading(true);
+    setBatchMsg(null);
+    try {
+      const res = await wakeAllSparks();
+      const ok = res.results.filter((r) => r.ok).length;
+      const fail = res.results.filter((r) => !r.ok).length;
+      setBatchMsg({
+        text: fail === 0 ? `${ok} wake packet(s) sent` : `${ok} sent, ${fail} failed`,
+        tone: fail === 0 ? "ok" : "err",
+      });
+    } catch (err: unknown) {
+      setBatchMsg({
+        text: err instanceof Error ? err.message : "Batch wake failed",
+        tone: "err",
+      });
+    } finally {
+      setBatchLoading(false);
+      setTimeout(() => setBatchMsg(null), 6000);
+    }
+  }
 
   if (visibleSparks.length === 0) {
     const allOffline = hideOffline && sparks.length > 0;
@@ -240,10 +297,41 @@ export function OverviewPage({ sparks, hideOffline = false, temperatureUnit = "c
         <h1 className="text-[32px] font-normal leading-tight tracking-tight text-text-strong">
           Overview
         </h1>
-        <span className="online-chip">
-          <span className="dot" />
-          {onlineCount}/{visibleSparks.length} online
-        </span>
+        <div className="flex items-center gap-3">
+          {batchMsg && (
+            <span className={`text-[11px] ${batchMsg.tone === "ok" ? "text-success" : "text-danger"}`}>
+              {batchMsg.text}
+            </span>
+          )}
+          {sparks.length > 0 && (
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => void handleWakeAll()}
+                disabled={batchLoading}
+                title="Wake all Sparks that have a MAC configured (WoL)"
+                className="flex items-center gap-1 rounded-md border border-border bg-surface-elevated px-2.5 py-1.5 text-[11px] text-muted hover:bg-success/20 hover:text-success transition-colors disabled:opacity-50"
+              >
+                <PowerOnIcon className="h-3 w-3" />
+                Wake All
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleShutdownAll()}
+                disabled={batchLoading || !sparks.some((s) => s.online)}
+                title="Shut down all online Sparks"
+                className="flex items-center gap-1 rounded-md border border-border bg-surface-elevated px-2.5 py-1.5 text-[11px] text-muted hover:bg-danger/20 hover:text-danger transition-colors disabled:opacity-50"
+              >
+                <PowerOffIcon className="h-3 w-3" />
+                Shutdown All
+              </button>
+            </div>
+          )}
+          <span className="online-chip">
+            <span className="dot" />
+            {onlineCount}/{visibleSparks.length} online
+          </span>
+        </div>
       </div>
       <div className="overview-page grid gap-[18px] sm:grid-cols-2 lg:grid-cols-3">
         {visibleSparks.map((spark) => (

--- a/src/components/SparkPage/SparkHeader.tsx
+++ b/src/components/SparkPage/SparkHeader.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import type { SparkSnapshot } from "../../api/types";
-import { EditIcon } from "../ui/icons";
+import { shutdownSpark, wakeSpark } from "../../api/client";
+import { EditIcon, PowerOffIcon, PowerOnIcon } from "../ui/icons";
 
 interface SparkHeaderProps {
   spark: SparkSnapshot;
@@ -21,9 +23,55 @@ function formatUptime(seconds: number): string {
 export function SparkHeader({ spark, onEdit }: SparkHeaderProps) {
   const { hardware } = spark;
   const online = spark.online;
+  const [powerLoading, setPowerLoading] = useState(false);
+  const [powerMsg, setPowerMsg] = useState<{ text: string; tone: "ok" | "err" } | null>(null);
+
+  async function handleShutdown() {
+    if (
+      !confirm(
+        `Gracefully shut down ${spark.name}? This will stop all containers and power off the node.`
+      )
+    ) {
+      return;
+    }
+    setPowerLoading(true);
+    setPowerMsg(null);
+    try {
+      const res = await shutdownSpark(spark.id);
+      setPowerMsg({ text: res.message || "Shutdown initiated", tone: "ok" });
+    } catch (err: unknown) {
+      setPowerMsg({
+        text: err instanceof Error ? err.message : "Shutdown failed",
+        tone: "err",
+      });
+    } finally {
+      setPowerLoading(false);
+      setTimeout(() => setPowerMsg(null), 5000);
+    }
+  }
+
+  async function handleWake() {
+    setPowerLoading(true);
+    setPowerMsg(null);
+    try {
+      const res = await wakeSpark(spark.id);
+      setPowerMsg({ text: res.message || "Wake packet sent", tone: "ok" });
+    } catch (err: unknown) {
+      setPowerMsg({
+        text: err instanceof Error ? err.message : "Wake failed",
+        tone: "err",
+      });
+    } finally {
+      setPowerLoading(false);
+      setTimeout(() => setPowerMsg(null), 5000);
+    }
+  }
 
   return (
-    <div className="spark-header panel flex flex-wrap items-center gap-x-4 gap-y-2 p-5" style={online ? undefined : { opacity: 0.6 }}>
+    <div
+      className="spark-header panel flex flex-wrap items-center gap-x-4 gap-y-2 p-5"
+      style={online ? undefined : { opacity: 0.6 }}
+    >
       <div className="flex items-center gap-2.5">
         <span
           className={`h-2 w-2 shrink-0 rounded-full ${online ? "bg-success dot-glow-success" : "bg-danger"}`}
@@ -47,16 +95,46 @@ export function SparkHeader({ spark, onEdit }: SparkHeaderProps) {
         </div>
       </div>
 
-      {onEdit && (
-        <button
-          type="button"
-          onClick={onEdit}
-          className="ml-auto flex items-center gap-1.5 rounded-md border border-border bg-surface-elevated px-3 py-1.5 text-[11px] text-muted hover:bg-surface-hover hover:text-text transition-colors"
-        >
-          <EditIcon className="h-3 w-3" />
-          Edit
-        </button>
-      )}
+      <div className="ml-auto flex items-center gap-2">
+        {powerMsg && (
+          <span className={`text-[11px] ${powerMsg.tone === "ok" ? "text-success" : "text-danger"}`}>
+            {powerMsg.text}
+          </span>
+        )}
+        {online ? (
+          <button
+            type="button"
+            onClick={() => void handleShutdown()}
+            disabled={powerLoading}
+            title="Graceful shutdown (requires /usr/local/bin/spark-shutdown on the host)"
+            className="flex items-center gap-1.5 rounded-md border border-border bg-surface-elevated px-3 py-1.5 text-[11px] text-muted hover:bg-danger/20 hover:text-danger transition-colors disabled:opacity-50"
+          >
+            <PowerOffIcon className="h-3 w-3" />
+            Shutdown
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void handleWake()}
+            disabled={powerLoading}
+            title="Wake-on-LAN (set MAC address in Edit Spark)"
+            className="flex items-center gap-1.5 rounded-md border border-border bg-surface-elevated px-3 py-1.5 text-[11px] text-muted hover:bg-success/20 hover:text-success transition-colors disabled:opacity-50"
+          >
+            <PowerOnIcon className="h-3 w-3" />
+            Wake
+          </button>
+        )}
+        {onEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="flex items-center gap-1.5 rounded-md border border-border bg-surface-elevated px-3 py-1.5 text-[11px] text-muted hover:bg-surface-hover hover:text-text transition-colors"
+          >
+            <EditIcon className="h-3 w-3" />
+            Edit
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -172,3 +172,30 @@ export function RotateIcon({ className = "" }: { className?: string }) {
     </svg>
   );
 }
+
+/** Power symbol — used for graceful shutdown. */
+export function PowerOffIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg {...baseProps(className)}>
+      <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
+      <line x1="12" y1="2" x2="12" y2="12" />
+    </svg>
+  );
+}
+
+/** Sun burst — used for Wake-on-LAN (distinct from PowerOffIcon). */
+export function PowerOnIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg {...baseProps(className)}>
+      <circle cx="12" cy="12" r="4" />
+      <line x1="12" y1="2" x2="12" y2="5" />
+      <line x1="12" y1="19" x2="12" y2="22" />
+      <line x1="2" y1="12" x2="5" y2="12" />
+      <line x1="19" y1="12" x2="22" y2="12" />
+      <line x1="4.93" y1="4.93" x2="7.05" y2="7.05" />
+      <line x1="16.95" y1="16.95" x2="19.07" y2="19.07" />
+      <line x1="4.93" y1="19.07" x2="7.05" y2="16.95" />
+      <line x1="16.95" y1="7.05" x2="19.07" y2="4.93" />
+    </svg>
+  );
+}

--- a/test/wol.test.mjs
+++ b/test/wol.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  broadcastForLanIp,
+  buildMagicPacket,
+  normalizeMac,
+} from "../server/wol.js";
+
+test("normalizeMac accepts colon and hyphen forms", () => {
+  assert.equal(normalizeMac("AA:BB:CC:DD:EE:FF"), "aa:bb:cc:dd:ee:ff");
+  assert.equal(normalizeMac("aa-bb-cc-dd-ee-ff"), "aa-bb-cc-dd-ee-ff");
+  assert.equal(normalizeMac("  aa:bb:cc:dd:ee:ff  "), "aa:bb:cc:dd:ee:ff");
+});
+
+test("normalizeMac rejects garbage", () => {
+  assert.equal(normalizeMac(null), null);
+  assert.equal(normalizeMac(""), null);
+  assert.equal(normalizeMac("not-a-mac"), null);
+  assert.equal(normalizeMac("aa:bb:cc:dd:ee"), null);
+});
+
+test("broadcastForLanIp derives /24 or falls back to limited broadcast", () => {
+  assert.equal(broadcastForLanIp("192.168.1.42"), "192.168.1.255");
+  assert.equal(broadcastForLanIp(""), "255.255.255.255");
+  assert.equal(broadcastForLanIp(null), "255.255.255.255");
+  assert.equal(broadcastForLanIp("not-an-ip"), "255.255.255.255");
+});
+
+test("buildMagicPacket is 6xFF followed by 16x MAC", () => {
+  const pkt = buildMagicPacket("01:23:45:67:89:ab");
+  assert.equal(pkt.length, 102);
+  assert.ok(pkt.subarray(0, 6).every((b) => b === 0xff));
+  for (let i = 0; i < 16; i++) {
+    assert.deepEqual(
+      [...pkt.subarray(6 + i * 6, 12 + i * 6)],
+      [0x01, 0x23, 0x45, 0x67, 0x89, 0xab]
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Power management only (from PR #2, without self-update / SSO / LLM cluster / compose override).

- Per-Spark **Shutdown** / **Wake** on the Spark header
- Overview **Shutdown All** / **Wake All**
- `macAddress` on Spark config (Edit dialog)
- Shared `server/wol.js`: single-settlement send, MAC validation, `/24` broadcast with global fallback
- Batch shutdown only targets **online** Sparks (offline skipped)
- README: host `spark-shutdown` script + LAN trust note for power APIs
- Unit tests for MAC / broadcast / magic packet

### Fixes vs upstream PR #2 power slice
- No hanging WoL on bind errors; no double HTTP responses
- `wake-all` no longer crashes on empty `lanIp`
- Distinct PowerOn (sun) vs PowerOff icons
- Batch shutdown UI/API aligned (online-only)
- No accidental `docker-compose.override.yml`

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Manual: set MAC, Wake offline Spark
- [ ] Manual: Shutdown with `/usr/local/bin/spark-shutdown` installed
