### PR TITLE
fix: correctly report GPU memory and processes on GB10 (unified memory)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tetris.html
 HANDOFF.md
 handoff.md
 test/
+config/gpu-memory.json

--- a/config/gpu-memory.json
+++ b/config/gpu-memory.json
@@ -1,1 +1,0 @@
-{"used": 0, "total": "[N/A]", "timestamp": 1784233381}

--- a/config/gpu-memory.sh
+++ b/config/gpu-memory.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
-# Run on host to write GPU memory to shared file
-# Add to crontab: * * * * * /mnt/admin/sparkDash/config/gpu-memory.sh
+OUTPUT="/opt/sparkDash/config/gpu-memory.json"
 
-OUTPUT="/mnt/admin/sparkDash/config/gpu-memory.json"
-MEMORY=$(nvidia-smi --query-compute-apps=pid,used_gpu_memory --format=csv,noheader,nounits 2>/dev/null | awk -F',' '{sum+=$2} END {print sum+0}')
-TOTAL=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | head -1)
+COMPUTE_RAW=$(nvidia-smi --query-compute-apps=pid,process_name,used_gpu_memory --format=csv,noheader,nounits 2>/dev/null)
 
-echo "{\"used\": $MEMORY, \"total\": \"$(echo $TOTAL | tr -d ' ')\", \"timestamp\": $(date +%s)}" > "$OUTPUT"
+USED=0
+PROCESSES=""
+while IFS=", " read -r pid pname vram; do
+    [ -z "$pid" ] && continue
+    USED=$((USED + vram))
+    if [ -n "$PROCESSES" ]; then PROCESSES="$PROCESSES,"; fi
+    PROCESSES="${PROCESSES}{\"pid\":$pid,\"name\":\"$pname\",\"vramMB\":$vram}"
+done <<< "$COMPUTE_RAW"
+
+TOTAL=$(awk "/^MemTotal:/ {printf \"%.0f\", \$2/1024}" /proc/meminfo)
+echo "{\"used\": $USED, \"total\": $TOTAL, \"processes\": [$PROCESSES], \"timestamp\": $(date +%s)}" > "$OUTPUT"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - /usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1:/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1:ro
       # Config + encrypted secrets (passwords survive restarts)
       - ./config:/app/config
+      # SSH keys for remote Spark monitoring (SSH to ofus + mama)
+      - /home/kesslerio/.ssh:/root/.ssh:ro
     environment:
       - PORT=5555
       - LLM_PORT=8888

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -214,7 +214,14 @@ export class SystemCollector {
     const file = this._readGpuMemoryFileFull();
     if ((used == null || used === 0) && file.used > 0) used = file.used;
     if (total == null && file.total > 0) total = file.total;
-
+    // Fallback: populate process cache from gpu-memory.json when nvidia-smi compute-apps returns empty (PID namespace isolation in containers)
+    if (this.nvidiaComputeAppsCache.size === 0 && Array.isArray(file.processes) && file.processes.length > 0) {
+      for (const proc of file.processes) {
+        if (proc.pid && proc.name && proc.vramMB) {
+          this.nvidiaComputeAppsCache.set(proc.pid, { name: proc.name, vramMB: proc.vramMB });
+        }
+      }
+    }
     // Unified-memory pool size + actual available memory from /proc/meminfo.
     // This matches the Unified Memory panel's basis so the two read consistently.
     const { totalMB: memTotalMB, availMB } = await this._readMeminfoMB();
@@ -499,12 +506,13 @@ export class SystemCollector {
         const memData = JSON.parse(fs.readFileSync(GPU_MEMORY_JSON_PATH, "utf-8"));
         const used = this._parseSmiNumber(memData.used) || 0;
         const total = this._parseSmiNumber(memData.total) || 0;
-        return { used, total };
+        const processes = Array.isArray(memData.processes) ? memData.processes : [];
+        return { used, total, processes };
       }
     } catch (err) {
       console.warn(`[SystemCollector] gpu-memory.json read failed: ${err.message}`);
     }
-    return { used: 0, total: 0 };
+    return { used: 0, total: 0, processes: [] };
   }
 
   /** Map container-visible mount to a host path for statfs. */


### PR DESCRIPTION
The DGX Spark (GB10) uses unified HBM3e memory — nvidia-smi reports `[N/A]` for all `memory.*` queries, so sparkDash showed `VRAM used: 0 / 122 GB (0%)` and an empty process list.

Additionally, `nvidia-smi --query-compute-apps` returns empty inside Docker containers due to PID namespace isolation, making the GPU process list permanently unavailable.

## Changes

**`config/gpu-memory.sh`** — Fixed the host cron script:
- Correct output path (`/opt/sparkDash/config/` instead of `/mnt/admin/sparkDash/config/`)
- Use `/proc/meminfo` for total memory (GB10 doesn't support `nvidia-smi --query-gpu=memory.total`)
- Capture GPU process names and VRAM alongside the aggregate sum

**`server/collectors/SystemCollector.js`** — Added fallback in `_queryNvidiaVram()`: when compute-apps returns empty (container PID namespace) and the host-written gpu-memory.json has process entries, populate the process cache from the file. Extended `_readGpuMemoryFileFull()` to return process data.

**`.gitignore`** — Added `config/gpu-memory.json` (regenerated every minute by the cron script).

**`docker-compose.yml`** — Mounted host `.ssh` directory for SSH key-based remote Spark monitoring.

## Validation

Verified on a 3-node deployment. The node running vLLM now reports:

> VRAM: 106,448 MB / 122,478 MB (87%)  
> Processes: VLLM::Worker_TP0 (106,448 MB)
