### PR TITLE
feat: show distributed workers on overview cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tetris.html
 HANDOFF.md
 handoff.md
 test/
+!tests/

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -166,6 +166,7 @@ export class SparkMonitor {
       workerNode: Boolean(this.spark.workerNode),
       llmPort: ports[0] ?? LLM_PORT,
       llmPorts: ports,
+      llmCluster: this.spark.llmCluster || null,
       hardware: this._getHardwareSummary(),
       metrics: {
         // NOTE: no `timestamp` here on purpose. The broadcast path skips

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -302,6 +302,7 @@ export class SparkRegistry {
       auth: sshIn.auth === "pass" ? "pass" : "key",
     };
     const llmPorts = this._normalizeLlmPorts(config.llmPorts ?? config.llmPort);
+    const llmCluster = this._normalizeLlmCluster(config.llmCluster);
     // Never keep password on the persisted object
     return {
       id: config.id,
@@ -315,11 +316,37 @@ export class SparkRegistry {
       isLocal: Boolean(config.isLocal),
       ssh,
       llmPorts,
+      llmCluster,
       /** When true, this Spark is an LLM worker — no local API card / probe. */
       workerNode: Boolean(config.workerNode),
       disabledDevices: Array.isArray(config.disabledDevices) ? config.disabledDevices : [],
       disabledInterfaces: Array.isArray(config.disabledInterfaces) ? config.disabledInterfaces : [],
       storagePollDisabled: Boolean(config.storagePollDisabled),
+    };
+  }
+
+  /** Normalize optional distributed-LLM cluster membership metadata. */
+  _normalizeLlmCluster(value) {
+    if (!value || typeof value !== "object") return null;
+    const role = value.role === "head" ? "head" : value.role === "worker" ? "worker" : null;
+    const headPort = Number(value.headPort);
+    const rank = Number(value.rank);
+    const worldSize = Number(value.worldSize);
+    if (
+      !role ||
+      typeof value.label !== "string" || !value.label.trim() ||
+      typeof value.headSparkId !== "string" || !value.headSparkId.trim() ||
+      !Number.isInteger(headPort) || headPort < 1 || headPort > 65535 ||
+      !Number.isInteger(rank) || rank < 0 ||
+      !Number.isInteger(worldSize) || worldSize < 1 || rank >= worldSize
+    ) return null;
+    return {
+      label: value.label.trim(),
+      role,
+      headSparkId: value.headSparkId.trim(),
+      headPort,
+      rank,
+      worldSize,
     };
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ function placeholderSnapshot(
     disabledInterfaces,
     llmPort: llmPorts[0] ?? 8888,
     llmPorts,
+    llmCluster: null,
     workerNode: false,
     hardware: {
       device: "NVIDIA DGX Spark",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -28,6 +28,8 @@ export interface SparkConfig {
   llmPort?: number;
   /** HTTP ports for LLM servers on this Spark (default [8888]) */
   llmPorts?: number[];
+  /** Optional membership in a distributed LLM cluster. */
+  llmCluster?: LlmClusterMembership | null;
   /**
    * When true, this Spark is a distributed-LLM worker: no local OpenAI API.
    * The LLM card is hidden and LLM ports are not probed.
@@ -35,6 +37,15 @@ export interface SparkConfig {
   workerNode?: boolean;
   /** When true, storage is only updated on manual refresh, not auto-polled. */
   storagePollDisabled?: boolean;
+}
+
+export interface LlmClusterMembership {
+  label: string;
+  role: "head" | "worker";
+  headSparkId: string;
+  headPort: number;
+  rank: number;
+  worldSize: number;
 }
 
 // ─── Hardware info ───────────────────────────────────────
@@ -180,6 +191,8 @@ export interface SparkSnapshot {
   llmPort: number;
   /** All LLM server ports configured for this Spark */
   llmPorts: number[];
+  /** Optional distributed LLM cluster membership. */
+  llmCluster: LlmClusterMembership | null;
   hardware: HardwareInfo;
   metrics: SparkMetrics;
 }

--- a/src/components/OverviewPage/OverviewPage.tsx
+++ b/src/components/OverviewPage/OverviewPage.tsx
@@ -177,7 +177,14 @@ function SparkCard({ spark, temperatureUnit, onSelect }: { spark: SparkSnapshot;
               }
               return null;
             })()}
-            {(() => {
+            {spark.workerNode ? (
+              <MiniStat
+                label="Worker"
+                value="Distributed"
+                tone="accent"
+                title="Distributed LLM worker node"
+              />
+            ) : (() => {
               // Find first available LLM for the overview card
               const llmArr = spark.metrics.llm;
               const llm = Array.isArray(llmArr) ? llmArr.find((l) => l.available) : null;

--- a/src/components/OverviewPage/OverviewPage.tsx
+++ b/src/components/OverviewPage/OverviewPage.tsx
@@ -3,6 +3,7 @@ import type { SparkSnapshot } from "../../api/types";
 import { shutdownAllSparks, wakeAllSparks } from "../../api/client";
 import { MetricBar } from "../ui/MetricBar";
 import { ActivityIcon, PowerOffIcon, PowerOnIcon } from "../ui/icons";
+import { getOverviewLlmStat } from "./overviewLlmStat";
 
 interface OverviewPageProps {
   sparks: SparkSnapshot[];
@@ -177,24 +178,15 @@ function SparkCard({ spark, temperatureUnit, onSelect }: { spark: SparkSnapshot;
               }
               return null;
             })()}
-            {spark.workerNode ? (
-              <MiniStat
-                label="Worker"
-                value="Distributed"
-                tone="accent"
-                title="Distributed LLM worker node"
-              />
-            ) : (() => {
-              // Find first available LLM for the overview card
-              const llmArr = spark.metrics.llm;
-              const llm = Array.isArray(llmArr) ? llmArr.find((l) => l.available) : null;
-              if (!llm) return null;
+            {(() => {
+              const stat = getOverviewLlmStat(spark);
+              if (!stat) return null;
               return (
                 <MiniStat
-                  label={llm.backend === "vllm" ? "vLLM" : llm.backend ?? "LLM"}
-                  value={llm.modelId ?? "unknown"}
+                  label={stat.label}
+                  value={stat.value}
                   tone="accent"
-                  title={llm.modelId ?? undefined}
+                  title={stat.title}
                 />
               );
             })()}

--- a/src/components/OverviewPage/overviewLlmStat.ts
+++ b/src/components/OverviewPage/overviewLlmStat.ts
@@ -1,0 +1,31 @@
+import type { SparkSnapshot } from "../../api/types";
+
+export interface OverviewLlmStat {
+  label: string;
+  value: string;
+  title?: string;
+}
+
+type OverviewLlmSource = Pick<SparkSnapshot, "llmCluster" | "metrics">;
+
+export function getOverviewLlmStat(spark: OverviewLlmSource): OverviewLlmStat | null {
+  const cluster = spark.llmCluster;
+  if (cluster?.role === "worker") {
+    return {
+      label: "Distributed worker",
+      value: cluster.label,
+      title: `${cluster.label} distributed worker · rank ${cluster.rank} / ${cluster.worldSize - 1}`,
+    };
+  }
+
+  const llm = Array.isArray(spark.metrics.llm)
+    ? spark.metrics.llm.find((candidate) => candidate.available)
+    : null;
+  if (!llm) return null;
+
+  return {
+    label: llm.backend === "vllm" ? "vLLM" : llm.backend ?? "LLM",
+    value: llm.modelId ?? "unknown",
+    title: llm.modelId ?? undefined,
+  };
+}

--- a/tests/overview-llm-stat.test.mts
+++ b/tests/overview-llm-stat.test.mts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getOverviewLlmStat } from "../src/components/OverviewPage/overviewLlmStat.ts";
+
+const noLlm = { llm: [] };
+
+test("distributed worker uses its cluster label on the overview card", () => {
+  const stat = getOverviewLlmStat({
+    llmCluster: {
+      label: "DeepSeek V4 Flash",
+      role: "worker",
+      headSparkId: "spark-05",
+      headPort: 8888,
+      rank: 1,
+      worldSize: 2,
+    },
+    metrics: noLlm,
+  });
+
+  assert.deepEqual(stat, {
+    label: "Distributed worker",
+    value: "DeepSeek V4 Flash",
+    title: "DeepSeek V4 Flash distributed worker · rank 1 / 1",
+  });
+});
+
+test("available local LLM keeps the existing overview stat", () => {
+  const stat = getOverviewLlmStat({
+    llmCluster: null,
+    metrics: {
+      llm: [{
+        available: true,
+        backend: "vllm",
+        modelId: "glm-5.2",
+        modelPath: null,
+        contextLength: null,
+        gpuMemoryUtilization: null,
+        slotsActive: 0,
+        slotsTotal: 0,
+        generationTps: 0,
+        prefillTps: 0,
+        totalOutputTokens: 0,
+        error: null,
+      }],
+    },
+  });
+
+  assert.deepEqual(stat, {
+    label: "vLLM",
+    value: "glm-5.2",
+    title: "glm-5.2",
+  });
+});


### PR DESCRIPTION
## Summary
- show distributed workers in the overview card slot used by vLLM
- keep the existing vLLM/model display unchanged for non-worker nodes

## Verification
- `npm run typecheck`
- `npm run build`
- rendered the live dashboard and verified the worker label occupies the vLLM mini-stat location