### PR TITLE
fix: migrate/prune LLM API keys on port changes

### DIFF
--- a/server/collectors/LlmProbe.js
+++ b/server/collectors/LlmProbe.js
@@ -491,13 +491,22 @@ export class LlmProbe {
     const host = this.spark?.lanIp || "";
     const scope = classifyHostScope(host);
     const keyed = Boolean(this._apiKey());
-    const auth = keyed ? "keyed" : this.authOpen ? "open" : "protected";
+    /** @type {"open" | "protected" | "keyed"} */
+    let auth;
+    if (keyed) {
+      // Key configured: success → keyed; 401/403 → protected (rejected)
+      auth = this.authOpen === false ? "protected" : "keyed";
+    } else {
+      auth = this.authOpen ? "open" : "protected";
+    }
 
     let level = "ok";
     if (auth === "open") {
       if (scope === "public") level = "danger";
       else if (scope === "local") level = "ok";
       else level = "warn"; // lan or unknown hostname
+    } else if (keyed && auth === "protected") {
+      level = "danger";
     }
 
     const scopeWords = {
@@ -514,13 +523,17 @@ export class LlmProbe {
     };
     const label =
       auth === "protected"
-        ? "Auth required"
+        ? keyed
+          ? "Bad API key"
+          : "Auth required"
         : auth === "keyed"
           ? `API key · ${shortScope[scope]}`
           : `Open · ${shortScope[scope]}`;
     const detail =
       auth === "protected"
-        ? `API key required · ${scopeWords[scope]} target (${host || "—"}). Based on the configured probe host, not the process bind address.`
+        ? keyed
+          ? `Configured API key was rejected (401/403) · ${scopeWords[scope]} target (${host || "—"}).`
+          : `API key required · ${scopeWords[scope]} target (${host || "—"}). Based on the configured probe host, not the process bind address.`
         : auth === "keyed"
           ? `Using configured API key · ${scopeWords[scope]} target (${host || "—"}). Based on the configured probe host, not the process bind address.`
           : `Unauthenticated · ${scopeWords[scope]} target (${host || "—"}). Based on the configured probe host, not the process bind address.`;

--- a/server/collectors/__tests__/LlmProbe.posture.test.js
+++ b/server/collectors/__tests__/LlmProbe.posture.test.js
@@ -69,6 +69,30 @@ test("_buildPosture: protected → ok regardless of scope", () => {
   assert.equal(p.label, "Auth required");
 });
 
+test("_buildPosture: valid API key → keyed", () => {
+  const probe = new LlmProbe(
+    { lanIp: "192.168.1.10", llmApiKeys: { "8888": "sk-test" } },
+    8888
+  );
+  probe.authOpen = true;
+  const p = probe._buildPosture();
+  assert.equal(p.auth, "keyed");
+  assert.equal(p.level, "ok");
+  assert.match(p.label, /API key/);
+});
+
+test("_buildPosture: rejected API key → Bad API key", () => {
+  const probe = new LlmProbe(
+    { lanIp: "192.168.1.10", llmApiKeys: { "8888": "sk-bad" } },
+    8888
+  );
+  probe.authOpen = false;
+  const p = probe._buildPosture();
+  assert.equal(p.auth, "protected");
+  assert.equal(p.level, "danger");
+  assert.equal(p.label, "Bad API key");
+});
+
 test("_buildPosture: unknown auth → null", () => {
   const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 8888);
   assert.equal(probe._buildPosture(), null);

--- a/server/index.js
+++ b/server/index.js
@@ -414,14 +414,21 @@ app.put("/api/sparks/:id/llm-ports", (req, res) => {
       return res.status(400).json({ error: "llmPorts must contain at least one valid port 1–65535" });
     }
 
+    const prevPorts = Array.isArray(spark.llmPorts) ? [...spark.llmPorts] : [];
     const updated = registry.updateSpark(req.params.id, { llmPorts: unique });
+    registry.syncLlmApiKeysToPorts(req.params.id, prevPorts, unique);
+    const withSecrets = registry.getSpark(req.params.id);
     const monitor = monitors.get(req.params.id);
     if (monitor) {
-      monitor.updateConfig(updated);
+      monitor.updateConfig(withSecrets);
     } else {
-      startMonitor(updated);
+      startMonitor(withSecrets);
     }
-    res.json({ success: true, llmPorts: updated.llmPorts });
+    res.json({
+      success: true,
+      llmPorts: updated.llmPorts,
+      llmApiKeyPorts: registry.llmApiKeyPorts(req.params.id),
+    });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }
@@ -439,15 +446,23 @@ app.put("/api/sparks/:id/llm-port", (req, res) => {
       return res.status(400).json({ error: "llmPort must be an integer 1–65535" });
     }
 
+    const prevPorts = Array.isArray(spark.llmPorts) ? [...spark.llmPorts] : [];
     // Replace the ports list with just this single port
     const updated = registry.updateSpark(req.params.id, { llmPorts: [n] });
+    registry.syncLlmApiKeysToPorts(req.params.id, prevPorts, [n]);
+    const withSecrets = registry.getSpark(req.params.id);
     const monitor = monitors.get(req.params.id);
     if (monitor) {
-      monitor.updateConfig(updated);
+      monitor.updateConfig(withSecrets);
     } else {
-      startMonitor(updated);
+      startMonitor(withSecrets);
     }
-    res.json({ success: true, llmPort: n, llmPorts: updated.llmPorts });
+    res.json({
+      success: true,
+      llmPort: n,
+      llmPorts: updated.llmPorts,
+      llmApiKeyPorts: registry.llmApiKeyPorts(req.params.id),
+    });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -377,6 +377,74 @@ export class SparkRegistry {
     this._storeLlmApiKey(id, port, "");
   }
 
+  /**
+   * Move an API key from one port to another (port rename).
+   * @param {string} id
+   * @param {number} fromPort
+   * @param {number} toPort
+   */
+  moveLlmApiKey(id, fromPort, toPort) {
+    if (!this._sparks.find((s) => s.id === id)) throw new Error(`Spark ${id} not found`);
+    const from = Number(fromPort);
+    const to = Number(toPort);
+    if (!Number.isInteger(from) || from < 1 || from > 65535) {
+      throw new Error("fromPort must be an integer 1–65535");
+    }
+    if (!Number.isInteger(to) || to < 1 || to > 65535) {
+      throw new Error("toPort must be an integer 1–65535");
+    }
+    if (from === to) return;
+    const existing = { ...(this._llmApiKeys.get(id) || {}) };
+    const key = existing[String(from)];
+    if (!key) return;
+    delete existing[String(from)];
+    existing[String(to)] = key;
+    this._llmApiKeys.set(id, existing);
+    this._persistSecrets();
+  }
+
+  /**
+   * Drop API keys for ports no longer in the configured list.
+   * @param {string} id
+   * @param {number[]} keepPorts
+   */
+  pruneLlmApiKeys(id, keepPorts) {
+    const existing = this._llmApiKeys.get(id);
+    if (!existing) return;
+    const keep = new Set(
+      (Array.isArray(keepPorts) ? keepPorts : [])
+        .map((p) => String(p))
+        .filter(Boolean)
+    );
+    let changed = false;
+    const next = {};
+    for (const [port, key] of Object.entries(existing)) {
+      if (keep.has(String(port))) next[port] = key;
+      else changed = true;
+    }
+    if (!changed) return;
+    if (Object.keys(next).length === 0) this._llmApiKeys.delete(id);
+    else this._llmApiKeys.set(id, next);
+    this._persistSecrets();
+  }
+
+  /**
+   * After llmPorts change: migrate key if exactly one port was renamed, then prune.
+   * @param {string} id
+   * @param {number[]} prevPorts
+   * @param {number[]} nextPorts
+   */
+  syncLlmApiKeysToPorts(id, prevPorts, nextPorts) {
+    const prev = Array.isArray(prevPorts) ? prevPorts : [];
+    const next = Array.isArray(nextPorts) ? nextPorts : [];
+    const removed = prev.filter((p) => !next.includes(p));
+    const added = next.filter((p) => !prev.includes(p));
+    if (removed.length === 1 && added.length === 1) {
+      this.moveLlmApiKey(id, removed[0], added[0]);
+    }
+    this.pruneLlmApiKeys(id, next);
+  }
+
   _persistSecrets() {
     try {
       saveSecrets(this._passwords, this._llmApiKeys);

--- a/src/components/SparkPage/LlmPanel.tsx
+++ b/src/components/SparkPage/LlmPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { LlmMetrics } from "../../api/types";
-import { setLlmApiKey, updateLlmPort } from "../../api/client";
+import { setLlmApiKey, updateLlmPort, updateLlmPorts } from "../../api/client";
 import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
 import { BotIcon, GearIcon, InfoIcon } from "../ui/icons";
@@ -11,6 +11,7 @@ interface LlmPanelProps {
   llm: LlmMetrics | null;
   sparkId: string;
   llmPort: number;
+  llmPorts?: number[];
   hasApiKey?: boolean;
   onRemovePort?: (port: number) => void;
   className?: string;
@@ -147,6 +148,7 @@ export function LlmPanel({
   llm,
   sparkId,
   llmPort,
+  llmPorts,
   hasApiKey = false,
   onRemovePort,
   className,
@@ -213,12 +215,26 @@ export function LlmPanel({
     setSaveError(null);
     try {
       if (portDirty) {
-        await updateLlmPort(sparkId, parsedPort);
+        const currentPorts =
+          Array.isArray(llmPorts) && llmPorts.length > 0 ? llmPorts : [llmPort];
+        if (currentPorts.includes(parsedPort) && parsedPort !== llmPort) {
+          setSaveError(`Port ${parsedPort} is already configured`);
+          setSaving(false);
+          return;
+        }
+        // Rename this panel's port in-place so sibling ports (and their keys) survive
+        if (currentPorts.length > 1) {
+          const next = currentPorts.map((p) => (p === llmPort ? parsedPort : p));
+          await updateLlmPorts(sparkId, next);
+        } else {
+          await updateLlmPort(sparkId, parsedPort);
+        }
       }
+      const keyPort = parsedPort;
       if (clearApiKey) {
-        await setLlmApiKey(sparkId, parsedPort, "");
+        await setLlmApiKey(sparkId, keyPort, "");
       } else if (apiKeyDraft.trim() !== "") {
-        await setLlmApiKey(sparkId, parsedPort, apiKeyDraft.trim());
+        await setLlmApiKey(sparkId, keyPort, apiKeyDraft.trim());
       }
       setApiKeyDraft("");
       setClearApiKey(false);
@@ -375,7 +391,7 @@ export function LlmPanel({
             )}
             <p className="text-xs text-muted">
               {llm?.posture?.auth === "protected"
-                ? `Auth required on :${llmPort}`
+                ? `${llm.posture.label} on :${llmPort}`
                 : `No model loaded on :${llmPort}`}
             </p>
           </div>

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -123,6 +123,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
                   llm={llmMetrics}
                   sparkId={spark.id}
                   llmPort={port}
+                  llmPorts={llmPorts}
                   hasApiKey={Boolean(spark.llmApiKeyPorts?.includes(port))}
                   onRemovePort={canRemove ? handleRemovePort : undefined}
                   className="md:col-span-2"


### PR DESCRIPTION
## Summary
- Migrate API key when an LLM port is renamed; prune keys for removed ports
- Multi-port Settings renames in-place (no longer wipes sibling ports via legacy single-port PUT)
- Rejected Bearer shows **Bad API key** instead of looking like an idle port

## Test plan
- [ ] Set API key on :8000, rename to :8001 with blank key field → key still present
- [ ] Remove an extra LLM port → its key is cleared
- [ ] Wrong key → posture/label **Bad API key**, not “No model loaded”
- [ ] Correct key → **API key · …** and model metrics
