### PR TITLE
Add optional per-port LLM API key (v1.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Format: version sections are listed newest first.
 
 ---
 
+## [1.4.4] — 2026-07-30
+
+### Added
+- **Optional per-port LLM API key** — set a Bearer token in LLM panel Settings for OpenAI-compatible gateways (e.g. LiteLLM); stored encrypted like SSH passwords; used by probe, Showcase, and Decode bench ([#21](https://github.com/MiaAI-Lab/sparkDash/issues/21))
+
+### Changed
+- **Settings version label** — reads `package.json` version instead of a hardcoded string
+
+---
+
+## [1.4.3] — 2026-07-30
+
+### Added
+- **Shutdown confirmation dialog** — Shutdown / Shutdown All open a danger-zone modal requiring a checkbox and typing `poweroff` before powering off ([#22](https://github.com/MiaAI-Lab/sparkDash/issues/22), [#24](https://github.com/MiaAI-Lab/sparkDash/pull/24))
+
+### Changed
+- **Decode benchmark results** — dropped Server column; show Aggregate + per-stream tok/s
+
+### Fixed
+- **Storage tile height jump** — always show disk ↑/↓ I/O rates (`0 B/s` when idle) so multi-disk panels keep a stable height ([#20](https://github.com/MiaAI-Lab/sparkDash/issues/20), [#23](https://github.com/MiaAI-Lab/sparkDash/pull/23))
+
+---
+
 ## [1.4.0] — 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,17 +46,16 @@ sparkDash is a real-time web dashboard for one or more **NVIDIA DGX Spark (GB10)
 
 ## Latest version changelog
 
-### Version 1.4.0 — Free storage, cleaner disk rows
-- **Free space** — each disk shows available GB right next to used/total; I/O speeds get their own row below
+### Version 1.4.4 — Optional LLM API key
+- **Per-port API key** — optional Bearer token in LLM Settings for authenticated OpenAI-compatible gateways; encrypted at rest ([#21](https://github.com/MiaAI-Lab/sparkDash/issues/21))
+- **Settings version** — footer shows the real `package.json` version
 
 Full history: [CHANGELOG.md](./CHANGELOG.md)
 
-### Version 1.3.9 — Showcase prompt types, full-token fills & live tok/s
-- **Prompt types** — Text / Structural / Mixed catalogs for apples-to-apples tok/s scenarios
-- **Fill max tokens** — showcase streams force full-length generations (`min_tokens` + `ignore_eos`)
-- **Accurate live tok/s** — estimate from text while streaming (SSE chunks were under-counting)
-- **Security posture badge** — open / LAN / public exposure hint on each LLM panel ([#17](https://github.com/MiaAI-Lab/sparkDash/issues/17))
-- **`BIND_HOST`** — configurable HTTP/WebSocket listen address ([#18](https://github.com/MiaAI-Lab/sparkDash/pull/18))
+### Version 1.4.3 — Shutdown confirm, stable storage I/O, decode bench cleanup
+- **Shutdown confirmation** — danger-zone dialog with checkbox + type `poweroff` before Shutdown / Shutdown All ([#22](https://github.com/MiaAI-Lab/sparkDash/issues/22))
+- **Stable Storage height** — always show disk ↑/↓ rates (`0 B/s` when idle) ([#20](https://github.com/MiaAI-Lab/sparkDash/issues/20))
+- **Decode benchmark** — Aggregate + per-stream tok/s (Server column removed)
 
 Full history: [CHANGELOG.md](./CHANGELOG.md)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparkdash",
-  "version": "1.3.9",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparkdash",
-      "version": "1.3.9",
+      "version": "1.4.4",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkdash",
-  "version": "1.4.0",
+  "version": "1.4.4",
   "description": "sparkDash — Multi-DGX Spark Monitoring Dashboard",
   "type": "module",
   "scripts": {

--- a/server/collectors/DecodeBench.js
+++ b/server/collectors/DecodeBench.js
@@ -222,6 +222,7 @@ async function runConcurrencyWave({
   abortSignal,
   sampleHardware = null,
   debug = false,
+  apiKey = null,
 }) {
   const url = `${baseUrl}/v1/chat/completions`;
   const prompts = pickDistinctPrompts(concurrency);
@@ -271,6 +272,7 @@ async function runConcurrencyWave({
     return runStreamingRequest(url, body, ctrl.signal, {
       debug,
       retryOnThinking400: true,
+      apiKey,
     }).finally(() => {
       clearTimeout(timeout);
       if (abortSignal) abortSignal.removeEventListener("abort", onParentAbort);
@@ -504,6 +506,7 @@ export class DecodeBenchManager {
    *   maxTokens?: number,
    *   debug?: boolean,
    *   sampleHardware?: (() => Promise<object | null> | object | null) | null,
+   *   apiKey?: string | null,
    * }} opts
    */
   start(opts) {
@@ -516,6 +519,7 @@ export class DecodeBenchManager {
       maxTokens: rawMax,
       debug = false,
       sampleHardware = null,
+      apiKey = null,
     } = opts;
 
     if (this.activeBySpark.has(sparkId)) {
@@ -573,6 +577,7 @@ export class DecodeBenchManager {
       error: null,
       _abort: abort,
       _debug: debugOn,
+      _apiKey: apiKey != null && String(apiKey).trim() ? String(apiKey).trim() : null,
       _sampleHardware:
         debugOn && typeof sampleHardware === "function" ? sampleHardware : null,
     };
@@ -621,6 +626,7 @@ export class DecodeBenchManager {
           abortSignal: job._abort.signal,
           sampleHardware: job._sampleHardware,
           debug,
+          apiKey: job._apiKey,
         });
 
         if (job._abort.signal.aborted) {

--- a/server/collectors/LlmProbe.js
+++ b/server/collectors/LlmProbe.js
@@ -490,7 +490,8 @@ export class LlmProbe {
 
     const host = this.spark?.lanIp || "";
     const scope = classifyHostScope(host);
-    const auth = this.authOpen ? "open" : "protected";
+    const keyed = Boolean(this._apiKey());
+    const auth = keyed ? "keyed" : this.authOpen ? "open" : "protected";
 
     let level = "ok";
     if (auth === "open") {
@@ -514,11 +515,15 @@ export class LlmProbe {
     const label =
       auth === "protected"
         ? "Auth required"
-        : `Open · ${shortScope[scope]}`;
+        : auth === "keyed"
+          ? `API key · ${shortScope[scope]}`
+          : `Open · ${shortScope[scope]}`;
     const detail =
       auth === "protected"
         ? `API key required · ${scopeWords[scope]} target (${host || "—"}). Based on the configured probe host, not the process bind address.`
-        : `Unauthenticated · ${scopeWords[scope]} target (${host || "—"}). Based on the configured probe host, not the process bind address.`;
+        : auth === "keyed"
+          ? `Using configured API key · ${scopeWords[scope]} target (${host || "—"}). Based on the configured probe host, not the process bind address.`
+          : `Unauthenticated · ${scopeWords[scope]} target (${host || "—"}). Based on the configured probe host, not the process bind address.`;
 
     return { level, auth, scope, label, detail };
   }
@@ -579,7 +584,18 @@ export class LlmProbe {
   }
 
   // ─── HTTP helpers ────────────────────────────────────────
+  _apiKey() {
+    const keys = this.spark?.llmApiKeys;
+    if (!keys || typeof keys !== "object") return null;
+    const raw = keys[String(this.port)] ?? keys[this.port];
+    const key = raw != null ? String(raw).trim() : "";
+    return key || null;
+  }
+
   async _fetch(url) {
-    return fetch(url, { signal: AbortSignal.timeout(LLM_PROBE_TIMEOUT_MS) });
+    const headers = {};
+    const apiKey = this._apiKey();
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+    return fetch(url, { signal: AbortSignal.timeout(LLM_PROBE_TIMEOUT_MS), headers });
   }
 }

--- a/server/collectors/LlmStreaming.js
+++ b/server/collectors/LlmStreaming.js
@@ -48,13 +48,20 @@ export function sleep(ms, signal) {
 /**
  * Read cumulative generation (output) token counters from the server —
  * same sources as LlmProbe live tok/s.
+ * @param {string} baseUrl
+ * @param {{ apiKey?: string | null }} [opts]
  * @returns {Promise<number | null>}
  */
-export async function readServerGenerationTokens(baseUrl) {
+export async function readServerGenerationTokens(baseUrl, opts = {}) {
+  const headers = {};
+  const apiKey = opts?.apiKey != null ? String(opts.apiKey).trim() : "";
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
   // vLLM Prometheus
   try {
     const res = await fetch(`${baseUrl}/metrics`, {
       signal: AbortSignal.timeout(5_000),
+      headers,
     });
     if (res.ok) {
       const txt = await res.text();
@@ -80,6 +87,7 @@ export async function readServerGenerationTokens(baseUrl) {
   try {
     const res = await fetch(`${baseUrl}/get_server_info`, {
       signal: AbortSignal.timeout(5_000),
+      headers,
     });
     if (res.ok) {
       const data = await res.json();
@@ -208,7 +216,7 @@ export function stripThinkingFlags(body) {
  * @param {string} baseUrl
  * @param {AbortSignal} signal
  * @param {number} [intervalMs=400]
- * @param {{ onSample?: (info: { rate: number, median: number | null, max: number | null, samples: number }) => void }} [opts]
+ * @param {{ onSample?: (info: { rate: number, median: number | null, max: number | null, samples: number }) => void, apiKey?: string | null }} [opts]
  * @returns {Promise<{ median: number | null, mean: number | null, max: number | null, samples: number }>}
  */
 export async function pollServerGenerationRates(
@@ -219,7 +227,8 @@ export async function pollServerGenerationRates(
 ) {
   /** @type {number[]} */
   const rates = [];
-  let lastTokens = await readServerGenerationTokens(baseUrl);
+  const apiKey = opts?.apiKey != null ? String(opts.apiKey).trim() : "";
+  let lastTokens = await readServerGenerationTokens(baseUrl, { apiKey: apiKey || null });
   let lastT = performance.now();
   const onSample = typeof opts.onSample === "function" ? opts.onSample : null;
 
@@ -230,7 +239,7 @@ export async function pollServerGenerationRates(
       break;
     }
     const now = performance.now();
-    const tokens = await readServerGenerationTokens(baseUrl);
+    const tokens = await readServerGenerationTokens(baseUrl, { apiKey: apiKey || null });
     if (tokens == null || lastTokens == null) {
       if (tokens != null) {
         lastTokens = tokens;
@@ -280,6 +289,7 @@ export async function pollServerGenerationRates(
  * - collectContent: accumulate full visible text (showcase)
  * - onDelta: live callback `{ text?, answer?, reasoning?, tokenCount, tFirst, tLast, … }`
  * - retryOnThinking400: if HTTP 400 and body had thinking flags, retry once stripped
+ * - apiKey: optional Bearer token for OpenAI-compatible gateways
  */
 export async function runStreamingRequest(
   url,
@@ -290,12 +300,14 @@ export async function runStreamingRequest(
     collectContent = false,
     onDelta = null,
     retryOnThinking400 = false,
+    apiKey = null,
   } = {}
 ) {
   const result = await runStreamingRequestOnce(url, body, signal, {
     debug,
     collectContent,
     onDelta,
+    apiKey,
   });
 
   if (
@@ -311,6 +323,7 @@ export async function runStreamingRequest(
       debug,
       collectContent,
       onDelta,
+      apiKey,
     });
   }
 
@@ -321,13 +334,13 @@ export async function runStreamingRequest(
  * @param {string} url
  * @param {Record<string, unknown>} body
  * @param {AbortSignal} signal
- * @param {{ debug?: boolean, collectContent?: boolean, onDelta?: Function | null }} opts
+ * @param {{ debug?: boolean, collectContent?: boolean, onDelta?: Function | null, apiKey?: string | null }} opts
  */
 async function runStreamingRequestOnce(
   url,
   body,
   signal,
-  { debug = false, collectContent = false, onDelta = null } = {}
+  { debug = false, collectContent = false, onDelta = null, apiKey = null } = {}
 ) {
   const t0 = performance.now();
   /** @type {number | null} */
@@ -357,12 +370,17 @@ async function runStreamingRequestOnce(
   const deltaCb = typeof onDelta === "function" ? onDelta : null;
 
   try {
+    /** @type {Record<string, string>} */
+    const headers = {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    };
+    const key = apiKey != null ? String(apiKey).trim() : "";
+    if (key) headers.Authorization = `Bearer ${key}`;
+
     const response = await fetch(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "text/event-stream",
-      },
+      headers,
       body: JSON.stringify(body),
       signal,
     });

--- a/server/collectors/ShowcaseManager.js
+++ b/server/collectors/ShowcaseManager.js
@@ -324,6 +324,7 @@ export class ShowcaseManager {
    *   thinking?: boolean,
    *   promptType?: string | null,
    *   prompts: string[],
+   *   apiKey?: string | null,
    * }} opts
    */
   start(opts) {
@@ -337,6 +338,7 @@ export class ShowcaseManager {
       thinking: rawThinking,
       promptType: rawPromptType,
       prompts: rawPrompts,
+      apiKey = null,
     } = opts;
 
     if (this.activeBySpark.has(sparkId)) {
@@ -449,6 +451,7 @@ export class ShowcaseManager {
       _lastTouchAt: now,
       _contentCap: cap,
       _lanIp: lanIp,
+      _apiKey: apiKey != null && String(apiKey).trim() ? String(apiKey).trim() : null,
       _sentContentLengths: /** @type {number[]} */ (prompts.map(() => 0)),
       _sentReasoningLengths: /** @type {number[]} */ (prompts.map(() => 0)),
     };
@@ -681,6 +684,7 @@ export class ShowcaseManager {
       ratePollAbort.signal,
       400,
       {
+        apiKey: session._apiKey,
         onSample: (info) => {
           if (session.status !== "running") return;
           session.serverGenerationTps = info.median;
@@ -727,6 +731,7 @@ export class ShowcaseManager {
       return runStreamingRequest(url, body, ctrl.signal, {
         collectContent: true,
         retryOnThinking400: true,
+        apiKey: session._apiKey,
         onDelta: (info) => {
           if (session.status !== "running") return;
           this._appendParts(session, stream, {
@@ -752,6 +757,7 @@ export class ShowcaseManager {
               {
                 collectContent: true,
                 retryOnThinking400: true,
+                apiKey: session._apiKey,
                 onDelta: (info) => {
                   if (session.status !== "running") return;
                   this._appendParts(session, stream, {

--- a/server/collectors/ssh.js
+++ b/server/collectors/ssh.js
@@ -173,8 +173,18 @@ export async function llmTest(spark, port) {
         ? port
         : Number(spark?.llmPorts?.[0] || spark?.llmPort) || 8888;
     const url = `http://${host}:${resolvedPort}/v1/models`;
-    const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
-    const data = await res.json();
+    /** @type {Record<string, string>} */
+    const headers = {};
+    const apiKey =
+      spark?.llmApiKeys?.[String(resolvedPort)] ||
+      spark?.llmApiKeys?.[resolvedPort] ||
+      null;
+    if (apiKey) headers.Authorization = `Bearer ${String(apiKey).trim()}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(3000), headers });
+    const data = await res.json().catch(() => ({}));
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, message: "Auth required (set API key in LLM Settings)" };
+    }
     return { ok: res.ok, message: `Model: ${data?.data?.[0]?.id || "unknown"}` };
   } catch (err) {
     return { ok: false, message: err.message };

--- a/server/index.js
+++ b/server/index.js
@@ -48,6 +48,15 @@ function resolveLlmPort(sparkOrPort) {
   return LLM_PORT;
 }
 
+/** Optional Bearer token for a Spark LLM port (from encrypted secrets). */
+function resolveLlmApiKey(spark, port) {
+  const keys = spark?.llmApiKeys;
+  if (!keys || typeof keys !== "object") return null;
+  const raw = keys[String(port)] ?? keys[port];
+  const key = raw != null ? String(raw).trim() : "";
+  return key || null;
+}
+
 // Rate-limit ephemeral + registered connectivity tests (per client IP)
 const allowTest = createRateLimiter(20, 60_000);
 
@@ -499,13 +508,54 @@ app.delete("/api/sparks/:id/llm-ports/:port", (req, res) => {
     }
 
     const updated = registry.updateSpark(req.params.id, { llmPorts: newPorts });
+    registry.clearLlmApiKey(req.params.id, port);
+    const withSecrets = registry.getSpark(req.params.id);
     const monitor = monitors.get(req.params.id);
     if (monitor) {
-      monitor.updateConfig(updated);
+      monitor.updateConfig(withSecrets);
     } else {
-      startMonitor(updated);
+      startMonitor(withSecrets);
     }
-    res.json({ success: true, llmPorts: updated.llmPorts });
+    res.json({
+      success: true,
+      llmPorts: updated.llmPorts,
+      llmApiKeyPorts: registry.llmApiKeyPorts(req.params.id),
+    });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Set / clear optional LLM API key for one port (encrypted secrets store)
+app.put("/api/sparks/:id/llm-ports/:port/api-key", (req, res) => {
+  try {
+    const spark = registry.getSpark(req.params.id);
+    if (!spark) return res.status(404).json({ error: "Spark not found" });
+
+    const port = parseInt(req.params.port, 10);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      return res.status(400).json({ error: "port must be an integer 1–65535" });
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(req.body || {}, "apiKey")) {
+      return res.status(400).json({ error: "apiKey is required (use \"\" to clear)" });
+    }
+
+    const apiKey = req.body.apiKey == null ? "" : String(req.body.apiKey);
+    const publicSpark = registry.setLlmApiKey(req.params.id, port, apiKey);
+    const withSecrets = registry.getSpark(req.params.id);
+    const monitor = monitors.get(req.params.id);
+    if (monitor) {
+      monitor.updateConfig(withSecrets);
+    } else {
+      startMonitor(withSecrets);
+    }
+    res.json({
+      success: true,
+      spark: publicSpark,
+      hasApiKey: registry.hasLlmApiKey(req.params.id, port),
+      llmApiKeyPorts: registry.llmApiKeyPorts(req.params.id),
+    });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }
@@ -563,6 +613,7 @@ app.post("/api/sparks/:id/llm/bench", (req, res) => {
       concurrencies: req.body?.concurrencies,
       maxTokens: req.body?.maxTokens,
       debug: benchDebug,
+      apiKey: resolveLlmApiKey(spark, port),
       sampleHardware:
         benchDebug && monitor
           ? async () => {
@@ -720,6 +771,7 @@ app.post("/api/sparks/:id/llm/showcase", (req, res) => {
       thinking: req.body?.thinking,
       promptType: req.body?.promptType,
       prompts: req.body?.prompts,
+      apiKey: resolveLlmApiKey(spark, port),
     });
     res.status(202).json(result);
   } catch (err) {

--- a/server/secretsStore.js
+++ b/server/secretsStore.js
@@ -1,10 +1,19 @@
 /**
- * Encrypted SSH password store — survives process/Docker restarts.
+ * Encrypted secrets store — survives process/Docker restarts.
  *
- * Passwords are NEVER written to sparks.json and NEVER returned by the API.
+ * Secrets are NEVER written to sparks.json and NEVER returned by the API.
  * They live in:
- *   - memory (Map) for SSH collectors
+ *   - memory (Maps) for SSH collectors / LLM probes
  *   - config/sparks-secrets.json (AES-256-GCM ciphertext, volume-mounted)
+ *
+ * File shape (v2):
+ *   {
+ *     version: 2,
+ *     secrets: { [sparkId]: "<encrypted ssh password>" },
+ *     llmApiKeys: { [sparkId]: "<encrypted JSON { \"8000\": \"sk-…\" }>" }
+ *   }
+ *
+ * v1 files (secrets only) still load; rewritten as v2 on next save.
  *
  * Encryption key:
  *   - SPARKDASH_SECRETS_KEY env (passphrase or 64-char hex), or
@@ -56,7 +65,6 @@ function resolveKey() {
       _cachedKey = keyFromString(raw);
       return _cachedKey;
     } catch (err) {
-      // Do NOT generate a new key — that would make existing secrets unreadable
       throw new Error(
         `Cannot read secrets key at ${SECRETS_KEY_PATH}: ${err.message}. ` +
           `Fix permissions or set SPARKDASH_SECRETS_KEY.`
@@ -64,7 +72,6 @@ function resolveKey() {
     }
   }
 
-  // No key yet — only create one if there is no secrets file either
   if (fs.existsSync(SPARKS_SECRETS_PATH)) {
     throw new Error(
       `Encrypted secrets exist at ${SPARKS_SECRETS_PATH} but key file is missing (${SECRETS_KEY_PATH}). ` +
@@ -109,59 +116,111 @@ function decrypt(blobB64, key) {
 }
 
 /**
- * Load sparkId -> password map from disk.
- * @returns {Map<string, string>}
+ * @returns {{
+ *   passwords: Map<string, string>,
+ *   llmApiKeys: Map<string, Record<string, string>>,
+ * }}
  */
 export function loadSecrets() {
-  const map = new Map();
-  if (!fs.existsSync(SPARKS_SECRETS_PATH)) return map;
+  /** @type {Map<string, string>} */
+  const passwords = new Map();
+  /** @type {Map<string, Record<string, string>>} */
+  const llmApiKeys = new Map();
+
+  if (!fs.existsSync(SPARKS_SECRETS_PATH)) {
+    return { passwords, llmApiKeys };
+  }
 
   try {
     const key = resolveKey();
     const raw = fs.readFileSync(SPARKS_SECRETS_PATH, "utf8");
     const data = JSON.parse(raw);
     const entries = data?.secrets || {};
-    if (typeof entries !== "object" || entries === null) return map;
-
-    let failed = 0;
-    for (const [id, blob] of Object.entries(entries)) {
-      if (!id || typeof blob !== "string") continue;
-      try {
-        const pw = decrypt(blob, key);
-        if (pw) map.set(id, pw);
-      } catch {
-        failed += 1;
-        console.error(
-          `[secretsStore] Failed to decrypt password for ${id} (wrong/missing key?)`
+    if (typeof entries === "object" && entries !== null) {
+      let failed = 0;
+      for (const [id, blob] of Object.entries(entries)) {
+        if (!id || typeof blob !== "string") continue;
+        try {
+          const pw = decrypt(blob, key);
+          if (pw) passwords.set(id, pw);
+        } catch {
+          failed += 1;
+          console.error(
+            `[secretsStore] Failed to decrypt password for ${id} (wrong/missing key?)`
+          );
+        }
+      }
+      if (passwords.size > 0) {
+        console.log(`[secretsStore] Loaded ${passwords.size} SSH password(s) from encrypted store`);
+      }
+      if (failed > 0) {
+        console.warn(
+          `[secretsStore] ${failed} password(s) could not be decrypted — re-enter via Edit Spark`
         );
       }
     }
-    if (map.size > 0) {
-      console.log(`[secretsStore] Loaded ${map.size} SSH password(s) from encrypted store`);
-    }
-    if (failed > 0) {
-      console.warn(
-        `[secretsStore] ${failed} password(s) could not be decrypted — re-enter via Edit Spark`
-      );
+
+    const keyEntries = data?.llmApiKeys || {};
+    if (typeof keyEntries === "object" && keyEntries !== null) {
+      let failed = 0;
+      let portCount = 0;
+      for (const [id, blob] of Object.entries(keyEntries)) {
+        if (!id || typeof blob !== "string") continue;
+        try {
+          const json = decrypt(blob, key);
+          const parsed = JSON.parse(json);
+          if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) continue;
+          /** @type {Record<string, string>} */
+          const ports = {};
+          for (const [port, apiKey] of Object.entries(parsed)) {
+            if (!apiKey || typeof apiKey !== "string") continue;
+            ports[String(port)] = apiKey;
+            portCount += 1;
+          }
+          if (Object.keys(ports).length > 0) llmApiKeys.set(id, ports);
+        } catch {
+          failed += 1;
+          console.error(
+            `[secretsStore] Failed to decrypt LLM API keys for ${id} (wrong/missing key?)`
+          );
+        }
+      }
+      if (portCount > 0) {
+        console.log(`[secretsStore] Loaded ${portCount} LLM API key(s) from encrypted store`);
+      }
+      if (failed > 0) {
+        console.warn(
+          `[secretsStore] ${failed} LLM API key bundle(s) could not be decrypted — re-enter via LLM Settings`
+        );
+      }
     }
   } catch (err) {
     console.error(`[secretsStore] Failed to load secrets: ${err.message}`);
   }
-  return map;
+
+  return { passwords, llmApiKeys };
 }
 
 /**
- * Persist sparkId -> password map (encrypted). Empty map removes the file.
- * Throws on failure so callers can surface errors to the UI.
- *
- * Encrypted file mode is 0o644 so bind-mounted volumes stay usable across
- * root/non-root container users (contents are ciphertext, not plaintext).
+ * Persist SSH passwords + per-port LLM API keys (encrypted).
+ * Empty maps remove the file when both are empty.
  *
  * @param {Map<string, string>} passwords
+ * @param {Map<string, Record<string, string>>} [llmApiKeys]
  */
-export function saveSecrets(passwords) {
-  if (!passwords || passwords.size === 0) {
-    // Only delete if we can read the path; never "clear" on a failed load
+export function saveSecrets(passwords, llmApiKeys = new Map()) {
+  const hasPasswords = passwords && passwords.size > 0;
+  let hasKeys = false;
+  if (llmApiKeys) {
+    for (const ports of llmApiKeys.values()) {
+      if (ports && Object.keys(ports).length > 0) {
+        hasKeys = true;
+        break;
+      }
+    }
+  }
+
+  if (!hasPasswords && !hasKeys) {
     if (fs.existsSync(SPARKS_SECRETS_PATH)) {
       try {
         fs.accessSync(SPARKS_SECRETS_PATH, fs.constants.W_OK);
@@ -178,11 +237,32 @@ export function saveSecrets(passwords) {
 
   const key = resolveKey();
   const secrets = {};
-  for (const [id, pw] of passwords.entries()) {
-    if (pw) secrets[id] = encrypt(pw, key);
+  if (passwords) {
+    for (const [id, pw] of passwords.entries()) {
+      if (pw) secrets[id] = encrypt(pw, key);
+    }
   }
 
-  const payload = JSON.stringify({ version: 1, secrets }, null, 2) + "\n";
+  /** @type {Record<string, string>} */
+  const llmOut = {};
+  if (llmApiKeys) {
+    for (const [id, ports] of llmApiKeys.entries()) {
+      if (!ports || typeof ports !== "object") continue;
+      const clean = {};
+      for (const [port, apiKey] of Object.entries(ports)) {
+        if (apiKey) clean[String(port)] = String(apiKey);
+      }
+      if (Object.keys(clean).length === 0) continue;
+      llmOut[id] = encrypt(JSON.stringify(clean), key);
+    }
+  }
+
+  const payload =
+    JSON.stringify({ version: 2, secrets, llmApiKeys: llmOut }, null, 2) + "\n";
   atomicWrite(SPARKS_SECRETS_PATH, payload, 0o644);
-  console.log(`[secretsStore] Saved ${Object.keys(secrets).length} SSH password(s)`);
+  const keyCount = Object.keys(llmOut).length;
+  console.log(
+    `[secretsStore] Saved ${Object.keys(secrets).length} SSH password(s)` +
+      (keyCount ? `, ${keyCount} LLM API key bundle(s)` : "")
+  );
 }

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -181,6 +181,11 @@ export class SparkMonitor {
       llmMonitoring: this._llmMonitoringEnabled(),
       llmPort: ports[0] ?? LLM_PORT,
       llmPorts: ports,
+      llmApiKeyPorts: Array.isArray(this.spark.llmApiKeyPorts)
+        ? this.spark.llmApiKeyPorts
+        : Object.keys(this.spark.llmApiKeys || {})
+            .map((p) => parseInt(p, 10))
+            .filter((n) => Number.isInteger(n)),
       hardware: this._getHardwareSummary(),
       metrics: {
         // NOTE: no `timestamp` here on purpose. The broadcast path skips

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -8,10 +8,10 @@ import { isValidSparkId } from "../validate.js";
  * SparkRegistry — loads, persists, and emits change events for the Spark list.
  * Single source of truth for `sparks.json`.
  *
- * SSH passwords:
+ * SSH passwords / LLM API keys:
  *  - Never written to sparks.json
- *  - Never returned by public API helpers (hasPassword only)
- *  - Held in memory for SSH collectors
+ *  - Never returned by public API helpers (hasPassword / llmApiKeyPorts only)
+ *  - Held in memory for SSH collectors / LLM probes
  *  - Encrypted at rest in config/sparks-secrets.json (survives Docker restart)
  */
 export class SparkRegistry {
@@ -19,13 +19,15 @@ export class SparkRegistry {
     this._sparks = [];
     /** @type {Map<string, string>} sparkId -> password */
     this._passwords = new Map();
+    /** @type {Map<string, Record<string, string>>} sparkId -> { portStr -> apiKey } */
+    this._llmApiKeys = new Map();
     this._listeners = new Set();
     this._load();
   }
 
   // ─── Accessors ──────────────────────────────────────────
   get sparks() {
-    return this._sparks.map((s) => this._withPassword(s));
+    return this._sparks.map((s) => this._withSecrets(s));
   }
 
   /** Public-safe list (no secrets). */
@@ -37,10 +39,10 @@ export class SparkRegistry {
     return this._sparks.map((s) => s.id);
   }
 
-  /** Find a Spark by ID (includes in-memory password if present). */
+  /** Find a Spark by ID (includes in-memory secrets if present). */
   getSpark(id) {
     const s = this._sparks.find((s) => s.id === id) || null;
-    return s ? this._withPassword(s) : null;
+    return s ? this._withSecrets(s) : null;
   }
 
   /** Redact secrets for API responses. */
@@ -52,7 +54,12 @@ export class SparkRegistry {
     if (ssh.auth === "pass" || this._passwords.has(spark.id)) {
       ssh.hasPassword = this._passwords.has(spark.id);
     }
-    return { ...spark, ssh };
+    const { llmApiKeys: _drop, ...rest } = spark;
+    return {
+      ...rest,
+      ssh,
+      llmApiKeyPorts: this.llmApiKeyPorts(spark.id),
+    };
   }
 
   // ─── CRUD ───────────────────────────────────────────────
@@ -69,8 +76,8 @@ export class SparkRegistry {
     this._storePassword(spark.id, config?.ssh?.password);
     this._sparks.push(spark);
     this._save();
-    this._emit("add", this._withPassword(spark));
-    return this._withPassword(spark);
+    this._emit("add", this._withSecrets(spark));
+    return this._withSecrets(spark);
   }
 
   /**
@@ -91,7 +98,7 @@ export class SparkRegistry {
     if (prev.detectedMacAddress === clean) return null;
     this._sparks[idx] = this._normalizeConfig({ ...prev, detectedMacAddress: clean });
     this._save();
-    this._emit("update", this._withPassword(this._sparks[idx]));
+    this._emit("update", this._withSecrets(this._sparks[idx]));
     return this.toPublic(this._sparks[idx]);
   }
 
@@ -143,8 +150,8 @@ export class SparkRegistry {
     };
     this._sparks[idx] = this._normalizeConfig(updated);
     this._save();
-    this._emit("update", this._withPassword(this._sparks[idx]));
-    return this._withPassword(this._sparks[idx]);
+    this._emit("update", this._withSecrets(this._sparks[idx]));
+    return this._withSecrets(this._sparks[idx]);
   }
 
   /** Remove a Spark by ID. Returns removed Spark or null. */
@@ -152,10 +159,16 @@ export class SparkRegistry {
     const idx = this._sparks.findIndex((s) => s.id === id);
     if (idx === -1) return null;
     const removed = this._sparks.splice(idx, 1)[0];
+    let secretsChanged = false;
     if (this._passwords.has(id)) {
       this._passwords.delete(id);
-      this._persistSecrets();
+      secretsChanged = true;
     }
+    if (this._llmApiKeys.has(id)) {
+      this._llmApiKeys.delete(id);
+      secretsChanged = true;
+    }
+    if (secretsChanged) this._persistSecrets();
     this._save();
     this._emit("remove", removed);
     return this.toPublic(removed);
@@ -197,10 +210,13 @@ export class SparkRegistry {
   _load() {
     // Load encrypted secrets first (survives restart)
     try {
-      this._passwords = loadSecrets();
+      const loaded = loadSecrets();
+      this._passwords = loaded.passwords || new Map();
+      this._llmApiKeys = loaded.llmApiKeys || new Map();
     } catch (err) {
       console.error("[SparkRegistry] secrets load failed:", err.message);
       this._passwords = new Map();
+      this._llmApiKeys = new Map();
     }
 
     try {
@@ -238,12 +254,13 @@ export class SparkRegistry {
 
   _save() {
     try {
-      // Never write passwords to sparks.json
+      // Never write passwords / API keys to sparks.json
       const sparks = this._sparks.map((s) => {
         const ssh = { ...(s.ssh || {}) };
         delete ssh.password;
         delete ssh.hasPassword;
-        return { ...s, ssh };
+        const { llmApiKeys: _k, llmApiKeyPorts: _p, ...rest } = s;
+        return { ...rest, ssh };
       });
       const data = { sparks };
       // Atomic write (tmp + rename) — a SIGKILL/power loss mid-write must not
@@ -296,23 +313,90 @@ export class SparkRegistry {
     return this._passwords.has(id);
   }
 
+  /**
+   * Ports that have an LLM API key configured for this Spark.
+   * @param {string} id
+   * @returns {number[]}
+   */
+  llmApiKeyPorts(id) {
+    const ports = this._llmApiKeys.get(id);
+    if (!ports) return [];
+    return Object.keys(ports)
+      .map((p) => parseInt(p, 10))
+      .filter((n) => Number.isInteger(n) && n >= 1 && n <= 65535)
+      .sort((a, b) => a - b);
+  }
+
+  hasLlmApiKey(id, port) {
+    const ports = this._llmApiKeys.get(id);
+    if (!ports) return false;
+    const key = ports[String(port)];
+    return Boolean(key && String(key).trim());
+  }
+
+  /**
+   * Set / clear an LLM API key for one port.
+   * @param {string} id
+   * @param {number} port
+   * @param {string|null|undefined} apiKey  null/undefined = no-op; "" = clear
+   */
+  setLlmApiKey(id, port, apiKey) {
+    if (!this._sparks.find((s) => s.id === id)) throw new Error(`Spark ${id} not found`);
+    const p = Number(port);
+    if (!Number.isInteger(p) || p < 1 || p > 65535) {
+      throw new Error("port must be an integer 1–65535");
+    }
+    this._storeLlmApiKey(id, p, apiKey);
+    return this.toPublic(this.getSpark(id));
+  }
+
+  /**
+   * @param {string} id
+   * @param {number} port
+   * @param {string|null|undefined} apiKey
+   */
+  _storeLlmApiKey(id, port, apiKey) {
+    if (apiKey == null) return;
+    const portKey = String(port);
+    const existing = { ...(this._llmApiKeys.get(id) || {}) };
+    if (apiKey === "") {
+      if (!existing[portKey]) return;
+      delete existing[portKey];
+      if (Object.keys(existing).length === 0) this._llmApiKeys.delete(id);
+      else this._llmApiKeys.set(id, existing);
+      this._persistSecrets();
+      return;
+    }
+    existing[portKey] = String(apiKey).trim();
+    this._llmApiKeys.set(id, existing);
+    this._persistSecrets();
+  }
+
+  /** Drop API key for a port (e.g. when the port is removed). */
+  clearLlmApiKey(id, port) {
+    this._storeLlmApiKey(id, port, "");
+  }
+
   _persistSecrets() {
     try {
-      saveSecrets(this._passwords);
+      saveSecrets(this._passwords, this._llmApiKeys);
     } catch (err) {
       console.error("[SparkRegistry] Failed to persist secrets:", err.message);
       throw err; // surface to API so the UI can show it
     }
   }
 
-  _withPassword(spark) {
+  _withSecrets(spark) {
     if (!spark) return spark;
     const password = this._passwords.get(spark.id);
-    if (!password) return { ...spark, ssh: { ...spark.ssh } };
-    return {
-      ...spark,
-      ssh: { ...spark.ssh, password },
-    };
+    const llmApiKeys = this._llmApiKeys.get(spark.id);
+    const ssh = { ...(spark.ssh || {}) };
+    if (password) ssh.password = password;
+    const out = { ...spark, ssh };
+    if (llmApiKeys && Object.keys(llmApiKeys).length > 0) {
+      out.llmApiKeys = { ...llmApiKeys };
+    }
+    return out;
   }
 
   _normalizeConfig(config) {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -266,6 +266,25 @@ export function updateLlmPort(
   });
 }
 
+/**
+ * Set or clear an optional LLM API key for one port.
+ * Pass apiKey "" to clear. Key is stored encrypted server-side and never returned.
+ */
+export function setLlmApiKey(
+  id: string,
+  port: number,
+  apiKey: string
+): Promise<{
+  success: boolean;
+  hasApiKey: boolean;
+  llmApiKeyPorts: number[];
+}> {
+  return apiFetch(`/api/sparks/${id}/llm-ports/${port}/api-key`, {
+    method: "PUT",
+    body: JSON.stringify({ apiKey }),
+  });
+}
+
 // ─── Power management ────────────────────────────────────
 export interface PowerResult {
   success: boolean;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -29,6 +29,11 @@ export interface SparkConfig {
   /** HTTP ports for LLM servers on this Spark (default [8888]) */
   llmPorts?: number[];
   /**
+   * Ports that have an encrypted LLM API key stored server-side.
+   * The key itself is never returned by the API.
+   */
+  llmApiKeyPorts?: number[];
+  /**
    * Cluster role for overview + worker behavior.
    * - head / standalone: local LLM API probed
    * - worker: no local API (LLM card hidden, ports not probed)
@@ -203,7 +208,7 @@ export interface LlmMetrics {
 export interface LlmPosture {
   /** ok = green, warn = amber, danger = red */
   level: "ok" | "warn" | "danger";
-  auth: "open" | "protected";
+  auth: "open" | "protected" | "keyed";
   scope: "local" | "lan" | "public" | "unknown";
   /** Short badge text */
   label: string;
@@ -247,6 +252,8 @@ export interface SparkSnapshot {
   llmPort: number;
   /** All LLM server ports configured for this Spark */
   llmPorts: number[];
+  /** Ports with a stored LLM API key (key itself never exposed) */
+  llmApiKeyPorts?: number[];
   hardware: HardwareInfo;
   metrics: SparkMetrics;
 }

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { fetchSettings, updateSettings } from "../api/client";
 import type { Settings } from "../api/types";
 import { useModalPresence } from "../hooks/useModalPresence";
+import packageJson from "../../package.json";
 
 interface SettingsDialogProps {
   open: boolean;
@@ -257,7 +258,7 @@ export function SettingsDialog({ open, onClose, onSaved }: SettingsDialogProps) 
 
         {/* Links */}
         <div className="mt-5 flex items-center gap-3 border-t border-border pt-3">
-          <span className="text-[10px] text-muted">sparkDash v1.3.0</span>
+          <span className="text-[10px] text-muted">sparkDash v{packageJson.version}</span>
           <span className="text-border-strong text-[10px]">·</span>
           <a
             href="https://x.com/MiaAI_lab"

--- a/src/components/SparkPage/LlmPanel.tsx
+++ b/src/components/SparkPage/LlmPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { LlmMetrics } from "../../api/types";
-import { updateLlmPort } from "../../api/client";
+import { setLlmApiKey, updateLlmPort } from "../../api/client";
 import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
 import { BotIcon, GearIcon, InfoIcon } from "../ui/icons";
@@ -11,6 +11,7 @@ interface LlmPanelProps {
   llm: LlmMetrics | null;
   sparkId: string;
   llmPort: number;
+  hasApiKey?: boolean;
   onRemovePort?: (port: number) => void;
   className?: string;
 }
@@ -142,11 +143,20 @@ function MetricInfoTip({
   );
 }
 
-export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: LlmPanelProps) {
+export function LlmPanel({
+  llm,
+  sparkId,
+  llmPort,
+  hasApiKey = false,
+  onRemovePort,
+  className,
+}: LlmPanelProps) {
   // Tail keyed by port so multi-port LLM sparklines stay distinct (8b).
   const genHistory = useMetricsHistoryTail(sparkId, `llm:${llmPort}.tps`);
   const [showSettings, setShowSettings] = useState(false);
   const [portDraft, setPortDraft] = useState(String(llmPort));
+  const [apiKeyDraft, setApiKeyDraft] = useState("");
+  const [clearApiKey, setClearApiKey] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [engineInfoOpen, setEngineInfoOpen] = useState(false);
@@ -172,7 +182,11 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
 
   // Keep draft in sync when server pushes a different port (other tab / reload)
   useEffect(() => {
-    if (!showSettings) setPortDraft(String(llmPort));
+    if (!showSettings) {
+      setPortDraft(String(llmPort));
+      setApiKeyDraft("");
+      setClearApiKey(false);
+    }
   }, [llmPort, showSettings]);
 
   const parsedPort = (() => {
@@ -183,24 +197,34 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
 
   const portDirty = parsedPort !== null && parsedPort !== llmPort;
   const portInvalid = portDraft.trim() !== "" && parsedPort === null;
+  const apiKeyDirty = apiKeyDraft.trim() !== "" || clearApiKey;
+  const settingsDirty = portDirty || apiKeyDirty;
 
-  const handleSavePort = async () => {
+  const handleSaveSettings = async () => {
     if (parsedPort === null) {
       setSaveError("Port must be an integer 1–65535");
       return;
     }
-    if (parsedPort === llmPort) {
+    if (!settingsDirty) {
       setShowSettings(false);
       return;
     }
     setSaving(true);
     setSaveError(null);
     try {
-      await updateLlmPort(sparkId, parsedPort);
-      // Port change will sync via WS broadcast — no local callback needed
+      if (portDirty) {
+        await updateLlmPort(sparkId, parsedPort);
+      }
+      if (clearApiKey) {
+        await setLlmApiKey(sparkId, parsedPort, "");
+      } else if (apiKeyDraft.trim() !== "") {
+        await setLlmApiKey(sparkId, parsedPort, apiKeyDraft.trim());
+      }
+      setApiKeyDraft("");
+      setClearApiKey(false);
       setShowSettings(false);
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : "Failed to save port");
+      setSaveError(err instanceof Error ? err.message : "Failed to save LLM settings");
     } finally {
       setSaving(false);
     }
@@ -231,6 +255,8 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
             onClick={() => {
               if (showSettings) {
                 setPortDraft(String(llmPort));
+                setApiKeyDraft("");
+                setClearApiKey(false);
                 setSaveError(null);
               }
               setShowSettings(!showSettings);
@@ -249,7 +275,7 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
       {showSettings ? (
         <div className="space-y-3">
           <p className="text-[10px] text-muted">
-            HTTP port of the LLM server on this Spark (vLLM / llama.cpp / sglang).
+            HTTP port of the LLM server on this Spark (vLLM / llama.cpp / sglang / OpenAI-compatible gateway).
           </p>
           <label className="block space-y-1">
             <span className="text-xs text-muted">Port</span>
@@ -266,12 +292,50 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
                   e.preventDefault();
-                  void handleSavePort();
+                  void handleSaveSettings();
                 }
               }}
               className="w-full rounded-md border border-border bg-surface-elevated px-3 py-1.5 font-tabular text-sm text-text outline-none focus:border-accent"
             />
           </label>
+          <label className="block space-y-1">
+            <span className="text-xs text-muted">API key (optional)</span>
+            <input
+              type="password"
+              autoComplete="new-password"
+              spellCheck={false}
+              value={apiKeyDraft}
+              disabled={clearApiKey}
+              placeholder={hasApiKey && !clearApiKey ? "•••••••• (saved — leave blank to keep)" : "Bearer token if required"}
+              onChange={(e) => {
+                setApiKeyDraft(e.target.value);
+                setClearApiKey(false);
+                setSaveError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleSaveSettings();
+                }
+              }}
+              className="w-full rounded-md border border-border bg-surface-elevated px-3 py-1.5 font-mono text-sm text-text outline-none focus:border-accent disabled:opacity-50"
+            />
+          </label>
+          {hasApiKey && (
+            <label className="flex cursor-pointer items-center gap-2 text-[11px] text-muted">
+              <input
+                type="checkbox"
+                checked={clearApiKey}
+                onChange={(e) => {
+                  setClearApiKey(e.target.checked);
+                  if (e.target.checked) setApiKeyDraft("");
+                  setSaveError(null);
+                }}
+                className="h-3.5 w-3.5 accent-[var(--color-accent)]"
+              />
+              Clear saved API key
+            </label>
+          )}
           {portInvalid && (
             <p className="text-[10px] text-danger">Enter an integer between 1 and 65535</p>
           )}
@@ -281,6 +345,8 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
               type="button"
               onClick={() => {
                 setPortDraft(String(llmPort));
+                setApiKeyDraft("");
+                setClearApiKey(false);
                 setSaveError(null);
                 setShowSettings(false);
               }}
@@ -291,8 +357,8 @@ export function LlmPanel({ llm, sparkId, llmPort, onRemovePort, className }: Llm
             </button>
             <button
               type="button"
-              onClick={() => void handleSavePort()}
-              disabled={saving || portInvalid || (!portDirty && parsedPort === llmPort)}
+              onClick={() => void handleSaveSettings()}
+              disabled={saving || portInvalid || !settingsDirty}
               className="rounded bg-accent px-2 py-1 text-[10px] font-medium text-white hover:bg-accent-hover disabled:opacity-50"
             >
               {saving ? "Saving…" : "Save"}

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -123,6 +123,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
                   llm={llmMetrics}
                   sparkId={spark.id}
                   llmPort={port}
+                  hasApiKey={Boolean(spark.llmApiKeyPorts?.includes(port))}
                   onRemovePort={canRemove ? handleRemovePort : undefined}
                   className="md:col-span-2"
                 />


### PR DESCRIPTION
## Summary
- Optional **API key** field in LLM panel Settings (per port)
- Encrypted at rest like SSH passwords; never returned by the API
- Sent as `Authorization: Bearer …` for probe, Showcase, and Decode bench
- Settings footer now shows the real `package.json` version
- Version bump **1.4.4** (+ changelog for 1.4.3 backlog)

Fixes #21

## Test plan
- [ ] Open LLM Settings on a port — blank API key still works for unauthenticated vLLM/llama.cpp
- [ ] Set a key for a protected gateway — model appears / posture shows API key
- [ ] Clear saved key via checkbox
- [ ] Showcase / Decode bench still work with and without a key
- [ ] Settings dialog footer shows `sparkDash v1.4.4`
