### PR TITLE
feat: Worker node checkbox hides LLM card

### DIFF
--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -31,10 +31,12 @@ export class SparkMonitor {
     this._onWolMac = typeof options.onWolMac === "function" ? options.onWolMac : null;
     this.collector = new SystemCollector(spark);
 
-    // One LlmProbe per port — Map<port, LlmProbe>
+    // One LlmProbe per port — Map<port, LlmProbe> (none on worker nodes)
     this.llmProbes = new Map();
-    for (const port of this._llmPorts()) {
-      this.llmProbes.set(port, new LlmProbe(spark, port));
+    if (!spark.workerNode) {
+      for (const port of this._llmPorts()) {
+        this.llmProbes.set(port, new LlmProbe(spark, port));
+      }
     }
 
     // Online status from dedicated liveness checks (not metric poll success)
@@ -58,6 +60,8 @@ export class SparkMonitor {
 
     // Timers
     this._intervals = [];
+    /** @type {ReturnType<typeof setInterval> | null} */
+    this._llmIntervalId = null;
     this._running = false;
     /** @type {Record<string, boolean>} in-flight domain guards */
     this._inflight = {};
@@ -65,11 +69,12 @@ export class SparkMonitor {
 
   /** Hot-update config without tearing down poll loops / rate baselines. */
   updateConfig(spark) {
+    const wasWorker = Boolean(this.spark?.workerNode);
     this.spark = spark;
     this.collector.spark = spark;
 
     // Rebuild LLM probe map — add new ports, remove stale ones, update existing
-    const ports = this._llmPorts();
+    const ports = this.spark.workerNode ? [] : this._llmPorts();
     const prevProbes = this.llmProbes;
     this.llmProbes = new Map();
     for (const port of ports) {
@@ -80,6 +85,28 @@ export class SparkMonitor {
       } else {
         this.llmProbes.set(port, new LlmProbe(spark, port));
       }
+    }
+    if (this.spark.workerNode) {
+      this._metrics.llm = [];
+    }
+
+    // Toggle LLM poll interval when workerNode flips without full restart
+    if (this._running && wasWorker !== Boolean(this.spark.workerNode)) {
+      this._restartLlmPollInterval();
+    }
+  }
+
+  /** Start or clear the LLM poll timer based on workerNode. */
+  _restartLlmPollInterval() {
+    if (this._llmIntervalId != null) {
+      clearInterval(this._llmIntervalId);
+      this._intervals = this._intervals.filter((id) => id !== this._llmIntervalId);
+      this._llmIntervalId = null;
+    }
+    if (!this.spark.workerNode && this._running) {
+      this._llmIntervalId = setInterval(() => this._pollDomain("llm"), POLL_INTERVAL_LLM);
+      this._intervals.push(this._llmIntervalId);
+      void this._pollDomain("llm");
     }
   }
 
@@ -109,7 +136,7 @@ export class SparkMonitor {
     this._intervals.push(setInterval(() => this._pollDomain("storage"), POLL_INTERVAL_STORAGE));
     this._intervals.push(setInterval(() => this._pollDomain("ram"), POLL_INTERVAL_CPU));
     this._intervals.push(setInterval(() => this._pollDomain("memory"), POLL_INTERVAL_BANDWIDTH));
-    this._intervals.push(setInterval(() => this._pollDomain("llm"), POLL_INTERVAL_LLM));
+    this._restartLlmPollInterval();
     // Liveness on a slightly slower cadence
     this._intervals.push(setInterval(() => this._checkOnline(), POLL_INTERVAL_LIVENESS));
     console.log(`[SparkMonitor] ${this.spark.id} started`);
@@ -120,13 +147,14 @@ export class SparkMonitor {
     this._running = false;
     for (const id of this._intervals) clearInterval(id);
     this._intervals = [];
+    this._llmIntervalId = null;
     this._inflight = {};
     console.log(`[SparkMonitor] ${this.spark.id} stopped`);
   }
 
   /** Return a full snapshot of this Spark's metrics. */
   snapshot() {
-    const ports = this._llmPorts();
+    const ports = this.spark.workerNode ? [] : this._llmPorts();
     return {
       id: this.spark.id,
       name: this.spark.name,
@@ -135,6 +163,7 @@ export class SparkMonitor {
       disabledDevices: this.spark.disabledDevices || [],
       disabledInterfaces: this.spark.disabledInterfaces || [],
       storagePollDisabled: Boolean(this.spark.storagePollDisabled),
+      workerNode: Boolean(this.spark.workerNode),
       llmPort: ports[0] ?? LLM_PORT,
       llmPorts: ports,
       hardware: this._getHardwareSummary(),
@@ -227,6 +256,8 @@ export class SparkMonitor {
     if (!this._running || this._inflight[domain]) return;
     // Skip storage auto-poll when disabled for this spark
     if (domain === "storage" && this.spark.storagePollDisabled) return;
+    // Worker nodes: no local LLM API
+    if (domain === "llm" && this.spark.workerNode) return;
     this._inflight[domain] = true;
     try {
       let result;

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -315,6 +315,8 @@ export class SparkRegistry {
       isLocal: Boolean(config.isLocal),
       ssh,
       llmPorts,
+      /** When true, this Spark is an LLM worker — no local API card / probe. */
+      workerNode: Boolean(config.workerNode),
       disabledDevices: Array.isArray(config.disabledDevices) ? config.disabledDevices : [],
       disabledInterfaces: Array.isArray(config.disabledInterfaces) ? config.disabledInterfaces : [],
       storagePollDisabled: Boolean(config.storagePollDisabled),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ function placeholderSnapshot(
     disabledInterfaces,
     llmPort: llmPorts[0] ?? 8888,
     llmPorts,
+    workerNode: false,
     hardware: {
       device: "NVIDIA DGX Spark",
       cpuModel: "…",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -28,6 +28,11 @@ export interface SparkConfig {
   llmPort?: number;
   /** HTTP ports for LLM servers on this Spark (default [8888]) */
   llmPorts?: number[];
+  /**
+   * When true, this Spark is a distributed-LLM worker: no local OpenAI API.
+   * The LLM card is hidden and LLM ports are not probed.
+   */
+  workerNode?: boolean;
   /** When true, storage is only updated on manual refresh, not auto-polled. */
   storagePollDisabled?: boolean;
 }
@@ -169,6 +174,8 @@ export interface SparkSnapshot {
   disabledDevices: string[];
   disabledInterfaces: string[];
   storagePollDisabled?: boolean;
+  /** Distributed LLM worker — LLM card inactive / not shown */
+  workerNode?: boolean;
   /** LLM server port (first port, for backward compat) */
   llmPort: number;
   /** All LLM server ports configured for this Spark */

--- a/src/components/EditSparkDialog.tsx
+++ b/src/components/EditSparkDialog.tsx
@@ -8,6 +8,7 @@ import {
   updateSpark,
 } from "../api/client";
 import type { SparkConfig } from "../api/types";
+import { InfoIcon } from "./ui/icons";
 
 interface EditSparkDialogProps {
   open: boolean;
@@ -199,6 +200,7 @@ export function EditSparkDialog({
         cx7Ip: config.cx7Ip,
         macAddress: config.macAddress || null,
         isLocal: config.isLocal,
+        workerNode: Boolean(config.workerNode),
         ssh: {
           host: config.ssh.host || config.lanIp,
           user: config.ssh.user,
@@ -305,6 +307,23 @@ export function EditSparkDialog({
                 className="rounded border-border"
               />
               This host (local collectors — no SSH for metrics)
+            </label>
+
+            <label className="flex items-center gap-2 text-xs text-muted">
+              <input
+                type="checkbox"
+                checked={Boolean(config.workerNode)}
+                onChange={(e) => update({ workerNode: e.target.checked })}
+                className="rounded border-border"
+              />
+              <span>Worker node</span>
+              <span
+                className="inline-flex shrink-0 text-muted hover:text-text cursor-help"
+                title="Check this when this Spark is a distributed-LLM worker (no local OpenAI-style API). The LLM card on this Spark will be inactive / hidden, and LLM ports will not be probed."
+                aria-label="When checked, the LLM card is not shown on this Spark because workers do not expose a local model API."
+              >
+                <InfoIcon className="h-3.5 w-3.5" />
+              </span>
             </label>
 
             {!config.isLocal && (

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -110,68 +110,76 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
           disabledInterfaces={disabledInterfaces}
           onDisabledChange={setDisabledInterfaces}
         />
-        {llmPorts.map((port, i) => {
-          const llmMetrics = metrics.llm?.[i] ?? null;
-          return (
-            <LlmPanel
-              key={port}
-              llm={llmMetrics}
-              sparkId={spark.id}
-              llmPort={port}
-              llmPortsCount={llmPorts.length}
-              onRemovePort={llmPorts.length > 1 ? handleRemovePort : undefined}
-              className="md:col-span-2"
-            />
-          );
-        })}
-        {showAddPort ? (
-          <div className="md:col-span-2 rounded-lg border border-border bg-surface p-3">
-            <div className="flex items-center gap-2">
-              <input
-                type="number"
-                min={1}
-                max={65535}
-                inputMode="numeric"
-                placeholder="Port number"
-                value={newPortDraft}
-                onChange={(e) => setNewPortDraft(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    void handleAddPort();
-                  }
-                }}
-                className="w-32 rounded-md border border-border bg-surface-elevated px-3 py-1.5 font-tabular text-sm text-text outline-none focus:border-accent"
-                autoFocus
-              />
-              <button
-                type="button"
-                onClick={() => void handleAddPort()}
-                disabled={!newPortDraft.trim()}
-                className="rounded bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
-              >
-                Add
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setShowAddPort(false);
-                  setNewPortDraft("");
-                }}
-                className="rounded border border-border px-3 py-1.5 text-xs text-muted hover:bg-surface-hover"
-              >
-                Cancel
-              </button>
-            </div>
+        {spark.workerNode ? (
+          <div className="md:col-span-2 rounded-lg border border-border bg-surface px-4 py-3 text-xs text-muted">
+            Worker node — LLM card inactive (no local model API on this Spark).
           </div>
         ) : (
-          <button
-            type="button"
-            onClick={() => setShowAddPort(true)}
-            className="md:col-span-2 rounded-lg border border-dashed border-border bg-transparent p-3 text-xs text-muted hover:border-accent hover:text-accent transition-colors"
-          >
-            + Add LLM port
-          </button>
+          <>
+            {llmPorts.map((port, i) => {
+              const llmMetrics = metrics.llm?.[i] ?? null;
+              return (
+                <LlmPanel
+                  key={port}
+                  llm={llmMetrics}
+                  sparkId={spark.id}
+                  llmPort={port}
+                  llmPortsCount={llmPorts.length}
+                  onRemovePort={llmPorts.length > 1 ? handleRemovePort : undefined}
+                  className="md:col-span-2"
+                />
+              );
+            })}
+            {showAddPort ? (
+              <div className="md:col-span-2 rounded-lg border border-border bg-surface p-3">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="number"
+                    min={1}
+                    max={65535}
+                    inputMode="numeric"
+                    placeholder="Port number"
+                    value={newPortDraft}
+                    onChange={(e) => setNewPortDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        void handleAddPort();
+                      }
+                    }}
+                    className="w-32 rounded-md border border-border bg-surface-elevated px-3 py-1.5 font-tabular text-sm text-text outline-none focus:border-accent"
+                    autoFocus
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void handleAddPort()}
+                    disabled={!newPortDraft.trim()}
+                    className="rounded bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+                  >
+                    Add
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowAddPort(false);
+                      setNewPortDraft("");
+                    }}
+                    className="rounded border border-border px-3 py-1.5 text-xs text-muted hover:bg-surface-hover"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowAddPort(true)}
+                className="md:col-span-2 rounded-lg border border-dashed border-border bg-transparent p-3 text-xs text-muted hover:border-accent hover:text-accent transition-colors"
+              >
+                + Add LLM port
+              </button>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -183,6 +183,17 @@ export function PowerOffIcon({ className = "" }: { className?: string }) {
   );
 }
 
+/** Circle-i — for short help / tooltips. */
+export function InfoIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg {...baseProps(className)}>
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="16" x2="12" y2="12" />
+      <line x1="12" y1="8" x2="12.01" y2="8" />
+    </svg>
+  );
+}
+
 /** Sun burst — used for Wake-on-LAN (distinct from PowerOffIcon). */
 export function PowerOnIcon({ className = "" }: { className?: string }) {
   return (


### PR DESCRIPTION
## Summary
- Edit Spark: **Worker node** checkbox + info tooltip
- When set: LLM card/ports UI inactive; no LLM port probes
- Overview already omits LLM when nothing available

## Test plan
- [x] npm test / typecheck / build
- [ ] Toggle Worker node on a Spark; confirm LLM section hidden
- [ ] Untoggle; LLM card returns after save
