### PR TITLE
Add typed confirmation dialog for Spark shutdown

### DIFF
--- a/src/components/ConfirmShutdownDialog.tsx
+++ b/src/components/ConfirmShutdownDialog.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useModalPresence } from "../hooks/useModalPresence";
+import { PowerOffIcon } from "./ui/icons";
+
+const CONFIRM_PHRASE = "poweroff";
+
+interface ConfirmShutdownDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+}
+
+function useEscape(enabled: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [enabled, onClose]);
+}
+
+export function ConfirmShutdownDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = "Shut down",
+}: ConfirmShutdownDialogProps) {
+  const [phrase, setPhrase] = useState("");
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const titleId = useId();
+  const { mounted, visible } = useModalPresence(open);
+
+  useEscape(open && !submitting, onClose);
+
+  useEffect(() => {
+    if (!open) {
+      setPhrase("");
+      setAcknowledged(false);
+      setSubmitting(false);
+      return;
+    }
+    const t = window.setTimeout(() => inputRef.current?.focus(), 50);
+    return () => window.clearTimeout(t);
+  }, [open]);
+
+  useEffect(() => {
+    if (!mounted) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [mounted]);
+
+  const phraseOk = phrase.trim().toLowerCase() === CONFIRM_PHRASE;
+  const canConfirm = phraseOk && acknowledged && !submitting;
+
+  const handleConfirm = async () => {
+    if (!canConfirm) return;
+    setSubmitting(true);
+    try {
+      await onConfirm();
+      onClose();
+    } catch {
+      setSubmitting(false);
+    }
+  };
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      className={`modal-overlay${visible ? " is-open" : ""}`}
+      onClick={(e) => {
+        if (submitting) return;
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="modal-sheet max-w-md"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+      >
+        <div className="modal-sheet__header flex items-center gap-2 text-danger" id={titleId}>
+          <PowerOffIcon className="h-4 w-4 shrink-0" />
+          <span>Danger zone — {title}</span>
+        </div>
+
+        <div className="modal-sheet__body space-y-3">
+          <p className="text-xs leading-relaxed text-muted">{description}</p>
+
+          <div className="rounded-md border border-danger/35 bg-danger/10 px-3 py-2.5">
+            <p className="text-[11px] font-medium text-danger">
+              This powers off hardware. Running containers and sessions will stop.
+            </p>
+          </div>
+
+          <label className="flex cursor-pointer items-start gap-2.5 text-xs text-text">
+            <input
+              type="checkbox"
+              checked={acknowledged}
+              disabled={submitting}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+              className="mt-0.5 h-3.5 w-3.5 shrink-0 accent-[var(--color-danger)]"
+            />
+            <span>I understand this cannot be undone from the dashboard.</span>
+          </label>
+
+          <div>
+            <label className="mb-1 block text-xs text-muted">
+              Type <span className="font-mono text-danger">{CONFIRM_PHRASE}</span> to confirm
+            </label>
+            <input
+              ref={inputRef}
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              value={phrase}
+              disabled={submitting}
+              onChange={(e) => setPhrase(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleConfirm();
+                }
+              }}
+              className="w-full rounded border border-border bg-surface-elevated px-3 py-1.5 font-mono text-xs text-text outline-none focus:border-danger"
+              placeholder={CONFIRM_PHRASE}
+            />
+          </div>
+        </div>
+
+        <div className="modal-sheet__footer">
+          <div className="modal-sheet__footer-actions">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="rounded-md border border-border bg-surface-elevated px-3 py-1.5 text-xs text-muted transition-colors hover:bg-surface-hover hover:text-text disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleConfirm()}
+              disabled={!canConfirm}
+              className="rounded-md border border-danger/50 bg-danger px-3 py-1.5 text-xs font-medium text-white transition-colors hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {submitting ? "Shutting down…" : confirmLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/OverviewPage/OverviewPage.tsx
+++ b/src/components/OverviewPage/OverviewPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { SparkSnapshot } from "../../api/types";
 import { resolveSparkRole } from "../../api/sparkRole";
 import { shutdownAllSparks, wakeAllSparks } from "../../api/client";
+import { ConfirmShutdownDialog } from "../ConfirmShutdownDialog";
 import { MetricBar } from "../ui/MetricBar";
 import { ActivityIcon, PowerOffIcon, PowerOnIcon } from "../ui/icons";
 
@@ -272,13 +273,12 @@ export function OverviewPage({ sparks, hideOffline = false, temperatureUnit = "c
   const visibleSparks = hideOffline ? sparks.filter((s) => s.online) : sparks;
   const [batchLoading, setBatchLoading] = useState(false);
   const [batchMsg, setBatchMsg] = useState<{ text: string; tone: "ok" | "err" } | null>(null);
+  const [shutdownOpen, setShutdownOpen] = useState(false);
+
+  const onlineShutdownCount = sparks.filter((s) => s.online).length;
 
   async function handleShutdownAll() {
-    const onlineCount = sparks.filter((s) => s.online).length;
-    if (onlineCount === 0) return;
-    if (!confirm(`Gracefully shut down all ${onlineCount} online Spark(s)? Offline nodes will be skipped.`)) {
-      return;
-    }
+    if (onlineShutdownCount === 0) return;
     setBatchLoading(true);
     setBatchMsg(null);
     try {
@@ -376,10 +376,10 @@ export function OverviewPage({ sparks, hideOffline = false, temperatureUnit = "c
               </button>
               <button
                 type="button"
-                onClick={() => void handleShutdownAll()}
-                disabled={batchLoading || !sparks.some((s) => s.online)}
+                onClick={() => setShutdownOpen(true)}
+                disabled={batchLoading || onlineShutdownCount === 0}
                 title="Shut down all online Sparks"
-                className="flex items-center gap-1 rounded-md border border-border bg-surface-elevated px-2.5 py-1.5 text-[11px] text-muted hover:bg-danger/20 hover:text-danger transition-colors disabled:opacity-50"
+                className="flex items-center gap-1 rounded-md border border-border bg-surface-elevated px-2.5 py-1.5 text-[11px] text-muted transition-colors hover:bg-danger/20 hover:text-danger disabled:opacity-50"
               >
                 <PowerOffIcon className="h-3 w-3" />
                 Shutdown All
@@ -392,6 +392,14 @@ export function OverviewPage({ sparks, hideOffline = false, temperatureUnit = "c
           </span>
         </div>
       </div>
+      <ConfirmShutdownDialog
+        open={shutdownOpen}
+        onClose={() => setShutdownOpen(false)}
+        onConfirm={handleShutdownAll}
+        title="Shutdown All"
+        description={`Gracefully shut down all ${onlineShutdownCount} online Spark${onlineShutdownCount === 1 ? "" : "s"}? Offline nodes will be skipped.`}
+        confirmLabel="Shut down all"
+      />
       <div className="overview-page grid sm:grid-cols-2 lg:grid-cols-3" style={{ gap: "var(--density-page-gap)" }}>
         {visibleSparks.map((spark) => (
           <SparkCard

--- a/src/components/SparkPage/SparkHeader.tsx
+++ b/src/components/SparkPage/SparkHeader.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { SparkSnapshot } from "../../api/types";
 import { resolveSparkRole } from "../../api/sparkRole";
 import { shutdownSpark, wakeSpark } from "../../api/client";
+import { ConfirmShutdownDialog } from "../ConfirmShutdownDialog";
 import { EditIcon, PowerOffIcon, PowerOnIcon } from "../ui/icons";
 
 interface SparkHeaderProps {
@@ -26,15 +27,9 @@ export function SparkHeader({ spark, onEdit }: SparkHeaderProps) {
   const online = spark.online;
   const [powerLoading, setPowerLoading] = useState(false);
   const [powerMsg, setPowerMsg] = useState<{ text: string; tone: "ok" | "err" } | null>(null);
+  const [shutdownOpen, setShutdownOpen] = useState(false);
 
   async function handleShutdown() {
-    if (
-      !confirm(
-        `Gracefully shut down ${spark.name}? This will stop all containers and power off the node.`
-      )
-    ) {
-      return;
-    }
     setPowerLoading(true);
     setPowerMsg(null);
     try {
@@ -138,10 +133,10 @@ export function SparkHeader({ spark, onEdit }: SparkHeaderProps) {
         {online ? (
           <button
             type="button"
-            onClick={() => void handleShutdown()}
+            onClick={() => setShutdownOpen(true)}
             disabled={powerLoading}
             title="Graceful shutdown (requires /usr/local/bin/spark-shutdown on the host)"
-            className="flex items-center gap-1.5 rounded-md border border-border bg-surface-elevated px-3 py-1.5 text-[11px] text-muted hover:bg-danger/20 hover:text-danger transition-colors disabled:opacity-50"
+            className="flex items-center gap-1.5 rounded-md border border-border bg-surface-elevated px-3 py-1.5 text-[11px] text-muted transition-colors hover:bg-danger/20 hover:text-danger disabled:opacity-50"
           >
             <PowerOffIcon className="h-3 w-3" />
             Shutdown
@@ -169,6 +164,15 @@ export function SparkHeader({ spark, onEdit }: SparkHeaderProps) {
           </button>
         )}
       </div>
+
+      <ConfirmShutdownDialog
+        open={shutdownOpen}
+        onClose={() => setShutdownOpen(false)}
+        onConfirm={handleShutdown}
+        title={`Shut down ${spark.name}`}
+        description={`Gracefully shut down ${spark.name}? This will stop all containers and power off the node.`}
+        confirmLabel="Shut down"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace `window.confirm` with a danger-zone modal for **Shutdown** and **Shutdown All**
- Require checkbox + typing `poweroff` before shutdown proceeds
- Keep trigger buttons normal/muted styling; danger cues live in the dialog

Fixes #22

## Test plan
- [ ] Overview → Shutdown All opens dialog; Cancel / Esc closes without action
- [ ] Confirm stays disabled until checkbox + `poweroff`
- [ ] Spark page → Shutdown uses the same dialog
- [ ] Buttons remain normal color (not red at rest)
