### PR TITLE
feat: LLM endpoint exposure / auth posture badge

### DIFF
--- a/server/collectors/LlmProbe.js
+++ b/server/collectors/LlmProbe.js
@@ -5,6 +5,7 @@
  * Ported from legacy `probeLlamaServerType` and `_getLlamaMetricsFor`.
  */
 import { LLM_PROBE_TIMEOUT_MS } from "../config.js";
+import { classifyHostScope } from "../validate.js";
 
 const FAIL_RESET_THRESHOLD = 3;
 const REDETECT_INTERVAL_MS = 60_000;
@@ -18,6 +19,8 @@ export class LlmProbe {
     // State
     this.backendType = null; // 'vllm' | 'llama.cpp' | 'sglang' | null
     this.serverIsOpenAI = null; // true = OpenAI-compatible
+    /** Whether /v1/models (or /slots) answered without credentials. null = unknown. */
+    this.authOpen = null;
     this.stepId = 0;
     this.modelId = null;
     this.modelPath = null;
@@ -118,6 +121,7 @@ export class LlmProbe {
   _resetDetection() {
     this.serverIsOpenAI = null;
     this.backendType = null;
+    this.authOpen = null;
     this.modelId = null;
     this.modelPath = null;
     this.generationTps = 0;
@@ -140,6 +144,19 @@ export class LlmProbe {
     this.lastTokenCounts = { input: 0, output: 0 };
   }
 
+  /** Note auth from an HTTP status on an unauthenticated probe request. */
+  _noteAuthStatus(status) {
+    if (status >= 200 && status < 300) {
+      this.authOpen = true;
+      return "ok";
+    }
+    if (status === 401 || status === 403) {
+      this.authOpen = false;
+      return "auth";
+    }
+    return "other";
+  }
+
   // ─── Server type detection ───────────────────────────────
   async _detectServerType() {
     // Skip the llama.cpp /slots probe once we've positively identified an
@@ -151,13 +168,19 @@ export class LlmProbe {
       const slotUrl = `${this.baseUrl}/slots`;
       try {
         const slotRes = await this._fetch(slotUrl);
-        if (slotRes.ok) {
+        const auth = this._noteAuthStatus(slotRes.status);
+        if (auth === "ok") {
           const slots = await slotRes.json();
           if (Array.isArray(slots)) {
             this.serverIsOpenAI = false;
             this.backendType = "llama.cpp";
             return;
           }
+        } else if (auth === "auth") {
+          // Authenticated llama.cpp — treat as protected OpenAI-style for posture
+          this.serverIsOpenAI = false;
+          this.backendType = "llama.cpp";
+          return;
         }
       } catch {}
     }
@@ -165,7 +188,8 @@ export class LlmProbe {
     // Try OpenAI-compatible
     try {
       const modelRes = await this._fetch(`${this.baseUrl}/v1/models`);
-      if (modelRes.ok) {
+      const auth = this._noteAuthStatus(modelRes.status);
+      if (auth === "ok" || auth === "auth") {
         this.serverIsOpenAI = true;
         this.backendType = "vllm";
         return;
@@ -182,11 +206,15 @@ export class LlmProbe {
     const dtSec = (now - this.lastProbeTime) / 1000;
     this.lastProbeTime = now;
 
-    // Model info from /v1/models — failure means server is down
+    // Model info from /v1/models — 401/403 means protected; other failure = down
     let modelsOk = false;
     try {
       const modelsRes = await this._fetch(`${this.baseUrl}/v1/models`);
-      if (modelsRes.ok) {
+      const auth = this._noteAuthStatus(modelsRes.status);
+      if (auth === "auth") {
+        return this._getSnapshot();
+      }
+      if (auth === "ok") {
         modelsOk = true;
         const modelsData = await modelsRes.json();
         const model = modelsData?.data?.[0];
@@ -306,7 +334,11 @@ export class LlmProbe {
     let slotsOk = false;
     try {
       const slotsRes = await this._fetch(`${this.baseUrl}/slots`);
-      if (slotsRes.ok) {
+      const auth = this._noteAuthStatus(slotsRes.status);
+      if (auth === "auth") {
+        return this._getSnapshot();
+      }
+      if (auth === "ok") {
         const slots = await slotsRes.json();
         if (Array.isArray(slots)) {
           slotsOk = true;
@@ -449,9 +481,52 @@ export class LlmProbe {
     return slot.n_prompt_tokens_processed || slot.n_prompt_tokens || 0;
   }
 
+  /**
+   * Observational exposure hint from probe target + unauthenticated reachability.
+   * Does not claim process bind address (0.0.0.0 vs interface).
+   */
+  _buildPosture() {
+    if (this.authOpen == null) return null;
+
+    const host = this.spark?.lanIp || "";
+    const scope = classifyHostScope(host);
+    const auth = this.authOpen ? "open" : "protected";
+
+    let level = "ok";
+    if (auth === "open") {
+      if (scope === "public") level = "danger";
+      else if (scope === "local") level = "ok";
+      else level = "warn"; // lan or unknown hostname
+    }
+
+    const scopeWords = {
+      local: "loopback",
+      lan: "LAN",
+      public: "public",
+      unknown: "unknown-host",
+    };
+    const shortScope = {
+      local: "Local",
+      lan: "LAN",
+      public: "Public",
+      unknown: "Host",
+    };
+    const label =
+      auth === "protected"
+        ? "Auth required"
+        : `Open · ${shortScope[scope]}`;
+    const detail =
+      auth === "protected"
+        ? `API key required · ${scopeWords[scope]} target (${host || "—"}). Based on the configured probe host, not the process bind address.`
+        : `Unauthenticated · ${scopeWords[scope]} target (${host || "—"}). Based on the configured probe host, not the process bind address.`;
+
+    return { level, auth, scope, label, detail };
+  }
+
   _getSnapshot() {
+    const metricsLive = this.serverIsOpenAI !== null && this.authOpen !== false;
     return {
-      available: this.serverIsOpenAI !== null,
+      available: metricsLive,
       backend: this.backendType,
       modelId: this.modelId || null,
       modelPath: this.modelPath || null,
@@ -471,6 +546,7 @@ export class LlmProbe {
       e2eP95Seconds: this.e2eP95Seconds,
       itlP95Seconds: this.itlP95Seconds,
       mtpAcceptanceRate: this.mtpAcceptanceRate,
+      posture: this._buildPosture(),
       error: this.error,
     };
   }
@@ -478,7 +554,7 @@ export class LlmProbe {
   _defaultLlm() {
     return {
       available: false,
-      backend: null,
+      backend: this.backendType,
       modelId: null,
       modelPath: null,
       contextLength: null,
@@ -497,6 +573,7 @@ export class LlmProbe {
       e2eP95Seconds: null,
       itlP95Seconds: null,
       mtpAcceptanceRate: null,
+      posture: this._buildPosture(),
       error: this.error,
     };
   }

--- a/server/collectors/__tests__/LlmProbe.posture.test.js
+++ b/server/collectors/__tests__/LlmProbe.posture.test.js
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for LLM endpoint security posture (#17).
+ * Run: npm test
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { classifyHostScope } from "../../validate.js";
+import { LlmProbe } from "../LlmProbe.js";
+
+test("classifyHostScope: loopback / localhost → local", () => {
+  assert.equal(classifyHostScope("127.0.0.1"), "local");
+  assert.equal(classifyHostScope("127.0.0.2"), "local");
+  assert.equal(classifyHostScope("localhost"), "local");
+  assert.equal(classifyHostScope("::1"), "local");
+});
+
+test("classifyHostScope: RFC1918 + link-local → lan", () => {
+  assert.equal(classifyHostScope("10.0.0.5"), "lan");
+  assert.equal(classifyHostScope("172.16.1.1"), "lan");
+  assert.equal(classifyHostScope("172.31.255.1"), "lan");
+  assert.equal(classifyHostScope("192.168.1.10"), "lan");
+  assert.equal(classifyHostScope("169.254.1.1"), "lan");
+});
+
+test("classifyHostScope: public IPv4 → public", () => {
+  assert.equal(classifyHostScope("8.8.8.8"), "public");
+  assert.equal(classifyHostScope("1.1.1.1"), "public");
+});
+
+test("classifyHostScope: hostname / empty → unknown", () => {
+  assert.equal(classifyHostScope("spark.example.com"), "unknown");
+  assert.equal(classifyHostScope(""), "unknown");
+  assert.equal(classifyHostScope("172.15.0.1"), "public"); // not RFC1918
+});
+
+test("_buildPosture: open + public → danger", () => {
+  const probe = new LlmProbe({ lanIp: "8.8.8.8" }, 8888);
+  probe.authOpen = true;
+  const p = probe._buildPosture();
+  assert.equal(p.level, "danger");
+  assert.equal(p.auth, "open");
+  assert.equal(p.scope, "public");
+  assert.match(p.label, /Open/);
+  assert.match(p.detail, /not the process bind address/);
+});
+
+test("_buildPosture: open + lan → warn", () => {
+  const probe = new LlmProbe({ lanIp: "192.168.1.50" }, 8888);
+  probe.authOpen = true;
+  const p = probe._buildPosture();
+  assert.equal(p.level, "warn");
+  assert.equal(p.scope, "lan");
+});
+
+test("_buildPosture: open + local → ok", () => {
+  const probe = new LlmProbe({ lanIp: "127.0.0.1" }, 8888);
+  probe.authOpen = true;
+  const p = probe._buildPosture();
+  assert.equal(p.level, "ok");
+  assert.equal(p.scope, "local");
+});
+
+test("_buildPosture: protected → ok regardless of scope", () => {
+  const probe = new LlmProbe({ lanIp: "8.8.8.8" }, 8888);
+  probe.authOpen = false;
+  const p = probe._buildPosture();
+  assert.equal(p.level, "ok");
+  assert.equal(p.auth, "protected");
+  assert.equal(p.label, "Auth required");
+});
+
+test("_buildPosture: unknown auth → null", () => {
+  const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 8888);
+  assert.equal(probe._buildPosture(), null);
+});
+
+test("_getSnapshot: protected auth marks available false but keeps posture", () => {
+  const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 8888);
+  probe.serverIsOpenAI = true;
+  probe.backendType = "vllm";
+  probe.authOpen = false;
+  const snap = probe._getSnapshot();
+  assert.equal(snap.available, false);
+  assert.equal(snap.posture.level, "ok");
+  assert.equal(snap.posture.auth, "protected");
+});

--- a/server/validate.js
+++ b/server/validate.js
@@ -29,6 +29,28 @@ export function isValidHost(host) {
 }
 
 /**
+ * Classify a probe target for security-posture hints.
+ * Uses the configured host only — not the process bind address.
+ * Hostnames (except localhost) are "unknown" (no DNS lookup).
+ *
+ * @returns {"local" | "lan" | "public" | "unknown"}
+ */
+export function classifyHostScope(host) {
+  if (typeof host !== "string" || !host.trim()) return "unknown";
+  const h = host.trim().toLowerCase();
+  if (h === "localhost" || h === "::1") return "local";
+  if (!isValidIPv4(h)) return "unknown";
+  const [a, b] = h.split(".").map(Number);
+  if (a === 127) return "local";
+  if (a === 10) return "lan";
+  if (a === 172 && b >= 16 && b <= 31) return "lan";
+  if (a === 192 && b === 168) return "lan";
+  if (a === 169 && b === 254) return "lan";
+  if (a === 0 || a >= 224) return "unknown";
+  return "public";
+}
+
+/**
  * Block cloud metadata / link-local misuse. Allow private, loopback, and public
  * (remote Sparks may be anywhere on a managed network).
  */

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -190,7 +190,25 @@ export interface LlmMetrics {
   itlP95Seconds?: number | null;
   /** vLLM speculative/MTP acceptance rate (accepted/drafted, 0–1). null when unavailable. */
   mtpAcceptanceRate?: number | null;
+  /**
+   * Observational exposure hint from unauthenticated probe reachability +
+   * configured target host scope. null when auth status is unknown.
+   * Does not claim process bind address.
+   */
+  posture?: LlmPosture | null;
   error: string | null;
+}
+
+/** Security posture badge payload from LlmProbe. */
+export interface LlmPosture {
+  /** ok = green, warn = amber, danger = red */
+  level: "ok" | "warn" | "danger";
+  auth: "open" | "protected";
+  scope: "local" | "lan" | "public" | "unknown";
+  /** Short badge text */
+  label: string;
+  /** Tooltip / title detail */
+  detail: string;
 }
 
 // ─── Full metrics snapshot ────────────────────────────────

--- a/src/components/SparkPage/LlmPanel.tsx
+++ b/src/components/SparkPage/LlmPanel.tsx
@@ -52,6 +52,23 @@ function BackendBadge({ backend }: { backend: string | null }) {
   );
 }
 
+/** Exposure / auth posture from the unauthenticated probe (issue #17). */
+function PostureBadge({
+  posture,
+}: {
+  posture: NonNullable<LlmMetrics["posture"]>;
+}) {
+  return (
+    <span
+      className={`llm-posture llm-posture--${posture.level}`}
+      title={posture.detail}
+    >
+      <span className="llm-posture__dot" />
+      {posture.label}
+    </span>
+  );
+}
+
 /** Small (i) next to a metric label; one open tooltip at a time. */
 function MetricInfoTip({
   id,
@@ -284,9 +301,17 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
         </div>
       ) : !available ? (
         <div className="space-y-3">
-          <div className="flex items-center gap-2 py-1">
-            <span className="h-1.5 w-1.5 rounded-full bg-muted" />
-            <p className="text-xs text-muted">No model loaded on :{llmPort}</p>
+          <div className="flex flex-wrap items-center gap-2 py-1">
+            {llm?.posture ? (
+              <PostureBadge posture={llm.posture} />
+            ) : (
+              <span className="h-1.5 w-1.5 rounded-full bg-muted" />
+            )}
+            <p className="text-xs text-muted">
+              {llm?.posture?.auth === "protected"
+                ? `Auth required on :${llmPort}`
+                : `No model loaded on :${llmPort}`}
+            </p>
           </div>
           <div className="border-t border-border pt-3 space-y-2">
             <button
@@ -312,6 +337,7 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
         <div className="space-y-3">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <BackendBadge backend={llm?.backend ?? null} />
+            {llm?.posture && <PostureBadge posture={llm.posture} />}
             {llm?.modelId && (
               <span
                 className="min-w-0 flex-1 truncate text-xs text-text"

--- a/src/index.css
+++ b/src/index.css
@@ -729,6 +729,36 @@ input[type="checkbox"] {
   color: var(--color-accent);
 }
 
+/* Endpoint exposure / auth posture (#17) */
+.llm-posture {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: help;
+}
+.llm-posture__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.llm-posture--ok {
+  background: color-mix(in srgb, var(--color-success) 16%, transparent);
+  color: var(--color-success);
+}
+.llm-posture--warn {
+  background: color-mix(in srgb, var(--color-warning) 16%, transparent);
+  color: var(--color-warning);
+}
+.llm-posture--danger {
+  background: color-mix(in srgb, var(--color-danger) 16%, transparent);
+  color: var(--color-danger);
+}
+
 /* ─── Mobile spark menu dropdown ────────────────────────── */
 /* Wrapper needed for absolute positioning */
 .mobile-menu-wrapper {


### PR DESCRIPTION
## Summary
- Adds a read-only green/amber/red posture badge on each LLM panel from signals the probe already has: unauthenticated `/v1/models` (or `/slots`) reachability + configured target host scope (loopback / LAN / public).
- Does **not** claim process bind address (`0.0.0.0` vs interface) — tooltip states that clearly.
- Closes #17.

## Levels
- **Red** — open + public target
- **Amber** — open + LAN / unknown hostname
- **Green** — auth required (401/403), or open on loopback

## Test plan
- [x] `npm test` (includes new posture unit tests)
- [x] `npm run typecheck`
- [ ] Manual: open LLM panel on a LAN Spark — expect amber “Open · LAN”
- [ ] Manual: tooltip mentions probe host, not bind address
