### PR TITLE
Skip llama.cpp /slots re-probe once a vLLM/sglang backend is detected

### DIFF
--- a/server/collectors/LlmProbe.js
+++ b/server/collectors/LlmProbe.js
@@ -142,18 +142,25 @@ export class LlmProbe {
 
   // ─── Server type detection ───────────────────────────────
   async _detectServerType() {
-    const slotUrl = `${this.baseUrl}/slots`;
-    try {
-      const slotRes = await this._fetch(slotUrl);
-      if (slotRes.ok) {
-        const slots = await slotRes.json();
-        if (Array.isArray(slots)) {
-          this.serverIsOpenAI = false;
-          this.backendType = "llama.cpp";
-          return;
+    // Skip the llama.cpp /slots probe once we've positively identified an
+    // OpenAI-compatible backend. vLLM and sglang have no /slots endpoint, so
+    // re-probing it on every re-detect cycle just spams 404s in the backend's
+    // access log (#15). Still probe /slots on first contact, when the type is
+    // unknown, or when the backend was previously llama.cpp.
+    if (this.backendType !== "vllm" && this.backendType !== "sglang") {
+      const slotUrl = `${this.baseUrl}/slots`;
+      try {
+        const slotRes = await this._fetch(slotUrl);
+        if (slotRes.ok) {
+          const slots = await slotRes.json();
+          if (Array.isArray(slots)) {
+            this.serverIsOpenAI = false;
+            this.backendType = "llama.cpp";
+            return;
+          }
         }
-      }
-    } catch {}
+      } catch {}
+    }
 
     // Try OpenAI-compatible
     try {


### PR DESCRIPTION
## What changed

`LlmProbe._detectServerType()` now skips the llama.cpp `/slots` probe when the backend is already known to be `vllm` or `sglang`. It still probes `/slots` on first contact, when the backend type is unknown, or when the backend was previously `llama.cpp`.

## Why

`probe()` re-runs detection every `REDETECT_INTERVAL_MS`, and `_detectServerType()` probed `/slots` unconditionally at the top. vLLM and sglang have no `/slots` endpoint, so every re-detect cycle fired a `GET /slots → 404` into the backend's own access log — indefinitely. Detection still worked (it falls through to `/v1/models`), so this was pure noise, but it never stopped: ~197 `/slots` 404s over 6h against a single DeepSeek-V4 vLLM server.

Fixes #15.

## Risk / tradeoffs

Small, contained to one method. One behavioral tradeoff worth calling out: if the backend at a given URL is swapped from vLLM to llama.cpp *between* re-detects, detection won't notice until the type resets to unknown — llama.cpp also serves `/v1/models`, so `/slots` is the only positive llama.cpp signal. Same-URL backend swaps are rare, and skipping `/slots` for a known OpenAI-compatible backend is the direct way to kill the log spam. If you'd rather keep catching swaps, an alternative is to re-probe `/slots` every Nth re-detect cycle instead of skipping it entirely — happy to switch to that approach if you prefer.

## How verified

- `node --check` on the modified file (syntax).
- Traced the four detection cases by hand:
  - unknown → probes `/slots` (unchanged)
  - llama.cpp → still probes `/slots`, re-confirms (unchanged)
  - vLLM / sglang → skips `/slots`, confirms via `/v1/models` (the fix; no more 404)
- Did not run the full test suite (no `npm install` in this checkout); the change is a single guarded conditional.
