### PR TITLE
feat: auto-detect Wake-on-LAN MAC from enP7s7

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Copy `.env.example` to `.env` if needed:
 ### Adding a Spark
 
 1. Open the **+** tab.
-2. Set **Name**, **LAN IP** (required), optional **CX7 IP**, optional **MAC address** (for Wake-on-LAN), **SSH user**, and auth (key or password).
+2. Set **Name**, **LAN IP** (required), optional **CX7 IP**, **SSH user**, and auth (key or password). Wake-on-LAN MAC is auto-read from **enP7s7** when online (optional override in Edit).
 3. **Test Connection** for SSH + LLM reachability.
 4. Save — a tab appears and metrics start streaming.
 
@@ -226,7 +226,7 @@ Copy `.env.example` to `.env` if needed:
 - **Shutdown** (per Spark or **Shutdown All** on Overview) runs over SSH:  
   `sudo -n /usr/local/bin/spark-shutdown`  
   Install that script on each Spark and allow passwordless sudo for it only.
-- **Wake** / **Wake All** send a UDP magic packet (port 9) to the Spark’s MAC. Set **MAC Address** in Edit Spark. Broadcast is derived as `/24` from LAN IP, or `255.255.255.255` if LAN IP is missing.
+- **Wake** / **Wake All** send a UDP magic packet (port 9). The MAC is taken from the **enP7s7** interface automatically while the Spark is online (persisted as `detectedMacAddress`). Optionally set a **MAC override** in Edit Spark. Broadcast is derived as `/24` from LAN IP, or `255.255.255.255` if LAN IP is missing.
 - Batch shutdown only targets **online** Sparks; offline nodes are skipped.
 - Same trust model as the rest of the API: **do not expose port 5555** beyond a trusted network — power actions are not separately authenticated.
 

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { HOST_PATHS, GPU_MEMORY_JSON_PATH, DGX_SPARK, HARDWARE_DEFAULTS } from "../config.js";
+import { normalizeMac, WOL_INTERFACE } from "../wol.js";
 import { sshExec } from "./ssh.js";
 
 /**
@@ -107,7 +108,8 @@ export class SystemCollector {
         primaryInterface = alt?.name ?? primaryInterface;
       }
       const linkSpeed = primaryInterface ? await this._getNetworkLinkSpeedMbps(primaryInterface) : null;
-      return { primaryInterface, linkSpeedMbps: linkSpeed, interfaces };
+      const wolMac = await this._getWolInterfaceMac();
+      return { primaryInterface, linkSpeedMbps: linkSpeed, interfaces, wolMac };
     } catch (err) {
       console.error(`[SystemCollector] Network error for ${this.spark.id}:`, err.message);
       return this._defaultNetwork();
@@ -654,6 +656,19 @@ export class SystemCollector {
     }
   }
 
+  /**
+   * MAC of the Spark LAN NIC used for Wake-on-LAN (enP7s7).
+   * @returns {Promise<string | null>}
+   */
+  async _getWolInterfaceMac() {
+    try {
+      const raw = await this._readHostFile(`/sys/class/net/${WOL_INTERFACE}/address`);
+      return normalizeMac(raw);
+    } catch {
+      return null;
+    }
+  }
+
   /** Mark interfaces listed in spark.disabledInterfaces (still returned for Settings). */
   _tagDisabledInterfaces(interfaces) {
     const disabled = this.spark.disabledInterfaces || [];
@@ -951,6 +966,9 @@ export class SystemCollector {
         "echo '---'",
         // Collect operstate for all non-virtual interfaces in one go
         "for d in /sys/class/net/*/operstate; do echo \"$(basename $(dirname $d)):$(cat $d)\"; done",
+        "echo '---'",
+        // WoL MAC for the primary LAN NIC on DGX Spark
+        `cat /sys/class/net/${WOL_INTERFACE}/address 2>/dev/null || true`,
       ].join("; ");
 
       const output = await sshExec(this.spark, cmd);
@@ -959,6 +977,7 @@ export class SystemCollector {
       const routeOut = sections[1]?.trim() || "";
       const ipOut = sections[2]?.trim() || "";
       const operstateOut = sections[3]?.trim() || "";
+      const wolMac = normalizeMac(sections[4]?.trim() || "");
 
       // Parse operstate lines ("enP7s7:up")
       const operstateMap = new Map();
@@ -1045,7 +1064,7 @@ export class SystemCollector {
         }
       }
 
-      return { primaryInterface, linkSpeedMbps, interfaces: tagged };
+      return { primaryInterface, linkSpeedMbps, interfaces: tagged, wolMac };
     } catch (err) {
       console.error(`[SystemCollector] Remote Network error for ${this.spark.id}:`, err.message);
       return this._defaultNetwork();
@@ -1239,7 +1258,7 @@ export class SystemCollector {
   }
 
   _defaultNetwork() {
-    return { primaryInterface: null, linkSpeedMbps: null, interfaces: [] };
+    return { primaryInterface: null, linkSpeedMbps: null, interfaces: [], wolMac: null };
   }
 
   _defaultUnifiedMemory() {

--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ import { SparkMonitor } from "./sparks/SparkMonitor.js";
 import { sshExec, sshTest, llmTest } from "./collectors/ssh.js";
 import { validateSparkTarget, createRateLimiter } from "./validate.js";
 import { getSettings, updateSettings, loadSettings } from "./settings.js";
-import { broadcastForLanIp, normalizeMac, sendWol } from "./wol.js";
+import { broadcastForLanIp, effectiveMac, normalizeMac, sendWol } from "./wol.js";
 
 dotenv.config();
 
@@ -53,7 +53,15 @@ const monitors = new Map();
 // ─── Start monitor for a Spark ───────────────────────────
 function startMonitor(spark) {
   if (monitors.has(spark.id)) return;
-  const monitor = new SparkMonitor(spark);
+  const monitor = new SparkMonitor(spark, {
+    onWolMac: (id, mac) => {
+      const updated = registry.noteDetectedMac(id, mac);
+      if (updated) {
+        const mon = monitors.get(id);
+        if (mon) mon.updateConfig(registry.getSpark(id));
+      }
+    },
+  });
   monitors.set(spark.id, monitor);
   monitor.start();
 }
@@ -581,12 +589,12 @@ app.post("/api/sparks/shutdown-all", async (_req, res) => {
 app.post("/api/sparks/wake-all", async (_req, res) => {
   const results = [];
   for (const spark of registry.sparks) {
-    const cleanMac = normalizeMac(spark.macAddress);
+    const cleanMac = effectiveMac(spark);
     if (!cleanMac) {
       results.push({
         id: spark.id,
         ok: false,
-        error: spark.macAddress ? `Invalid MAC: ${spark.macAddress}` : "No MAC address configured",
+        error: "No MAC address (enP7s7 not seen yet; set override in Edit Spark)",
       });
       continue;
     }
@@ -625,15 +633,17 @@ app.post("/api/sparks/:id/wake", async (req, res) => {
     const spark = registry.getSpark(req.params.id);
     if (!spark) return res.status(404).json({ error: "Spark not found" });
 
-    const cleanMac = normalizeMac(spark.macAddress || req.body?.mac);
+    // Body mac > user override > auto-detected enP7s7
+    const cleanMac = normalizeMac(req.body?.mac) || effectiveMac(spark);
     if (!cleanMac) {
-      if (!spark.macAddress && !req.body?.mac) {
+      if (req.body?.mac || spark.macAddress) {
         return res.status(400).json({
-          error: "No MAC address configured. Set macAddress on the Spark or pass mac in the body.",
+          error: `Invalid MAC address: ${req.body?.mac || spark.macAddress}`,
         });
       }
       return res.status(400).json({
-        error: `Invalid MAC address: ${spark.macAddress || req.body?.mac}`,
+        error:
+          "No MAC address yet. Wait until the node is online so enP7s7 can be detected, or set a MAC override in Edit Spark.",
       });
     }
 

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -22,8 +22,13 @@ const ONLINE_GRACE_MS = 10000;
  * Exposes snapshot() for WebSocket pushed payload.
  */
 export class SparkMonitor {
-  constructor(spark) {
+  /**
+   * @param {object} spark
+   * @param {{ onWolMac?: (sparkId: string, mac: string) => void }} [options]
+   */
+  constructor(spark, options = {}) {
     this.spark = spark;
+    this._onWolMac = typeof options.onWolMac === "function" ? options.onWolMac : null;
     this.collector = new SystemCollector(spark);
 
     // One LlmProbe per port — Map<port, LlmProbe>
@@ -269,6 +274,13 @@ export class SparkMonitor {
           break;
         case "network":
           this._metrics.network = result;
+          if (result?.wolMac && this._onWolMac) {
+            try {
+              this._onWolMac(this.spark.id, result.wolMac);
+            } catch (err) {
+              console.error(`[SparkMonitor] ${this.spark.id} wolMac persist error:`, err.message);
+            }
+          }
           break;
         case "storage":
           this._metrics.storage = result;

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -73,12 +73,35 @@ export class SparkRegistry {
     return this._withPassword(spark);
   }
 
+  /**
+   * Persist the last-seen MAC for the WoL NIC (enP7s7). No-op if unchanged.
+   * Does not overwrite a user macAddress override.
+   * @param {string} id
+   * @param {string} mac
+   * @returns {object | null} updated public spark, or null if unchanged / missing
+   */
+  noteDetectedMac(id, mac) {
+    const idx = this._sparks.findIndex((s) => s.id === id);
+    if (idx === -1) return null;
+    const clean = String(mac || "")
+      .trim()
+      .toLowerCase();
+    if (!/^([0-9a-f]{2}[:\-]){5}[0-9a-f]{2}$/.test(clean)) return null;
+    const prev = this._sparks[idx];
+    if (prev.detectedMacAddress === clean) return null;
+    this._sparks[idx] = this._normalizeConfig({ ...prev, detectedMacAddress: clean });
+    this._save();
+    this._emit("update", this._withPassword(this._sparks[idx]));
+    return this.toPublic(this._sparks[idx]);
+  }
+
   /** Update an existing Spark by ID. Does not allow changing `id`. */
   updateSpark(id, updates) {
     const idx = this._sparks.findIndex((s) => s.id === id);
     if (idx === -1) throw new Error(`Spark ${id} not found`);
 
-    const { id: _ignoreId, ...safeUpdates } = updates || {};
+    // Client cannot set detectedMacAddress (auto from enP7s7 only)
+    const { id: _ignoreId, detectedMacAddress: _ignoreDetected, ...safeUpdates } = updates || {};
     const prev = this._sparks[idx];
 
     // Merge ssh carefully so we don't drop auth fields
@@ -285,7 +308,10 @@ export class SparkRegistry {
       name: config.name || config.id,
       lanIp: config.lanIp || "",
       cx7Ip: config.cx7Ip || null,
+      /** Optional user override for Wake-on-LAN. Empty → use detectedMacAddress. */
       macAddress: config.macAddress || null,
+      /** Last MAC seen on enP7s7 (auto; not set via public PATCH). */
+      detectedMacAddress: config.detectedMacAddress || null,
       isLocal: Boolean(config.isLocal),
       ssh,
       llmPorts,

--- a/server/wol.js
+++ b/server/wol.js
@@ -5,6 +5,17 @@ import dgram from "node:dgram";
 
 const MAC_RE = /^([0-9a-f]{2}[:\-]){5}[0-9a-f]{2}$/;
 
+/** Primary LAN NIC on DGX Spark used for WoL auto-detect. */
+export const WOL_INTERFACE = "enP7s7";
+
+/**
+ * Resolve MAC for wake: user override first, then last auto-detected enP7s7 MAC.
+ * @param {{ macAddress?: string | null, detectedMacAddress?: string | null }} spark
+ */
+export function effectiveMac(spark) {
+  return normalizeMac(spark?.macAddress) || normalizeMac(spark?.detectedMacAddress);
+}
+
 /** @param {unknown} mac */
 export function normalizeMac(mac) {
   if (mac == null) return null;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -4,8 +4,13 @@ export interface SparkConfig {
   name: string;
   lanIp: string;
   cx7Ip?: string | null;
-  /** Ethernet MAC for Wake-on-LAN (aa:bb:cc:dd:ee:ff) */
+  /**
+   * Optional Wake-on-LAN MAC override. When empty, the server uses
+   * `detectedMacAddress` from the enP7s7 interface.
+   */
   macAddress?: string | null;
+  /** Last MAC read from enP7s7 while the Spark was online (read-only). */
+  detectedMacAddress?: string | null;
   isLocal: boolean;
   ssh: {
     host: string;
@@ -105,6 +110,8 @@ export interface NetworkMetrics {
   primaryInterface: string | null;
   linkSpeedMbps: number | null;
   interfaces: NetworkInterface[];
+  /** MAC of enP7s7 when present (same value persisted as detectedMacAddress). */
+  wolMac?: string | null;
 }
 
 // ─── Unified memory metrics ──────────────────────────────

--- a/src/components/EditSparkDialog.tsx
+++ b/src/components/EditSparkDialog.tsx
@@ -276,14 +276,25 @@ export function EditSparkDialog({
             </div>
 
             <div>
-              <label className="mb-1 block text-xs text-muted">MAC Address (Wake-on-LAN)</label>
+              <label className="mb-1 block text-xs text-muted">
+                MAC Address (Wake-on-LAN override)
+              </label>
               <input
                 type="text"
                 value={config.macAddress || ""}
                 onChange={(e) => update({ macAddress: e.target.value || null })}
-                placeholder="e.g. 00:1a:2b:3c:4d:5e"
+                placeholder={
+                  config.detectedMacAddress
+                    ? `Auto: ${config.detectedMacAddress}`
+                    : "Auto from enP7s7 when online"
+                }
                 className="w-full rounded border border-border bg-surface-elevated px-3 py-1.5 text-xs text-text outline-none focus:border-accent"
               />
+              <p className="mt-1 text-[10px] text-muted">
+                {config.detectedMacAddress
+                  ? `Using enP7s7 automatically (${config.detectedMacAddress}). Leave blank to keep auto, or enter a different MAC.`
+                  : "Leave blank to use enP7s7 once the Spark has been online and detected."}
+              </p>
             </div>
 
             <label className="flex items-center gap-2 text-xs text-muted">

--- a/test/wol.test.mjs
+++ b/test/wol.test.mjs
@@ -3,7 +3,9 @@ import assert from "node:assert/strict";
 import {
   broadcastForLanIp,
   buildMagicPacket,
+  effectiveMac,
   normalizeMac,
+  WOL_INTERFACE,
 } from "../server/wol.js";
 
 test("normalizeMac accepts colon and hyphen forms", () => {
@@ -36,4 +38,17 @@ test("buildMagicPacket is 6xFF followed by 16x MAC", () => {
       [0x01, 0x23, 0x45, 0x67, 0x89, 0xab]
     );
   }
+});
+
+test("effectiveMac prefers user override over detected enP7s7 MAC", () => {
+  assert.equal(WOL_INTERFACE, "enP7s7");
+  assert.equal(
+    effectiveMac({ macAddress: null, detectedMacAddress: "aa:bb:cc:dd:ee:ff" }),
+    "aa:bb:cc:dd:ee:ff"
+  );
+  assert.equal(
+    effectiveMac({ macAddress: "11:22:33:44:55:66", detectedMacAddress: "aa:bb:cc:dd:ee:ff" }),
+    "11:22:33:44:55:66"
+  );
+  assert.equal(effectiveMac({ macAddress: null, detectedMacAddress: null }), null);
 });


### PR DESCRIPTION
## Summary
- Network poll reads MAC of `enP7s7` (local + remote)
- Persists as `detectedMacAddress` when it changes
- Wake uses override `macAddress` if set, else auto-detected MAC
- Edit Spark: blank field = auto; optional override + help text

## Test plan
- [x] `npm test` / `typecheck` / `build`
- [ ] Online Spark: confirm `detectedMacAddress` fills after network poll
- [ ] Wake offline using auto MAC
- [ ] Override MAC still preferred
