### PR TITLE
Add configurable server bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Copy `.env.example` to `.env` if needed:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `BIND_HOST` | `0.0.0.0` | HTTP and WebSocket listen address |
 | `PORT` | `5555` | HTTP + WebSocket listen port |
 | `LLM_PORT` | `8888` | Default LLM probe port |
 | `POLL_INTERVAL_GPU` | `2000` | GPU poll (ms) |
@@ -230,6 +231,9 @@ Copy `.env.example` to `.env` if needed:
 | `HOST_PROC_PATH` | `/host/proc` | Host proc mount inside container |
 | `HOST_SYS_PATH` | `/host/sys` | Host sys mount |
 | `HOST_ROOT_PATH` | `/host/root` | Host root mount |
+
+> When using Docker's default bridge network, keep `BIND_HOST=0.0.0.0`.  
+> With `network_mode: host`, use `BIND_HOST=127.0.0.1` to restrict access to the local host or a reverse proxy.
 
 ### Adding a Spark
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       # Config + encrypted secrets (passwords survive restarts)
       - ./config:/app/config
     environment:
+      - BIND_HOST=0.0.0.0
       - PORT=5555
       - LLM_PORT=8888
       - NODE_ENV=production

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT = path.resolve(__dirname, "..");
 
+const BIND_HOST = process.env.BIND_HOST || "0.0.0.0";
 const PORT = parseInt(process.env.PORT || "5555", 10);
 const LLM_PORT = parseInt(process.env.LLM_PORT || "8888", 10);
 
@@ -1091,9 +1092,9 @@ function restartBroadcast() {
 loadSettings();
 startBroadcast();
 
-server.listen(PORT, "0.0.0.0", () => {
-  console.log(`[sparkDash] server listening on http://0.0.0.0:${PORT}`);
-  console.log(`[sparkDash] WebSocket endpoint ws://0.0.0.0:${PORT}/ws`);
+server.listen(PORT, BIND_HOST, () => {
+  console.log(`[sparkDash] server listening on http://${BIND_HOST}:${PORT}`);
+  console.log(`[sparkDash] WebSocket endpoint ws://${BIND_HOST}:${PORT}/ws`);
   startAllMonitors();
 });
 


### PR DESCRIPTION
Adds `BIND_HOST` support for the HTTP and WebSocket server.

Defaults to `0.0.0.0` for existing Docker bridge deployments, while allowing `127.0.0.1` for host-networked or reverse-proxy setups.