### PR TITLE
bump 1.4.5 — SGLang detect, model wrap, decode concurrencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Format: version sections are listed newest first.
 
 ---
 
+## [1.4.5] — 2026-07-31
+
+### Fixed
+- **SGLang detection** — OpenAI-compatible servers are no longer always labeled vLLM; SGLang is identified via `owned_by` / `/get_server_info`, and HF hub cache model paths are shortened to `org/name` ([#29](https://github.com/MiaAI-Lab/sparkDash/pull/29))
+- **Overview model name trim** — long LLM / worker labels wrap instead of ellipsis-truncating in the stats grid
+
+### Changed
+- **Decode benchmark concurrencies** — added 5, 10, 12, and 24 ([#27](https://github.com/MiaAI-Lab/sparkDash/pull/27))
+- **LLM API key port renames** — keys migrate/prune when ports change; rejected keys show “Bad API key” ([#26](https://github.com/MiaAI-Lab/sparkDash/pull/26))
+
+---
+
 ## [1.4.4] — 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,16 +46,17 @@ sparkDash is a real-time web dashboard for one or more **NVIDIA DGX Spark (GB10)
 
 ## Latest version changelog
 
-### Version 1.4.4 — Optional LLM API key
-- **Per-port API key** — optional Bearer token in LLM Settings for authenticated OpenAI-compatible gateways; encrypted at rest ([#21](https://github.com/MiaAI-Lab/sparkDash/issues/21))
-- **Settings version** — footer shows the real `package.json` version
+### Version 1.4.5 — SGLang detect, model wrap, decode concurrencies
+- **SGLang detection** — correct backend badge; HF cache paths shortened to `org/name` ([#29](https://github.com/MiaAI-Lab/sparkDash/pull/29))
+- **Model name wrap** — overview / LLM panel show full model id (wrap, no ellipsis trim)
+- **Decode concurrencies** — 5, 10, 12, 24 ([#27](https://github.com/MiaAI-Lab/sparkDash/pull/27))
+- **API key port renames** — migrate/prune keys; “Bad API key” on reject ([#26](https://github.com/MiaAI-Lab/sparkDash/pull/26))
 
 Full history: [CHANGELOG.md](./CHANGELOG.md)
 
-### Version 1.4.3 — Shutdown confirm, stable storage I/O, decode bench cleanup
-- **Shutdown confirmation** — danger-zone dialog with checkbox + type `poweroff` before Shutdown / Shutdown All ([#22](https://github.com/MiaAI-Lab/sparkDash/issues/22))
-- **Stable Storage height** — always show disk ↑/↓ rates (`0 B/s` when idle) ([#20](https://github.com/MiaAI-Lab/sparkDash/issues/20))
-- **Decode benchmark** — Aggregate + per-stream tok/s (Server column removed)
+### Version 1.4.4 — Optional LLM API key
+- **Per-port API key** — optional Bearer token in LLM Settings for authenticated OpenAI-compatible gateways; encrypted at rest ([#21](https://github.com/MiaAI-Lab/sparkDash/issues/21))
+- **Settings version** — footer shows the real `package.json` version
 
 Full history: [CHANGELOG.md](./CHANGELOG.md)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparkdash",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparkdash",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkdash",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "sparkDash — Multi-DGX Spark Monitoring Dashboard",
   "type": "module",
   "scripts": {

--- a/src/components/OverviewPage/OverviewPage.tsx
+++ b/src/components/OverviewPage/OverviewPage.tsx
@@ -36,12 +36,15 @@ function MiniStat({
   tone = "default",
   bold = true,
   title,
+  wrap = false,
 }: {
   label: string;
   value: string;
   tone?: "default" | "accent" | "warning" | "danger" | "success";
   bold?: boolean;
   title?: string;
+  /** Allow value to wrap (no ellipsis trim) — used for long model ids. */
+  wrap?: boolean;
 }) {
   const toneClass =
     tone === "danger"
@@ -57,9 +60,15 @@ function MiniStat({
     <div className="flex min-w-0 flex-col gap-0.5">
       <span className="text-[10px] tracking-wide text-muted">{label}</span>
       <span
-        className={`font-tabular text-[13px] truncate ${bold ? "font-semibold" : ""} ${toneClass}`}
+        className={`font-tabular text-[13px] ${
+          wrap
+            ? "whitespace-normal break-words leading-snug [overflow-wrap:anywhere]"
+            : "truncate"
+        } ${bold ? "font-semibold" : ""} ${toneClass}`}
         title={title}
-      >{value}</span>
+      >
+        {value}
+      </span>
     </div>
   );
 }
@@ -231,6 +240,7 @@ function SparkCard({
                     value={label}
                     tone="accent"
                     title={title}
+                    wrap
                   />
                 );
               }
@@ -245,6 +255,7 @@ function SparkCard({
                   value={llm.modelId ?? "unknown"}
                   tone="accent"
                   title={llm.modelId ?? undefined}
+                  wrap
                 />
               );
             })()}

--- a/src/components/SparkPage/LlmPanel.tsx
+++ b/src/components/SparkPage/LlmPanel.tsx
@@ -422,7 +422,7 @@ export function LlmPanel({
             {llm?.posture && <PostureBadge posture={llm.posture} />}
             {llm?.modelId && (
               <span
-                className="min-w-0 flex-1 truncate text-xs text-text"
+                className="min-w-0 flex-1 whitespace-normal break-words text-xs leading-snug text-text [overflow-wrap:anywhere]"
                 title={llm.modelId}
               >
                 {llm.modelId}


### PR DESCRIPTION
## Summary
- Version **1.4.5** in package.json, lockfile, CHANGELOG, README
- Overview / LLM panel model ids wrap (no ellipsis trim)
- Changelog covers SGLang detection (#29), decode concurrencies (#27), API key port migrate (#26)

## Test plan
- [ ] Settings footer shows `sparkDash v1.4.5`
- [ ] Long model names wrap on Overview cards
