### PR TITLE
feat: surface vLLM inference metrics (KV cache, requests, TTFT/ITL p95, preemptions) in sparkDash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,11 @@ services:
       - /usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1:/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1:ro
       # Config + encrypted secrets (passwords survive restarts)
       - ./config:/app/config
+      # SSH keys for remote Spark monitoring (ofus, mama)
+      - /home/kesslerio/.ssh:/root/.ssh:ro
+    # Allow the local Spark's LLM probe to reach host-side vLLM on port 8888
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - PORT=5555
       - LLM_PORT=8888

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:client": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
+    "test": "node --test server/collectors/__tests__/*.test.js",
     "preview": "vite preview",
     "start": "node server/index.js",
     "docker:up": "docker compose up -d",

--- a/server/collectors/LlmProbe.js
+++ b/server/collectors/LlmProbe.js
@@ -37,6 +37,14 @@ export class LlmProbe {
     // Cumulative total output tokens (generation) as reported by the LLM server
     this.totalOutputTokens = 0;
 
+    // vLLM inference performance metrics (null when backend !== 'vllm' or unreachable)
+    this.kvCacheUsage = null;       // 0–1 fraction
+    this.requestsRunning = null;
+    this.requestsWaiting = null;
+    this.ttftP95Seconds = null;     // computed from histogram buckets
+    this.interTokenP95Seconds = null;
+    this.preemptionsTotal = null;  // cumulative counter
+
     this._consecutiveFailures = 0;
     this._lastDetectAt = 0;
   }
@@ -111,6 +119,12 @@ export class LlmProbe {
     this.slotsActive = 0;
     this.slotsTotal = 0;
     this.totalOutputTokens = 0;
+    this.kvCacheUsage = null;
+    this.requestsRunning = null;
+    this.requestsWaiting = null;
+    this.ttftP95Seconds = null;
+    this.interTokenP95Seconds = null;
+    this.preemptionsTotal = null;
     this.slotState.clear();
     this.lastTokenCounts = { input: 0, output: 0 };
   }
@@ -213,6 +227,9 @@ export class LlmProbe {
           }
 
           const running = this._getVllmMetric(txt, "num_requests_running");
+          // requestsRunning updates unconditionally (null on missing) to stay in sync with
+          // the other vLLM metrics; slotsActive keeps its round-to-int, null-skipped behavior.
+          this.requestsRunning = running;
           if (running != null) this.slotsActive = Math.round(running);
 
           // Engine sleep state (0 = active, 1 = sleeping)
@@ -220,6 +237,22 @@ export class LlmProbe {
             const sleepState = this._getVllmMetric(txt, "engine_sleep_state");
             if (sleepState != null) this.gpuMemoryUtilization = sleepState;
           }
+
+          // vLLM inference performance metrics (Prometheus exposition)
+          this.requestsWaiting = this._getVllmMetric(txt, "num_requests_waiting");
+          this.kvCacheUsage = this._getVllmMetric(txt, "kv_cache_usage_perc");
+          this.preemptionsTotal = this._getVllmMetric(txt, "num_preemptions_total");
+
+          const ttftHist = this._parseVllmHistogram(txt, "vllm:time_to_first_token_seconds");
+          const ttftP95 = this._histogramQuantile(ttftHist.buckets, ttftHist.total, 0.95);
+          // Round to 3 decimals at storage: the UI displays .toFixed(3), and a stable
+          // stringified value preserves the WebSocket broadcast's byte-identical diff-cache
+          // (a raw interpolated float jitters tick-to-tick as the _count total shifts).
+          this.ttftP95Seconds = ttftP95 == null ? null : Math.round(ttftP95 * 1000) / 1000;
+
+          const itlHist = this._parseVllmHistogram(txt, "vllm:inter_token_latency_seconds");
+          const itlP95 = this._histogramQuantile(itlHist.buckets, itlHist.total, 0.95);
+          this.interTokenP95Seconds = itlP95 == null ? null : Math.round(itlP95 * 1000) / 1000;
         }
       } catch {}
     }
@@ -310,6 +343,80 @@ export class LlmProbe {
     return found ? sum : null;
   }
 
+  /**
+   * Parse a vLLM Prometheus histogram from the /metrics text body.
+   * Returns { buckets: [{upper, count}], total } where `upper` is the bucket's
+   * le boundary (Infinity for +Inf) and `count` is the cumulative sample count.
+   * `total` is the histogram's _count line (summed across label sets); null if absent.
+   * Ported from the legacy gx10-ds4-monitor `_histogram_quantile` input shape.
+   */
+  _parseVllmHistogram(body, metricPrefix) {
+    const esc = metricPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Bucket lines: <metricPrefix>_bucket{...le="X"...} VALUE
+    // The [^}]* class allows prior label values (which may contain ") but cannot cross
+    // the closing brace, bounding the match. Adversarial bodies with thousands of
+    // partial le= tokens on one line can cause quadratic backtracking (~5s for 550KB),
+    // but the /metrics exposition is a localhost trusted source, so this is accepted.
+    const bucketRe = new RegExp(`^${esc}_bucket\\{[^}]*\\ble="([^"]+)"[^}]*\\}\\s+([\\d.eE+-]+)\\s*$`, "gm");
+    const byUpper = new Map();
+    let infCount = 0;
+    let m;
+    while ((m = bucketRe.exec(body)) !== null) {
+      const le = m[1];
+      const count = parseFloat(m[2]);
+      if (!Number.isFinite(count)) continue;
+      // +Inf is the unbounded tail bucket; keep it (its count is the cumulative total
+      // for observations exceeding the highest finite le). Only skip non-numeric le
+      // values that are neither finite nor +Inf.
+      const upper = le === "+Inf" ? Infinity : parseFloat(le);
+      if (upper !== Infinity && !Number.isFinite(upper)) continue;
+      if (upper === Infinity) infCount += count;
+      // Sum cumulative counts per le boundary across label sets (multi-engine / multi-model / LoRA),
+      // matching how _getVllmMetric sums scalar series. Without this, duplicate `upper` values
+      // produce non-monotonic counts and the quantile interpolates against the wrong series.
+      byUpper.set(upper, (byUpper.get(upper) || 0) + count);
+    }
+    const total = this._getVllmMetric(body, `${metricPrefix.replace(/^vllm:/, "")}_count`);
+    // Consistency check: the +Inf bucket count must equal the _count total (Prometheus
+    // invariant). A mismatch means the body is partial/corrupted (relabel rules, proxy
+    // line-drops, truncated read) — interpolating against a partial distribution with the
+    // full total yields a plausible-but-wrong quantile. Return empty buckets so the UI
+    // shows '—' rather than a silently wrong number.
+    if (total != null && infCount > 0 && Math.abs(infCount - total) > 1e-6) {
+      return { buckets: [], total: null };
+    }
+    const buckets = Array.from(byUpper, ([upper, count]) => ({ upper, count }));
+    buckets.sort((a, b) => a.upper - b.upper);
+    return { buckets, total };
+  }
+
+  /**
+   * Compute a quantile from histogram buckets via Prometheus-style linear
+   * interpolation between bucket boundaries. Ported from the legacy
+   * gx10-ds4-monitor `_histogram_quantile` (metrics.py).
+   * Returns null when buckets are empty, total is missing/non-positive,
+   * or the target lands in the unbounded (+Inf) tail.
+   */
+  _histogramQuantile(buckets, total, quantile) {
+    if (!buckets || !buckets.length || total == null || total <= 0) return null;
+    const target = total * quantile;
+    let prevUpper = 0.0;
+    let prevCount = 0.0;
+    for (const { upper, count } of buckets) {
+      if (count >= target) {
+        // Target lands in the unbounded (+Inf) tail — no finite upper to interpolate
+        // against. Return null per the documented contract (UI shows '—') rather than
+        // interpolating to Infinity, which would render as 'Infinitys'.
+        if (!Number.isFinite(upper)) return null;
+        if (count === prevCount) return upper;
+        return prevUpper + (upper - prevUpper) * ((target - prevCount) / (count - prevCount));
+      }
+      prevUpper = upper;
+      prevCount = count;
+    }
+    return null;
+  }
+
   _getSlotDecoded(slot) {
     // Some llama.cpp builds nest n_decoded inside next_token[0]
     if (slot.n_decoded != null) {
@@ -340,6 +447,12 @@ export class LlmProbe {
       generationTps: this.generationTps,
       prefillTps: this.prefillTps,
       totalOutputTokens: this.totalOutputTokens,
+      kvCacheUsage: this.kvCacheUsage,
+      requestsRunning: this.requestsRunning,
+      requestsWaiting: this.requestsWaiting,
+      ttftP95Seconds: this.ttftP95Seconds,
+      interTokenP95Seconds: this.interTokenP95Seconds,
+      preemptionsTotal: this.preemptionsTotal,
       error: this.error,
     };
   }
@@ -357,6 +470,12 @@ export class LlmProbe {
       generationTps: 0,
       prefillTps: 0,
       totalOutputTokens: 0,
+      kvCacheUsage: null,
+      requestsRunning: null,
+      requestsWaiting: null,
+      ttftP95Seconds: null,
+      interTokenP95Seconds: null,
+      preemptionsTotal: null,
       error: this.error,
     };
   }

--- a/server/collectors/__tests__/LlmProbe.histogram.test.js
+++ b/server/collectors/__tests__/LlmProbe.histogram.test.js
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for LlmProbe's vLLM histogram parsing and quantile computation.
+ *
+ * These cover the pure-math helpers (_parseVllmHistogram, _histogramQuantile)
+ * that compute TTFT/ITL p95 from vLLM's Prometheus /metrics exposition. A wrong
+ * quantile silently renders a plausible-but-wrong latency SLO number, so the
+ * edge cases here (empty body, +Inf tail, multi-series, partial body, label
+ * injection) are the correctness-critical paths.
+ *
+ * Uses node:test (shipped with Node 22) — no dependencies required.
+ * Run: npm test
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { LlmProbe } from "../LlmProbe.js";
+
+// Stub spark — LlmProbe only reads spark.lanIp in the constructor.
+const stubSpark = { lanIp: "127.0.0.1" };
+function makeProbe() {
+  return new LlmProbe(stubSpark, 8888);
+}
+
+// A realistic single-series TTFT histogram body (vLLM default buckets).
+const SINGLE_SERIES_BODY = `
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.001",model_name="m"} 0.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.1",model_name="m"} 634.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.5",model_name="m"} 1749.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="1.0",model_name="m"} 2330.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="10.0",model_name="m"} 2588.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="2560.0",model_name="m"} 2644.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="m"} 2644.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="m"} 2644.0
+vllm:time_to_first_token_seconds_sum{engine="0",model_name="m"} 2869.0
+`;
+
+// ─── _parseVllmHistogram ──────────────────────────────────────────────────
+
+test("_parseVllmHistogram parses a single-series body into sorted monotonic buckets", () => {
+  const probe = makeProbe();
+  const { buckets, total } = probe._parseVllmHistogram(
+    SINGLE_SERIES_BODY,
+    "vllm:time_to_first_token_seconds"
+  );
+  assert.equal(total, 2644);
+  assert.ok(buckets.length >= 7, `expected >=7 buckets, got ${buckets.length}`);
+  // Counts must be monotonically non-decreasing.
+  for (let i = 1; i < buckets.length; i++) {
+    assert.ok(
+      buckets[i].count >= buckets[i - 1].count,
+      `non-monotonic at ${i}: ${buckets[i - 1].count} -> ${buckets[i].count}`
+    );
+  }
+  // +Inf bucket is retained as the last entry with upper Infinity.
+  const inf = buckets.find((b) => b.upper === Infinity);
+  assert.ok(inf, "+Inf bucket should be retained");
+  assert.equal(inf.count, 2644);
+});
+
+test("_parseVllmHistogram sums cumulative counts per le across multi-series label sets", () => {
+  const probe = makeProbe();
+  // Two engines, each emitting the same bucket layout. The per-le sum should
+  // combine the cumulative counts (cumulative + cumulative = combined cumulative).
+  const body = `
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.1",model_name="m"} 100.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="1.0",model_name="m"} 500.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="m"} 500.0
+vllm:time_to_first_token_seconds_bucket{engine="1",le="0.1",model_name="m"} 50.0
+vllm:time_to_first_token_seconds_bucket{engine="1",le="1.0",model_name="m"} 250.0
+vllm:time_to_first_token_seconds_bucket{engine="1",le="+Inf",model_name="m"} 250.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="m"} 500.0
+vllm:time_to_first_token_seconds_count{engine="1",model_name="m"} 250.0
+`;
+  const { buckets, total } = probe._parseVllmHistogram(
+    body,
+    "vllm:time_to_first_token_seconds"
+  );
+  assert.equal(total, 750, "total should sum both _count lines");
+  const le01 = buckets.find((b) => b.upper === 0.1);
+  const le10 = buckets.find((b) => b.upper === 1.0);
+  const inf = buckets.find((b) => b.upper === Infinity);
+  assert.equal(le01.count, 150, "le=0.1 should sum 100+50");
+  assert.equal(le10.count, 750, "le=1.0 should sum 500+250");
+  assert.equal(inf.count, 750, "+Inf should sum 500+250");
+});
+
+test("_parseVllmHistogram returns empty buckets and null total on an empty body", () => {
+  const probe = makeProbe();
+  const { buckets, total } = probe._parseVllmHistogram("", "vllm:time_to_first_token_seconds");
+  assert.deepEqual(buckets, []);
+  assert.equal(total, null);
+});
+
+test("_parseVllmHistogram returns empty buckets when +Inf count != _count (partial/corrupted body)", () => {
+  const probe = makeProbe();
+  // Body with only low-le buckets present but a full _count — a truncated/relabel-filtered
+  // exposition. The +Inf count (9000) does not equal _count (10000), so the body is
+  // inconsistent and the parser must refuse to yield a plausible-but-wrong quantile.
+  const body = `
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.1",model_name="m"} 100.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.5",model_name="m"} 9000.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="m"} 9000.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="m"} 10000.0
+`;
+  const { buckets, total } = probe._parseVllmHistogram(
+    body,
+    "vllm:time_to_first_token_seconds"
+  );
+  assert.deepEqual(buckets, [], "inconsistent body should yield empty buckets");
+  assert.equal(total, null, "inconsistent body should yield null total");
+});
+
+test("_parseVllmHistogram is robust to a label value containing le=\" as a substring", () => {
+  const probe = makeProbe();
+  // A model_name containing le=" — the regex must match the actual le label, not the
+  // one embedded in the model name. vLLM model names are user-configurable.
+  const body = `
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.1",model_name="le=\\"0.5\\""} 100.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="1.0",model_name="le=\\"0.5\\""} 500.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="le=\\"0.5\\""} 500.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="le=\\"0.5\\""} 500.0
+`;
+  const { buckets, total } = probe._parseVllmHistogram(
+    body,
+    "vllm:time_to_first_token_seconds"
+  );
+  assert.equal(total, 500);
+  // The first bucket's upper must be 0.1 (the real le), not 0.5 (the one in the model name).
+  const first = buckets.find((b) => b.upper !== Infinity);
+  assert.equal(first.upper, 0.1, "should match the real le label, not the one in model_name");
+});
+
+// ─── _histogramQuantile ───────────────────────────────────────────────────
+
+test("_histogramQuantile interpolates a p80 within a finite bucket", () => {
+  const probe = makeProbe();
+  // Buckets: le=0.1 c=100, le=0.5 c=500, le=1.0 c=900, le=+Inf c=1000. p80 target=800.
+  // 500 < 800 <= 900 → falls in le=1.0 bucket; interpolate 0.5 + (1.0-0.5)*((800-500)/(900-500))=0.875.
+  const buckets = [
+    { upper: 0.1, count: 100 },
+    { upper: 0.5, count: 500 },
+    { upper: 1.0, count: 900 },
+    { upper: Infinity, count: 1000 },
+  ];
+  const result = probe._histogramQuantile(buckets, 1000, 0.8);
+  assert.ok(result !== null, "expected a finite quantile, got null");
+  assert.ok(Math.abs(result - 0.875) < 1e-9, `expected ~0.875, got ${result}`);
+});
+
+test("_histogramQuantile p95 lands in +Inf tail when highest finite bucket is below target", () => {
+  const probe = makeProbe();
+  // Same buckets, p95 target=950. 900 < 950 <= 1000 (the +Inf bucket) → null (unbounded tail).
+  const buckets = [
+    { upper: 0.1, count: 100 },
+    { upper: 0.5, count: 500 },
+    { upper: 1.0, count: 900 },
+    { upper: Infinity, count: 1000 },
+  ];
+  const result = probe._histogramQuantile(buckets, 1000, 0.95);
+  assert.equal(result, null, "p95 in +Inf tail must return null, not interpolate to Infinity");
+});
+
+test("_histogramQuantile returns null when target lands in the +Inf tail", () => {
+  const probe = makeProbe();
+  // All samples in the +Inf bucket (highest finite le=10, c=95; +Inf c=100). p97 target=97.
+  // 95 < 97 → falls into the +Inf bucket → unbounded → null (UI shows '—').
+  const buckets = [
+    { upper: 1.0, count: 50 },
+    { upper: 10.0, count: 95 },
+    { upper: Infinity, count: 100 },
+  ];
+  const result = probe._histogramQuantile(buckets, 100, 0.97);
+  assert.equal(result, null, "target in +Inf tail must return null, not Infinity");
+});
+
+test("_histogramQuantile returns null on empty buckets, missing total, or non-positive total", () => {
+  const probe = makeProbe();
+  assert.equal(probe._histogramQuantile([], 100, 0.95), null);
+  assert.equal(probe._histogramQuantile([{ upper: 1, count: 50 }], null, 0.95), null);
+  assert.equal(probe._histogramQuantile([{ upper: 1, count: 50 }], 0, 0.95), null);
+  assert.equal(probe._histogramQuantile([{ upper: 1, count: 50 }], -5, 0.95), null);
+});
+
+test("_histogramQuantile count===prevCount short-circuit returns the bucket upper (defensive)", () => {
+  const probe = makeProbe();
+  // Non-monotonic input where a bucket has the same cumulative count as the previous
+  // bucket (no new samples) and the target falls in it. The short-circuit returns the
+  // bucket's upper boundary directly rather than dividing by (count - prevCount) = 0.
+  // Construct: [{0.1, 0}, {0.5, 0}, {1.0, 100}, {Inf, 100}], total=100, p50 target=50.
+  // Buckets 0.1 and 0.5 have count 0 (below target 50). Bucket 1.0 count=100 >= 50,
+  // prevCount=0 → 100 !== 0, interpolates. To hit count===prevCount we need the
+  // FIRST bucket that reaches the target to have count == prevCount. That requires
+  // prevCount >= target already — which means a prior bucket already met the target.
+  // This path is defensive against non-monotonic buckets; verify it doesn't divide by
+  // zero: [{0.1, 100}, {0.5, 100}], total=100, p50 target=50. Bucket 0.1 count=100>=50,
+  // prevCount=0 → interpolates 0.05. The short-circuit is unreachable for valid data,
+  // so this test just confirms normal interpolation on the boundary target=prevCount.
+  const buckets = [
+    { upper: 0.1, count: 100 },
+    { upper: 0.5, count: 100 },
+    { upper: Infinity, count: 100 },
+  ];
+  // p50 target=50 falls in the 0.1 bucket (count 100 >= 50), prevCount 0: interpolate
+  // 0 + (0.1-0)*((50-0)/(100-0)) = 0.05. Verifies no division-by-zero on the boundary.
+  const result = probe._histogramQuantile(buckets, 100, 0.5);
+  assert.ok(Math.abs(result - 0.05) < 1e-9, `expected ~0.05, got ${result}`);
+});
+
+test("_histogramQuantile returns null when all buckets are +Inf (degenerate)", () => {
+  const probe = makeProbe();
+  const buckets = [{ upper: Infinity, count: 100 }];
+  const result = probe._histogramQuantile(buckets, 100, 0.95);
+  assert.equal(result, null, "only +Inf bucket must return null");
+});

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -149,6 +149,18 @@ export interface LlmMetrics {
   prefillTps: number;
   /** Cumulative total output (generation) tokens as reported by the LLM server */
   totalOutputTokens: number;
+  /** vLLM KV cache usage fraction (0–1). null when backend !== 'vllm' or unreachable. */
+  kvCacheUsage: number | null;
+  /** vLLM running request count. null when backend !== 'vllm' or unreachable. */
+  requestsRunning: number | null;
+  /** vLLM waiting request count. null when backend !== 'vllm' or unreachable. */
+  requestsWaiting: number | null;
+  /** vLLM time-to-first-token p95 in seconds (histogram quantile). null when unavailable. */
+  ttftP95Seconds: number | null;
+  /** vLLM inter-token latency p95 in seconds (histogram quantile). null when unavailable. */
+  interTokenP95Seconds: number | null;
+  /** vLLM cumulative preemption count. null when backend !== 'vllm' or unreachable. */
+  preemptionsTotal: number | null;
   error: string | null;
 }
 

--- a/src/components/SparkPage/LlmPanel.tsx
+++ b/src/components/SparkPage/LlmPanel.tsx
@@ -300,6 +300,59 @@ export function LlmPanel({ llm, sparkId, llmPort, llmPortsCount = 1, onRemovePor
               </div>
             </div>
           </div>
+
+          {llm?.backend === "vllm" && (
+            <div className="grid grid-cols-5 gap-2 border-t border-border pt-3">
+              <div className="space-y-0.5">
+                <div className="text-[10px] uppercase tracking-wide text-muted">KV Cache</div>
+                <div
+                  className={`font-tabular text-sm ${
+                    llm.kvCacheUsage == null
+                      ? "text-text"
+                      : llm.kvCacheUsage >= 0.8
+                        ? "text-danger"
+                        : llm.kvCacheUsage >= 0.5
+                          ? "text-warning"
+                          : "text-success"
+                  }`}
+                >
+                  {llm.kvCacheUsage != null
+                    ? `${(llm.kvCacheUsage * 100).toFixed(1)}%`
+                    : "—"}
+                </div>
+              </div>
+              <div className="space-y-0.5">
+                <div className="text-[10px] uppercase tracking-wide text-muted">Requests</div>
+                <div className="font-tabular text-sm text-text">
+                  {llm.requestsRunning != null && llm.requestsWaiting != null
+                    ? `${llm.requestsRunning} run / ${llm.requestsWaiting} wait`
+                    : "—"}
+                </div>
+              </div>
+              <div className="space-y-0.5">
+                <div className="text-[10px] uppercase tracking-wide text-muted">TTFT p95</div>
+                <div className="font-tabular text-sm text-text">
+                  {llm.ttftP95Seconds != null ? `${llm.ttftP95Seconds.toFixed(3)}s` : "—"}
+                </div>
+              </div>
+              <div className="space-y-0.5">
+                <div className="text-[10px] uppercase tracking-wide text-muted">ITL p95</div>
+                <div className="font-tabular text-sm text-text">
+                  {llm.interTokenP95Seconds != null
+                    ? `${llm.interTokenP95Seconds.toFixed(3)}s`
+                    : "—"}
+                </div>
+              </div>
+              <div className="space-y-0.5">
+                <div className="text-[10px] uppercase tracking-wide text-muted">Preempts</div>
+                <div className="font-tabular text-sm text-text">
+                  {llm.preemptionsTotal != null
+                    ? Math.round(llm.preemptionsTotal).toLocaleString()
+                    : "—"}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </Panel>


### PR DESCRIPTION
## What

Surfaces five real-time vLLM inference performance metrics in the sparkDash LLM panel, sourced from each node's vLLM Prometheus `/metrics` endpoint:

- **KV cache usage %** (colour-coded: green <50%, amber 50–80%, red ≥80%)
- **Running / waiting request counts**
- **TTFT p95** (time-to-first-token, seconds, 3dp)
- **ITL p95** (inter-token latency, seconds, 3dp)
- **Cumulative preemptions**

The metrics ride the existing WebSocket snapshot pipeline — no new endpoints, no storage, no config UI. The tiles render only when `backend === 'vllm'`; llama.cpp/sglang Sparks are visually unchanged.

## Why

The legacy `gx10-ds4-monitor` dashboard already collects these metrics but is single-node. sparkDash is the cluster dashboard (all nodes) and already probes vLLM via `_probeOpenAICompatible()`, but only surfaced token rates, slots, and engine sleep state — not the KV cache pressure, request queue depth, or latency quantiles that tell you whether the serving stack is healthy under load. This adds those high-signal operational tiles to the cluster view.

## How

- **`server/collectors/LlmProbe.js`** — two new pure-math helpers:
  - `_parseVllmHistogram(body, metricPrefix)` — scans the `/metrics` text for `<prefix>_bucket{...le="X"...}` lines, sums cumulative counts per `le` boundary across label sets (multi-engine/multi-model/LoRA), and validates the `+Inf` bucket count equals the `_count` total (Prometheus invariant). A mismatch (partial/corrupted body from relabel rules, proxy line-drops, truncated reads) returns empty buckets so the UI shows `—` rather than a plausible-but-wrong quantile.
  - `_histogramQuantile(buckets, total, quantile)` — Prometheus-style linear interpolation, ported from the legacy dashboard's Python `_histogram_quantile`. Returns `null` when the target lands in the unbounded `+Inf` tail (so the UI shows `—`, not `Infinity`).
  - Six new state fields, parsed in `_probeOpenAICompatible` from the same `/metrics` body already fetched (no second HTTP call). Quantiles are rounded to 3 decimals at storage to preserve the WebSocket broadcast's byte-identical diff-cache.
- **`src/api/types.ts`** — five new nullable fields on `LlmMetrics`.
- **`src/components/SparkPage/LlmPanel.tsx`** — a 5-tile row rendered conditionally on `backend === 'vllm'`, with KV cache colour coding and `—` fallbacks per tile.
- **`docker-compose.yml`** — SSH key mount (for remote Spark monitoring) + `host.docker.internal:host-gateway` extra_hosts (so the local Spark's LLM probe can reach host-side vLLM).
- **`server/collectors/__tests__/LlmProbe.histogram.test.js`** — 11 `node:test` cases (zero dependencies): single/multi-series parsing, empty body, partial-body consistency check, label injection, `+Inf` tail, null/empty/non-positive total guards, finite interpolation, boundary interpolation.

## Validation

- **Unit tests**: 11/11 pass (`node --test server/collectors/__tests__/*.test.js`).
- **Live metrics**: `curl http://localhost:5555/api/sparks/john/metrics` returns `llm[0]` with `backend:'vllm'`, `available:true`, `kvCacheUsage:0`, `requestsRunning:0`, `requestsWaiting:0`, `ttftP95Seconds:2.714`, `interTokenP95Seconds:0.12`, `preemptionsTotal:0`, `error:null`.
- **Browser**: the john node detail page renders all five tiles with live values (KV CACHE 0.0%, REQUESTS 0 run / 0 wait, TTFT P95 2.714s, ITL P95 0.120s, PREEMPTS 0); no `Infinity` corruption; existing tiles (Engine, Total Generated) intact.
- **Non-vLLM gate**: a Spark whose vLLM is unreachable correctly omits the tile row (verified on the mama node).

## Notes

- The legacy `gx10-ds4-monitor` systemd service continues running in parallel (both read the same `/metrics` endpoint — no conflict). Persistent history and trend charts are a planned follow-on.
- The histogram regex is quadratic on adversarial `/metrics` bodies with thousands of partial `le=` tokens on one line (~5s for 550KB). This is accepted because the exposition is a localhost trusted source; documented in a code comment.

## Settled decisions

These design choices were settled with the maintainer before implementation:

- **Core metrics now, full observability later** (user-directed; rejected: SQLite-backed 24h+ history — deferred to a follow-on to ship live metrics faster)
- **Extend the existing LlmProbe/LlmPanel, not a new collector** (user-directed; rejected: a separate collector class + UI page — reuses the existing WebSocket pipeline)
- **Live-only, no persistent storage** (user-directed; rejected: SQLite history — follow-on scope)
- **vLLM-only backend gate** (user-approved; rejected: also cover llama.cpp/sglang — only vLLM is deployed)
- **Port the histogram-quantile algorithm inline, no dependency** (user-approved; rejected: a prometheus-parsing library — the algorithm is ~12 lines of pure math)
- **No upstream PR pressure** (user-directed; rejected: deferring the contribution until the fork stabilises — this PR is the stabilisation step)

Proceeded under flag: none. No settled decision was challenged during review.