### PR TITLE
fix: GB10 GPU used/process metrics via host gpu-memory.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 sparks.json
 config/sparks-secrets.json
 config/.secrets-key
+config/gpu-memory.json
 *.log
 .DS_Store
 docs/

--- a/config/gpu-memory.json
+++ b/config/gpu-memory.json
@@ -1,1 +1,0 @@
-{"used": 0, "total": "[N/A]", "timestamp": 1784233381}

--- a/config/gpu-memory.sh
+++ b/config/gpu-memory.sh
@@ -1,9 +1,130 @@
 #!/bin/bash
-# Run on host to write GPU memory to shared file
-# Add to crontab: * * * * * /mnt/admin/sparkDash/config/gpu-memory.sh
+# Host-side GPU memory helper for DGX Spark (GB10) and Docker deployments.
+#
+# Why this exists
+# ---------------
+# On GB10, nvidia-smi memory.used / memory.total are often [N/A] (unified HBM).
+# "Used by GPU" is better taken from compute-apps. Inside Docker, compute-apps
+# can also be empty or hard to correlate (PID namespace / partial driver mounts),
+# so the Node collector may not see processes. This script runs on the *host*
+# and writes a small JSON file the container reads via the ./config bind mount.
+#
+# Install (example)
+# -----------------
+#   chmod +x /path/to/sparkDash/config/gpu-memory.sh
+#   * * * * * /path/to/sparkDash/config/gpu-memory.sh
+#
+# Output path (first match wins)
+# ------------------------------
+#   1) $SPARKDASH_GPU_MEMORY_JSON
+#   2) $SPARKDASH_CONFIG/gpu-memory.json
+#   3) <directory of this script>/gpu-memory.json  (default with ./config mount)
+#
+# JSON shape
+# ----------
+#   {
+#     "used": <MB, sum of compute-apps used_gpu_memory>,
+#     "total": <MB, MemTotal from /proc/meminfo — unified pool size on GB10>,
+#     "processes": [ { "pid", "name", "vramMB" }, ... ],
+#     "timestamp": <unix seconds>
+#   }
+#
+# "total" is OS MemTotal (unified pool), not discrete VRAM. The dashboard treats
+# GB10 the same way in SystemCollector (MemTotal as pool size).
 
-OUTPUT="/mnt/admin/sparkDash/config/gpu-memory.json"
-MEMORY=$(nvidia-smi --query-compute-apps=pid,used_gpu_memory --format=csv,noheader,nounits 2>/dev/null | awk -F',' '{sum+=$2} END {print sum+0}')
-TOTAL=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | head -1)
+set -euo pipefail
 
-echo "{\"used\": $MEMORY, \"total\": \"$(echo $TOTAL | tr -d ' ')\", \"timestamp\": $(date +%s)}" > "$OUTPUT"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -n "${SPARKDASH_GPU_MEMORY_JSON:-}" ]; then
+  OUTPUT="$SPARKDASH_GPU_MEMORY_JSON"
+elif [ -n "${SPARKDASH_CONFIG:-}" ]; then
+  OUTPUT="${SPARKDASH_CONFIG%/}/gpu-memory.json"
+else
+  OUTPUT="${SCRIPT_DIR}/gpu-memory.json"
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+# Prefer Python for safe JSON (process names may contain quotes/spaces).
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$OUTPUT" <<'PY'
+import json, os, re, subprocess, sys, time
+
+out_path = sys.argv[1]
+processes = []
+used = 0
+
+try:
+    raw = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "--query-compute-apps=pid,process_name,used_gpu_memory",
+            "--format=csv,noheader,nounits",
+        ],
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+except (subprocess.CalledProcessError, FileNotFoundError):
+    raw = ""
+
+for line in raw.splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    # CSV: pid, process_name (may contain commas rarely), used_gpu_memory
+    parts = [p.strip() for p in line.split(",")]
+    if len(parts) < 3:
+        continue
+    try:
+        pid = int(parts[0])
+    except ValueError:
+        continue
+    try:
+        vram = float(parts[-1])
+    except ValueError:
+        continue
+    if not (pid > 0 and vram == vram):  # vram == vram rejects NaN
+        continue
+    name = ",".join(parts[1:-1]).strip() or "unknown"
+    vram_i = int(round(vram))
+    used += vram_i
+    processes.append({"pid": pid, "name": name, "vramMB": vram_i})
+
+total = 0
+try:
+    with open("/proc/meminfo", "r", encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("MemTotal:"):
+                kb = int(line.split()[1])
+                total = int(round(kb / 1024.0))
+                break
+except OSError:
+    pass
+
+payload = {
+    "used": int(used),
+    "total": int(total),
+    "processes": processes,
+    "timestamp": int(time.time()),
+}
+
+tmp = out_path + f".{os.getpid()}.tmp"
+with open(tmp, "w", encoding="utf-8") as f:
+    json.dump(payload, f, separators=(",", ":"))
+    f.write("\n")
+os.replace(tmp, out_path)
+PY
+  exit 0
+fi
+
+# Fallback without Python: aggregate used only (no process names — safer than broken JSON).
+USED=$(
+  nvidia-smi --query-compute-apps=used_gpu_memory --format=csv,noheader,nounits 2>/dev/null \
+    | awk '{s+=$1} END {printf "%.0f", s+0}'
+)
+TOTAL=$(awk '/^MemTotal:/ {printf "%.0f", $2/1024}' /proc/meminfo 2>/dev/null || echo 0)
+TS=$(date +%s)
+TMP="${OUTPUT}.$$.tmp"
+printf '{"used":%s,"total":%s,"processes":[],"timestamp":%s}\n' "${USED:-0}" "${TOTAL:-0}" "$TS" >"$TMP"
+mv -f "$TMP" "$OUTPUT"

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -210,10 +210,37 @@ export class SystemCollector {
       } catch {}
     }
 
-    // Host cron file (gpu-memory.sh) as last resort for used / total
+    // Host cron file (gpu-memory.sh): used/total + process list when SMI is empty.
+    // Common in Docker: memory.* is N/A on GB10; compute-apps can also be empty
+    // depending on PID namespace / driver mounts (not always, but often enough).
     const file = this._readGpuMemoryFileFull();
     if ((used == null || used === 0) && file.used > 0) used = file.used;
     if (total == null && file.total > 0) total = file.total;
+
+    if (
+      this.nvidiaComputeAppsCache.size === 0 &&
+      Array.isArray(file.processes) &&
+      file.processes.length > 0
+    ) {
+      for (const proc of file.processes) {
+        const pid = Number(proc?.pid);
+        const vramMB = this._parseSmiNumber(proc?.vramMB);
+        const name =
+          typeof proc?.name === "string" && proc.name.trim()
+            ? proc.name.trim()
+            : "unknown";
+        // Allow vramMB === 0; only skip missing / non-finite values
+        if (!Number.isInteger(pid) || pid <= 0 || vramMB == null) continue;
+        this.nvidiaComputeAppsCache.set(pid, { name, vramMB });
+      }
+      if ((used == null || used === 0) && this.nvidiaComputeAppsCache.size > 0) {
+        let sum = 0;
+        for (const entry of this.nvidiaComputeAppsCache.values()) {
+          sum += entry.vramMB || 0;
+        }
+        if (sum > 0) used = sum;
+      }
+    }
 
     // Unified-memory pool size + actual available memory from /proc/meminfo.
     // This matches the Unified Memory panel's basis so the two read consistently.
@@ -499,12 +526,13 @@ export class SystemCollector {
         const memData = JSON.parse(fs.readFileSync(GPU_MEMORY_JSON_PATH, "utf-8"));
         const used = this._parseSmiNumber(memData.used) || 0;
         const total = this._parseSmiNumber(memData.total) || 0;
-        return { used, total };
+        const processes = Array.isArray(memData.processes) ? memData.processes : [];
+        return { used, total, processes };
       }
     } catch (err) {
       console.warn(`[SystemCollector] gpu-memory.json read failed: ${err.message}`);
     }
-    return { used: 0, total: 0 };
+    return { used: 0, total: 0, processes: [] };
   }
 
   /** Map container-visible mount to a host path for statfs. */


### PR DESCRIPTION
## Summary
Proper fix for GB10 unified-memory VRAM/process reporting (supersedes contributor work in #10 with a hardened implementation).

- **`config/gpu-memory.sh`**: host cron helper writes safe JSON via Python (`used`, `total` from MemTotal, `processes[]`); path configurable via env or script directory (works with `./config` bind mount). No machine-specific paths.
- **`SystemCollector`**: when in-container `compute-apps` is empty, hydrate process cache from the host file; allow `vramMB === 0`; still prefer live SMI when available.
- **`.gitignore`**: stop tracking generated `config/gpu-memory.json` (removed from repo).

Intentionally **not** included: hard-coded host SSH key mounts in `docker-compose.yml`.

This lands the useful ideas from #10 without the deploy-specific / fragile bits. #10 will be closed with a detailed comment.

## Test plan
- [ ] On GB10 host, run `config/gpu-memory.sh` and confirm JSON has numeric `total` and process entries under load
- [ ] In Docker, confirm GPU panel shows non-zero used and process names when SMI apps empty
- [ ] Confirm discrete-GPU / remote SSH paths still work when SMI works without the file
