### PR TITLE
fix: always show disk I/O rates in Storage panel

### DIFF
--- a/src/components/SparkPage/StoragePanel.tsx
+++ b/src/components/SparkPage/StoragePanel.tsx
@@ -226,16 +226,14 @@ export function StoragePanel({
                         {formatGb(disk.available)} free
                       </span>
                     </div>
-                    {disk.readSpeed > 0 || disk.writeSpeed > 0 ? (
-                      <div className="flex items-center justify-end gap-3 text-[10px]">
-                        <span className="font-tabular text-muted">
-                          <span className="text-accent">↑</span> {formatBytesPerSec(disk.writeSpeed)}
-                        </span>
-                        <span className="font-tabular text-muted">
-                          <span className="text-accent">↓</span> {formatBytesPerSec(disk.readSpeed)}
-                        </span>
-                      </div>
-                    ) : null}
+                    <div className="flex items-center justify-end gap-3 text-[10px]">
+                      <span className="font-tabular text-muted">
+                        <span className="text-accent">↑</span> {formatBytesPerSec(disk.writeSpeed || 0)}
+                      </span>
+                      <span className="font-tabular text-muted">
+                        <span className="text-accent">↓</span> {formatBytesPerSec(disk.readSpeed || 0)}
+                      </span>
+                    </div>
                   </div>
                 );
               })}


### PR DESCRIPTION
## Summary
- Always render ↑/↓ throughput under each disk in the Storage panel, showing `0 B/s` when idle
- Prevents the panel height from jumping when I/O activity appears on one of multiple disks

Fixes #20

## Test plan
- [ ] Open a Spark with 2+ disks visible in Storage
- [ ] Confirm every disk shows ↑ and ↓ rates even when idle (`0 B/s`)
- [ ] Generate disk I/O and confirm rates update without layout jump
- [ ] Toggle Storage settings / refresh still works
