### PR TITLE
feat: surface vLLM KV cache, queue, TTFT p95, and preemptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:client": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
+    "test": "node --test server/collectors/__tests__/*.test.js",
     "preview": "vite preview",
     "start": "node server/index.js",
     "docker:up": "docker compose up -d",

--- a/server/collectors/LlmProbe.js
+++ b/server/collectors/LlmProbe.js
@@ -37,6 +37,14 @@ export class LlmProbe {
     // Cumulative total output tokens (generation) as reported by the LLM server
     this.totalOutputTokens = 0;
 
+    // vLLM inference metrics from /metrics (null when not vLLM / missing series)
+    // Metric names follow stock vLLM Prometheus exposition (versions may differ).
+    this.kvCacheUsage = null; // 0–1 fraction
+    this.requestsRunning = null;
+    this.requestsWaiting = null;
+    this.ttftP95Seconds = null;
+    this.preemptionsTotal = null; // cumulative counter
+
     this._consecutiveFailures = 0;
     this._lastDetectAt = 0;
   }
@@ -111,6 +119,11 @@ export class LlmProbe {
     this.slotsActive = 0;
     this.slotsTotal = 0;
     this.totalOutputTokens = 0;
+    this.kvCacheUsage = null;
+    this.requestsRunning = null;
+    this.requestsWaiting = null;
+    this.ttftP95Seconds = null;
+    this.preemptionsTotal = null;
     this.slotState.clear();
     this.lastTokenCounts = { input: 0, output: 0 };
   }
@@ -213,6 +226,8 @@ export class LlmProbe {
           }
 
           const running = this._getVllmMetric(txt, "num_requests_running");
+          // Keep requestsRunning in sync with other vLLM tiles (null when missing)
+          this.requestsRunning = running;
           if (running != null) this.slotsActive = Math.round(running);
 
           // Engine sleep state (0 = active, 1 = sleeping)
@@ -220,6 +235,16 @@ export class LlmProbe {
             const sleepState = this._getVllmMetric(txt, "engine_sleep_state");
             if (sleepState != null) this.gpuMemoryUtilization = sleepState;
           }
+
+          // vLLM inference performance (same /metrics body — no extra HTTP)
+          this.requestsWaiting = this._getVllmMetric(txt, "num_requests_waiting");
+          this.kvCacheUsage = this._getVllmMetric(txt, "kv_cache_usage_perc");
+          this.preemptionsTotal = this._getVllmMetric(txt, "num_preemptions_total");
+
+          const ttftHist = this._parseVllmHistogram(txt, "vllm:time_to_first_token_seconds");
+          const ttftP95 = this._histogramQuantile(ttftHist.buckets, ttftHist.total, 0.95);
+          // Round to 3 decimals so WS snapshots stay stable (avoids float jitter)
+          this.ttftP95Seconds = ttftP95 == null ? null : Math.round(ttftP95 * 1000) / 1000;
         }
       } catch {}
     }
@@ -310,6 +335,61 @@ export class LlmProbe {
     return found ? sum : null;
   }
 
+  /**
+   * Parse a vLLM Prometheus histogram from /metrics text.
+   * Returns { buckets: [{upper, count}], total } with cumulative counts per `le`,
+   * summed across label sets. `total` is the summed `_count` series (or null).
+   */
+  _parseVllmHistogram(body, metricPrefix) {
+    const esc = metricPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Bucket lines: <metricPrefix>_bucket{...le="X"...} VALUE
+    const bucketRe = new RegExp(
+      `^${esc}_bucket\\{[^}]*\\ble="([^"]+)"[^}]*\\}\\s+([\\d.eE+-]+)\\s*$`,
+      "gm"
+    );
+    const byUpper = new Map();
+    let infCount = 0;
+    let m;
+    while ((m = bucketRe.exec(body)) !== null) {
+      const le = m[1];
+      const count = parseFloat(m[2]);
+      if (!Number.isFinite(count)) continue;
+      const upper = le === "+Inf" ? Infinity : parseFloat(le);
+      if (upper !== Infinity && !Number.isFinite(upper)) continue;
+      if (upper === Infinity) infCount += count;
+      byUpper.set(upper, (byUpper.get(upper) || 0) + count);
+    }
+    const total = this._getVllmMetric(body, `${metricPrefix.replace(/^vllm:/, "")}_count`);
+    // Prometheus invariant: +Inf bucket count == _count. Mismatch → refuse quantile.
+    if (total != null && infCount > 0 && Math.abs(infCount - total) > 1e-6) {
+      return { buckets: [], total: null };
+    }
+    const buckets = Array.from(byUpper, ([upper, count]) => ({ upper, count }));
+    buckets.sort((a, b) => a.upper - b.upper);
+    return { buckets, total };
+  }
+
+  /**
+   * Prometheus-style linear interpolation for a histogram quantile.
+   * Returns null when empty / invalid or target is in the +Inf tail.
+   */
+  _histogramQuantile(buckets, total, quantile) {
+    if (!buckets || !buckets.length || total == null || total <= 0) return null;
+    const target = total * quantile;
+    let prevUpper = 0.0;
+    let prevCount = 0.0;
+    for (const { upper, count } of buckets) {
+      if (count >= target) {
+        if (!Number.isFinite(upper)) return null;
+        if (count === prevCount) return upper;
+        return prevUpper + (upper - prevUpper) * ((target - prevCount) / (count - prevCount));
+      }
+      prevUpper = upper;
+      prevCount = count;
+    }
+    return null;
+  }
+
   _getSlotDecoded(slot) {
     // Some llama.cpp builds nest n_decoded inside next_token[0]
     if (slot.n_decoded != null) {
@@ -340,6 +420,11 @@ export class LlmProbe {
       generationTps: this.generationTps,
       prefillTps: this.prefillTps,
       totalOutputTokens: this.totalOutputTokens,
+      kvCacheUsage: this.kvCacheUsage,
+      requestsRunning: this.requestsRunning,
+      requestsWaiting: this.requestsWaiting,
+      ttftP95Seconds: this.ttftP95Seconds,
+      preemptionsTotal: this.preemptionsTotal,
       error: this.error,
     };
   }
@@ -357,6 +442,11 @@ export class LlmProbe {
       generationTps: 0,
       prefillTps: 0,
       totalOutputTokens: 0,
+      kvCacheUsage: null,
+      requestsRunning: null,
+      requestsWaiting: null,
+      ttftP95Seconds: null,
+      preemptionsTotal: null,
       error: this.error,
     };
   }

--- a/server/collectors/__tests__/LlmProbe.histogram.test.js
+++ b/server/collectors/__tests__/LlmProbe.histogram.test.js
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for LlmProbe's vLLM histogram parsing and quantile computation.
+ *
+ * These cover the pure-math helpers (_parseVllmHistogram, _histogramQuantile)
+ * that compute TTFT p95 from vLLM's Prometheus /metrics exposition. A wrong
+ * quantile silently renders a plausible-but-wrong latency SLO number, so the
+ * edge cases here (empty body, +Inf tail, multi-series, partial body, label
+ * injection) are the correctness-critical paths.
+ *
+ * Uses node:test (shipped with Node 22) — no dependencies required.
+ * Run: npm test
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { LlmProbe } from "../LlmProbe.js";
+
+// Stub spark — LlmProbe only reads spark.lanIp in the constructor.
+const stubSpark = { lanIp: "127.0.0.1" };
+function makeProbe() {
+  return new LlmProbe(stubSpark, 8888);
+}
+
+// A realistic single-series TTFT histogram body (vLLM default buckets).
+const SINGLE_SERIES_BODY = `
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.001",model_name="m"} 0.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.1",model_name="m"} 634.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.5",model_name="m"} 1749.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="1.0",model_name="m"} 2330.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="10.0",model_name="m"} 2588.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="2560.0",model_name="m"} 2644.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="m"} 2644.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="m"} 2644.0
+vllm:time_to_first_token_seconds_sum{engine="0",model_name="m"} 2869.0
+`;
+
+// ─── _parseVllmHistogram ──────────────────────────────────────────────────
+
+test("_parseVllmHistogram parses a single-series body into sorted monotonic buckets", () => {
+  const probe = makeProbe();
+  const { buckets, total } = probe._parseVllmHistogram(
+    SINGLE_SERIES_BODY,
+    "vllm:time_to_first_token_seconds"
+  );
+  assert.equal(total, 2644);
+  assert.ok(buckets.length >= 7, `expected >=7 buckets, got ${buckets.length}`);
+  // Counts must be monotonically non-decreasing.
+  for (let i = 1; i < buckets.length; i++) {
+    assert.ok(
+      buckets[i].count >= buckets[i - 1].count,
+      `non-monotonic at ${i}: ${buckets[i - 1].count} -> ${buckets[i].count}`
+    );
+  }
+  // +Inf bucket is retained as the last entry with upper Infinity.
+  const inf = buckets.find((b) => b.upper === Infinity);
+  assert.ok(inf, "+Inf bucket should be retained");
+  assert.equal(inf.count, 2644);
+});
+
+test("_parseVllmHistogram sums cumulative counts per le across multi-series label sets", () => {
+  const probe = makeProbe();
+  // Two engines, each emitting the same bucket layout. The per-le sum should
+  // combine the cumulative counts (cumulative + cumulative = combined cumulative).
+  const body = `
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.1",model_name="m"} 100.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="1.0",model_name="m"} 500.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="m"} 500.0
+vllm:time_to_first_token_seconds_bucket{engine="1",le="0.1",model_name="m"} 50.0
+vllm:time_to_first_token_seconds_bucket{engine="1",le="1.0",model_name="m"} 250.0
+vllm:time_to_first_token_seconds_bucket{engine="1",le="+Inf",model_name="m"} 250.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="m"} 500.0
+vllm:time_to_first_token_seconds_count{engine="1",model_name="m"} 250.0
+`;
+  const { buckets, total } = probe._parseVllmHistogram(
+    body,
+    "vllm:time_to_first_token_seconds"
+  );
+  assert.equal(total, 750, "total should sum both _count lines");
+  const le01 = buckets.find((b) => b.upper === 0.1);
+  const le10 = buckets.find((b) => b.upper === 1.0);
+  const inf = buckets.find((b) => b.upper === Infinity);
+  assert.equal(le01.count, 150, "le=0.1 should sum 100+50");
+  assert.equal(le10.count, 750, "le=1.0 should sum 500+250");
+  assert.equal(inf.count, 750, "+Inf should sum 500+250");
+});
+
+test("_parseVllmHistogram returns empty buckets and null total on an empty body", () => {
+  const probe = makeProbe();
+  const { buckets, total } = probe._parseVllmHistogram("", "vllm:time_to_first_token_seconds");
+  assert.deepEqual(buckets, []);
+  assert.equal(total, null);
+});
+
+test("_parseVllmHistogram returns empty buckets when +Inf count != _count (partial/corrupted body)", () => {
+  const probe = makeProbe();
+  // Body with only low-le buckets present but a full _count — a truncated/relabel-filtered
+  // exposition. The +Inf count (9000) does not equal _count (10000), so the body is
+  // inconsistent and the parser must refuse to yield a plausible-but-wrong quantile.
+  const body = `
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.1",model_name="m"} 100.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.5",model_name="m"} 9000.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="m"} 9000.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="m"} 10000.0
+`;
+  const { buckets, total } = probe._parseVllmHistogram(
+    body,
+    "vllm:time_to_first_token_seconds"
+  );
+  assert.deepEqual(buckets, [], "inconsistent body should yield empty buckets");
+  assert.equal(total, null, "inconsistent body should yield null total");
+});
+
+test("_parseVllmHistogram is robust to a label value containing le=\" as a substring", () => {
+  const probe = makeProbe();
+  // A model_name containing le=" — the regex must match the actual le label, not the
+  // one embedded in the model name. vLLM model names are user-configurable.
+  const body = `
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.1",model_name="le=\\"0.5\\""} 100.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="1.0",model_name="le=\\"0.5\\""} 500.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="le=\\"0.5\\""} 500.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="le=\\"0.5\\""} 500.0
+`;
+  const { buckets, total } = probe._parseVllmHistogram(
+    body,
+    "vllm:time_to_first_token_seconds"
+  );
+  assert.equal(total, 500);
+  // The first bucket's upper must be 0.1 (the real le), not 0.5 (the one in the model name).
+  const first = buckets.find((b) => b.upper !== Infinity);
+  assert.equal(first.upper, 0.1, "should match the real le label, not the one in model_name");
+});
+
+// ─── _histogramQuantile ───────────────────────────────────────────────────
+
+test("_histogramQuantile interpolates a p80 within a finite bucket", () => {
+  const probe = makeProbe();
+  // Buckets: le=0.1 c=100, le=0.5 c=500, le=1.0 c=900, le=+Inf c=1000. p80 target=800.
+  // 500 < 800 <= 900 → falls in le=1.0 bucket; interpolate 0.5 + (1.0-0.5)*((800-500)/(900-500))=0.875.
+  const buckets = [
+    { upper: 0.1, count: 100 },
+    { upper: 0.5, count: 500 },
+    { upper: 1.0, count: 900 },
+    { upper: Infinity, count: 1000 },
+  ];
+  const result = probe._histogramQuantile(buckets, 1000, 0.8);
+  assert.ok(result !== null, "expected a finite quantile, got null");
+  assert.ok(Math.abs(result - 0.875) < 1e-9, `expected ~0.875, got ${result}`);
+});
+
+test("_histogramQuantile p95 lands in +Inf tail when highest finite bucket is below target", () => {
+  const probe = makeProbe();
+  // Same buckets, p95 target=950. 900 < 950 <= 1000 (the +Inf bucket) → null (unbounded tail).
+  const buckets = [
+    { upper: 0.1, count: 100 },
+    { upper: 0.5, count: 500 },
+    { upper: 1.0, count: 900 },
+    { upper: Infinity, count: 1000 },
+  ];
+  const result = probe._histogramQuantile(buckets, 1000, 0.95);
+  assert.equal(result, null, "p95 in +Inf tail must return null, not interpolate to Infinity");
+});
+
+test("_histogramQuantile returns null when target lands in the +Inf tail", () => {
+  const probe = makeProbe();
+  // All samples in the +Inf bucket (highest finite le=10, c=95; +Inf c=100). p97 target=97.
+  // 95 < 97 → falls into the +Inf bucket → unbounded → null (UI shows '—').
+  const buckets = [
+    { upper: 1.0, count: 50 },
+    { upper: 10.0, count: 95 },
+    { upper: Infinity, count: 100 },
+  ];
+  const result = probe._histogramQuantile(buckets, 100, 0.97);
+  assert.equal(result, null, "target in +Inf tail must return null, not Infinity");
+});
+
+test("_histogramQuantile returns null on empty buckets, missing total, or non-positive total", () => {
+  const probe = makeProbe();
+  assert.equal(probe._histogramQuantile([], 100, 0.95), null);
+  assert.equal(probe._histogramQuantile([{ upper: 1, count: 50 }], null, 0.95), null);
+  assert.equal(probe._histogramQuantile([{ upper: 1, count: 50 }], 0, 0.95), null);
+  assert.equal(probe._histogramQuantile([{ upper: 1, count: 50 }], -5, 0.95), null);
+});
+
+test("_histogramQuantile count===prevCount short-circuit returns the bucket upper (defensive)", () => {
+  const probe = makeProbe();
+  // Non-monotonic input where a bucket has the same cumulative count as the previous
+  // bucket (no new samples) and the target falls in it. The short-circuit returns the
+  // bucket's upper boundary directly rather than dividing by (count - prevCount) = 0.
+  // Construct: [{0.1, 0}, {0.5, 0}, {1.0, 100}, {Inf, 100}], total=100, p50 target=50.
+  // Buckets 0.1 and 0.5 have count 0 (below target 50). Bucket 1.0 count=100 >= 50,
+  // prevCount=0 → 100 !== 0, interpolates. To hit count===prevCount we need the
+  // FIRST bucket that reaches the target to have count == prevCount. That requires
+  // prevCount >= target already — which means a prior bucket already met the target.
+  // This path is defensive against non-monotonic buckets; verify it doesn't divide by
+  // zero: [{0.1, 100}, {0.5, 100}], total=100, p50 target=50. Bucket 0.1 count=100>=50,
+  // prevCount=0 → interpolates 0.05. The short-circuit is unreachable for valid data,
+  // so this test just confirms normal interpolation on the boundary target=prevCount.
+  const buckets = [
+    { upper: 0.1, count: 100 },
+    { upper: 0.5, count: 100 },
+    { upper: Infinity, count: 100 },
+  ];
+  // p50 target=50 falls in the 0.1 bucket (count 100 >= 50), prevCount 0: interpolate
+  // 0 + (0.1-0)*((50-0)/(100-0)) = 0.05. Verifies no division-by-zero on the boundary.
+  const result = probe._histogramQuantile(buckets, 100, 0.5);
+  assert.ok(Math.abs(result - 0.05) < 1e-9, `expected ~0.05, got ${result}`);
+});
+
+test("_histogramQuantile returns null when all buckets are +Inf (degenerate)", () => {
+  const probe = makeProbe();
+  const buckets = [{ upper: Infinity, count: 100 }];
+  const result = probe._histogramQuantile(buckets, 100, 0.95);
+  assert.equal(result, null, "only +Inf bucket must return null");
+});

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -149,6 +149,16 @@ export interface LlmMetrics {
   prefillTps: number;
   /** Cumulative total output (generation) tokens as reported by the LLM server */
   totalOutputTokens: number;
+  /** vLLM KV cache usage fraction (0–1). null when backend !== vllm or unreachable. */
+  kvCacheUsage?: number | null;
+  /** vLLM running request count. null when unavailable. */
+  requestsRunning?: number | null;
+  /** vLLM waiting request count. null when unavailable. */
+  requestsWaiting?: number | null;
+  /** vLLM time-to-first-token p95 in seconds. null when unavailable. */
+  ttftP95Seconds?: number | null;
+  /** vLLM cumulative preemption count. null when unavailable. */
+  preemptionsTotal?: number | null;
   error: string | null;
 }
 

--- a/src/components/SparkPage/LlmPanel.tsx
+++ b/src/components/SparkPage/LlmPanel.tsx
@@ -3,7 +3,7 @@ import type { LlmMetrics } from "../../api/types";
 import { updateLlmPort } from "../../api/client";
 import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
-import { BotIcon, GearIcon } from "../ui/icons";
+import { BotIcon, GearIcon, InfoIcon } from "../ui/icons";
 import { BenchmarkDialog } from "./BenchmarkDialog";
 
 interface LlmPanelProps {
@@ -14,6 +14,16 @@ interface LlmPanelProps {
   className?: string;
 }
 
+const VLLM_METRIC_INFO = {
+  kvCache:
+    "Fraction of the engine’s KV cache memory currently in use (0–100%). High values (≥80%) mean little room for new or long contexts and often lead to queuing or preemptions.",
+  requests:
+    "Run = requests actively generating on the GPU. Wait = accepted but not yet scheduled (capacity or constraints). Growing wait with high KV cache usually means the server is overloaded.",
+  ttftP95:
+    "95th percentile time-to-first-token from vLLM’s history of requests: how long “slow” requests wait until the first output token. Spikes mean queueing, long prefills, or cold paths—not average decode speed.",
+  preempts:
+    "Cumulative times the engine paused a running request to free KV cache for others. Rising under load signals memory pressure; zero is normal when the server is comfortable.",
+} as const;
 
 /** Backend badge — neutral surfaces with a single accent dot. No blue/purple. */
 function BackendBadge({ backend }: { backend: string | null }) {
@@ -33,6 +43,74 @@ function BackendBadge({ backend }: { backend: string | null }) {
   );
 }
 
+/** Small (i) next to a metric label; one open tooltip at a time. */
+function MetricInfoTip({
+  id,
+  label,
+  text,
+  openId,
+  setOpenId,
+}: {
+  id: string;
+  label: string;
+  text: string;
+  openId: string | null;
+  setOpenId: (id: string | null) => void;
+}) {
+  const open = openId === id;
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timer.current != null) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  }, []);
+
+  const scheduleClose = useCallback(() => {
+    clearTimer();
+    timer.current = setTimeout(() => setOpenId(null), 2000);
+  }, [clearTimer, setOpenId]);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  return (
+    <div className="flex items-center gap-1 text-[10px] uppercase tracking-wide text-muted">
+      <span>{label}</span>
+      <button
+        type="button"
+        onClick={() => {
+          if (open) {
+            clearTimer();
+            setOpenId(null);
+          } else {
+            setOpenId(id);
+            scheduleClose();
+          }
+        }}
+        onMouseEnter={() => {
+          clearTimer();
+          setOpenId(id);
+        }}
+        onMouseLeave={scheduleClose}
+        className="relative cursor-pointer opacity-60 hover:opacity-100"
+        aria-label={`${label} info`}
+      >
+        <InfoIcon className="h-2.5 w-2.5" />
+        {open && (
+          <div
+            onMouseEnter={clearTimer}
+            onMouseLeave={scheduleClose}
+            className="absolute left-0 top-full z-20 mt-1 w-52 rounded-md border border-border bg-surface-elevated px-3 py-2 text-left text-[11px] font-normal normal-case leading-snug text-text shadow-lg"
+          >
+            {text}
+          </div>
+        )}
+      </button>
+    </div>
+  );
+}
+
 export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: LlmPanelProps) {
   const [genHistory, setGenHistory] = useState<number[]>([]);
   const [showSettings, setShowSettings] = useState(false);
@@ -41,6 +119,8 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
   const [saveError, setSaveError] = useState<string | null>(null);
   const [engineInfoOpen, setEngineInfoOpen] = useState(false);
   const [benchOpen, setBenchOpen] = useState(false);
+  /** Which vLLM metric info tip is open (kvCache | requests | ttftP95 | preempts). */
+  const [metricInfoId, setMetricInfoId] = useState<string | null>(null);
   const engineInfoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearEngineInfoTimer = useCallback(() => {
@@ -302,6 +382,75 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
               </div>
             </div>
           </div>
+
+          {llm?.backend === "vllm" && (
+            <div className="grid grid-cols-2 gap-2 border-t border-border pt-3 sm:grid-cols-4">
+              <div className="space-y-0.5">
+                <MetricInfoTip
+                  id="kvCache"
+                  label="KV Cache"
+                  text={VLLM_METRIC_INFO.kvCache}
+                  openId={metricInfoId}
+                  setOpenId={setMetricInfoId}
+                />
+                <div
+                  className={`font-tabular text-sm ${
+                    llm.kvCacheUsage == null
+                      ? "text-text"
+                      : llm.kvCacheUsage >= 0.8
+                        ? "text-danger"
+                        : llm.kvCacheUsage >= 0.5
+                          ? "text-warning"
+                          : "text-success"
+                  }`}
+                >
+                  {llm.kvCacheUsage != null
+                    ? `${(llm.kvCacheUsage * 100).toFixed(1)}%`
+                    : "—"}
+                </div>
+              </div>
+              <div className="space-y-0.5">
+                <MetricInfoTip
+                  id="requests"
+                  label="Requests"
+                  text={VLLM_METRIC_INFO.requests}
+                  openId={metricInfoId}
+                  setOpenId={setMetricInfoId}
+                />
+                <div className="font-tabular text-sm text-text">
+                  {llm.requestsRunning != null && llm.requestsWaiting != null
+                    ? `${Math.round(llm.requestsRunning)} run / ${Math.round(llm.requestsWaiting)} wait`
+                    : "—"}
+                </div>
+              </div>
+              <div className="space-y-0.5">
+                <MetricInfoTip
+                  id="ttftP95"
+                  label="TTFT p95"
+                  text={VLLM_METRIC_INFO.ttftP95}
+                  openId={metricInfoId}
+                  setOpenId={setMetricInfoId}
+                />
+                <div className="font-tabular text-sm text-text">
+                  {llm.ttftP95Seconds != null ? `${llm.ttftP95Seconds.toFixed(3)}s` : "—"}
+                </div>
+              </div>
+              <div className="space-y-0.5">
+                <MetricInfoTip
+                  id="preempts"
+                  label="Preempts"
+                  text={VLLM_METRIC_INFO.preempts}
+                  openId={metricInfoId}
+                  setOpenId={setMetricInfoId}
+                />
+                <div className="font-tabular text-sm text-text">
+                  {llm.preemptionsTotal != null
+                    ? Math.round(llm.preemptionsTotal).toLocaleString()
+                    : "—"}
+                </div>
+              </div>
+            </div>
+          )}
 
           <div className="border-t border-border pt-3">
             <button


### PR DESCRIPTION
## Summary
Adds high-signal **vLLM-only** ops tiles to the LLM panel, sourced from the existing Prometheus `/metrics` scrape (no extra HTTP call).

| Tile | Source |
|------|--------|
| **KV Cache** | `kv_cache_usage_perc` (colour-coded) |
| **Requests** | `num_requests_running` / `num_requests_waiting` |
| **TTFT p95** | histogram quantile on `time_to_first_token_seconds` |
| **Preempts** | `num_preemptions_total` (cumulative) |

- Small **info icons** explain each tile
- Responsive 2×2 / 4-column layout (no ITL p95 — dropped as lower priority)
- Pure-math histogram helpers + **11 unit tests** (`npm test`)
- Intentionally **omits** personal `docker-compose` SSH mounts and `host.docker.internal` from contributor PR #11

Supersedes [#11](https://github.com/MiaAI-Lab/sparkDash/pull/11) with a rebased, cleaned integration on current main (including decode bench UI).

## Test plan
- [x] `npm test` — 11/11 pass
- [x] Live probe against vLLM on LAN (`kvCacheUsage`, `ttftP95Seconds`, etc.)
- [ ] Browser: Spark with vLLM shows four tiles + tooltips; non-vLLM / offline port unchanged
