### PR TITLE
fix: Worker node badge in Spark header

### DIFF
--- a/src/components/SparkPage/SparkHeader.tsx
+++ b/src/components/SparkPage/SparkHeader.tsx
@@ -80,6 +80,14 @@ export function SparkHeader({ spark, onEdit }: SparkHeaderProps) {
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <h2 className="truncate text-base font-semibold text-text-strong">{spark.name}</h2>
+            {spark.workerNode && (
+              <span
+                className="shrink-0 rounded bg-accent/15 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-accent"
+                title="Distributed LLM worker — no local model API; LLM card is hidden"
+              >
+                Worker node
+              </span>
+            )}
             {online && spark.uptime != null && (
               <span
                 className="shrink-0 rounded bg-accent/15 px-1.5 py-0.5 font-tabular text-[10px] font-medium text-accent"

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -110,11 +110,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
           disabledInterfaces={disabledInterfaces}
           onDisabledChange={setDisabledInterfaces}
         />
-        {spark.workerNode ? (
-          <div className="md:col-span-2 rounded-lg border border-border bg-surface px-4 py-3 text-xs text-muted">
-            Worker node — LLM card inactive (no local model API on this Spark).
-          </div>
-        ) : (
+        {!spark.workerNode && (
           <>
             {llmPorts.map((port, i) => {
               const llmMetrics = metrics.llm?.[i] ?? null;


### PR DESCRIPTION
Replace the LLM inactive banner with a **Worker node** badge in the Spark header. LLM panels stay hidden with no extra copy.
