### PR TITLE
fix: count reasoning deltas in decode bench tok/s

### DIFF
--- a/server/collectors/DecodeBench.js
+++ b/server/collectors/DecodeBench.js
@@ -208,10 +208,39 @@ async function pollServerGenerationRates(baseUrl, signal, intervalMs = 400) {
 }
 
 /**
+ * Pull generated text out of one streamed choice.
+ *
+ * Reasoning models (DeepSeek-V4-Flash, R1-style) emit their thinking phase as
+ * `delta.reasoning` / `delta.reasoning_content` and only switch to
+ * `delta.content` at the end — but `usage.completion_tokens` counts *both*.
+ * Timing the window on content alone therefore pairs the full token count with
+ * a fraction of the wall clock (inflated tok/s), or with a zero-length window
+ * when the reply never leaves the reasoning phase (tok/s reads 0).
+ *
+ * @returns {{ text: string, isReasoning: boolean }} empty text when the delta
+ * carries no generated tokens (role-only openers, tool calls, keepalives).
+ */
+export function extractDeltaText(choice) {
+  const delta = choice?.delta;
+  const content = delta?.content ?? choice?.text;
+  if (typeof content === "string" && content.length > 0) {
+    return { text: content, isReasoning: false };
+  }
+  // `reasoning_content` is the vLLM/OpenAI spelling; `reasoning` is what
+  // DeepSeek-V4-Flash emits. Accept either.
+  const reasoning = delta?.reasoning_content ?? delta?.reasoning;
+  if (typeof reasoning === "string" && reasoning.length > 0) {
+    return { text: reasoning, isReasoning: true };
+  }
+  return { text: "", isReasoning: false };
+}
+
+/**
  * Parse one OpenAI-compatible SSE stream for a single completion request.
  *
  * Decode tok/s uses the **first-token → last-token** window (not stream EOF),
- * so trailing usage/[DONE] latency does not drag the rate down.
+ * so trailing usage/[DONE] latency does not drag the rate down. Reasoning
+ * deltas count as tokens for both ends of that window — see extractDeltaText.
  *
  * When `debug` is true, also captures a compact HTTP/SSE debug trace
  * (no full completion text).
@@ -222,6 +251,10 @@ async function runStreamingRequest(url, body, signal, { debug = false } = {}) {
   let tFirst = null;
   /** @type {number | null} */
   let tLast = null;
+  /** First *answer* token — after the reasoning phase, when there is one. */
+  /** @type {number | null} */
+  let tFirstContent = null;
+  let reasoningChunkCount = 0;
   let chunkTokenCount = 0;
   let usageCompletionTokens = null;
   /** @type {Record<string, number> | null} */
@@ -314,14 +347,19 @@ async function runStreamingRequest(url, body, signal, { debug = false } = {}) {
 
           const choice = json.choices?.[0];
           if (debug && choice?.finish_reason) finishReason = String(choice.finish_reason);
-          const delta = choice?.delta?.content ?? choice?.text ?? "";
-          if (typeof delta === "string" && delta.length > 0) {
+          const { text: delta, isReasoning } = extractDeltaText(choice);
+          if (delta.length > 0) {
             const now = performance.now();
             if (tFirst == null) tFirst = now;
             tLast = now;
+            if (isReasoning) {
+              reasoningChunkCount += 1;
+            } else if (tFirstContent == null) {
+              tFirstContent = now;
+            }
             // OpenAI-compatible servers typically emit ~1 token per content chunk.
             chunkTokenCount += 1;
-            if (debug) content += delta;
+            if (debug && !isReasoning) content += delta;
           }
         }
       }
@@ -347,7 +385,9 @@ async function runStreamingRequest(url, body, signal, { debug = false } = {}) {
   // Post-first-token tokens. With usage: all but the first generated token.
   const decodeTokens = Math.max(0, completionTokens - (completionTokens > 0 ? 1 : 0));
 
-  // Decode window: first content token → last content token (excludes prefill + teardown).
+  // Decode window: first generated token → last generated token (excludes
+  // prefill + teardown). Reasoning tokens are inside the window because
+  // usage.completion_tokens counts them.
   const decodeMs =
     tFirst != null && tLast != null && tLast > tFirst ? tLast - tFirst : 0;
   const decodeTps =
@@ -356,6 +396,9 @@ async function runStreamingRequest(url, body, signal, { debug = false } = {}) {
   /** @type {Record<string, unknown>} */
   const out = {
     ttftMs: round2(ttftMs),
+    /** Reasoning models only: first answer token, after the thinking phase. */
+    ttftContentMs: tFirstContent != null ? round2(tFirstContent - t0) : null,
+    reasoningChunks: reasoningChunkCount,
     decodeMs: round2(decodeMs),
     completionTokens,
     decodeTokens,
@@ -507,6 +550,8 @@ function streamPublicResult(r, index, prompt, reqMeta, debug = false) {
   const out = {
     index,
     ttftMs: r?.ttftMs ?? 0,
+    ttftContentMs: r?.ttftContentMs ?? null,
+    reasoningChunks: r?.reasoningChunks ?? 0,
     decodeTps: r?.decodeTps ?? 0,
     decodeTokens: r?.decodeTokens ?? 0,
     completionTokens: r?.completionTokens ?? 0,

--- a/server/collectors/__tests__/DecodeBench.reasoning.test.js
+++ b/server/collectors/__tests__/DecodeBench.reasoning.test.js
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for DecodeBench's streamed-delta extraction.
+ *
+ * Reasoning models (DeepSeek-V4-Flash, R1-style) emit their thinking phase as
+ * `delta.reasoning` / `delta.reasoning_content` and only switch to
+ * `delta.content` at the very end — while `usage.completion_tokens` counts
+ * both. Timing the decode window on content alone pairs the full token count
+ * with a fraction of the wall clock (inflated tok/s), or with a zero-length
+ * window when the reply never leaves the reasoning phase (tok/s reads 0).
+ * These cases pin the delta shapes that must count as generated tokens.
+ *
+ * Uses node:test (shipped with Node 22) — no dependencies required.
+ * Run: npm test
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { extractDeltaText } from "../DecodeBench.js";
+
+test("plain content delta is generated text, not reasoning", () => {
+  const r = extractDeltaText({ delta: { content: "hello" } });
+  assert.equal(r.text, "hello");
+  assert.equal(r.isReasoning, false);
+});
+
+test("legacy completions `text` field still counts", () => {
+  const r = extractDeltaText({ text: "hello" });
+  assert.equal(r.text, "hello");
+  assert.equal(r.isReasoning, false);
+});
+
+test("DeepSeek-V4-Flash `reasoning` delta counts as generated text", () => {
+  const r = extractDeltaText({ delta: { reasoning: "1. The user asks" } });
+  assert.equal(r.text, "1. The user asks");
+  assert.equal(r.isReasoning, true);
+});
+
+test("OpenAI/vLLM `reasoning_content` delta counts as generated text", () => {
+  const r = extractDeltaText({ delta: { reasoning_content: "thinking" } });
+  assert.equal(r.text, "thinking");
+  assert.equal(r.isReasoning, true);
+});
+
+test("content wins when a chunk carries both", () => {
+  const r = extractDeltaText({
+    delta: { content: "answer", reasoning: "thought" },
+  });
+  assert.equal(r.text, "answer");
+  assert.equal(r.isReasoning, false);
+});
+
+test("role-only opener yields no tokens", () => {
+  const r = extractDeltaText({ delta: { role: "assistant", content: "" } });
+  assert.equal(r.text, "");
+  assert.equal(r.isReasoning, false);
+});
+
+test("usage-only / finish-only chunks yield no tokens", () => {
+  assert.equal(extractDeltaText({ delta: {}, finish_reason: "length" }).text, "");
+  assert.equal(extractDeltaText(undefined).text, "");
+  assert.equal(extractDeltaText(null).text, "");
+  assert.equal(extractDeltaText({}).text, "");
+});
+
+test("non-string deltas (tool calls) are ignored", () => {
+  const r = extractDeltaText({
+    delta: { content: null, tool_calls: [{ index: 0 }] },
+  });
+  assert.equal(r.text, "");
+});


### PR DESCRIPTION
## Problem

The decode benchmark reports **0 tok/s and 0 ms TTFT** against reasoning models. Hit with `deepseek-v4-flash-robolab` on a 2x DGX-Spark vLLM endpoint.

Reasoning models stream their thinking phase as `delta.reasoning` / `delta.reasoning_content` and only switch to `delta.content` at the very end — but `usage.completion_tokens` counts **both**. `runStreamingRequest` only looked at `delta.content` / `choices[0].text`, so:

- the full token count got paired with a fraction of the wall clock (inflated tok/s), and
- when a reply spent its whole budget reasoning, `tFirst`/`tLast` never got set → zero-length window → `decodeTps = 0`, `ttftMs = 0`.

A baseline run against the unpatched code confirmed it: `meanDecodeTps 0`, `meanTtftMs 0`, 256 completion tokens, no error reported — the stream counts as OK, the number is just silently zero.

Worth noting this model emits `reasoning`, **not** the vLLM/OpenAI `reasoning_content` spelling. `extractDeltaText` accepts either.

## Fix

New `extractDeltaText()` treats `content`, `reasoning_content`, and `reasoning` as generated text. The decode window and TTFT now open on the first generated token of *any* kind, matching what `completion_tokens` measures. Debug traces keep capturing answer text only — reasoning is excluded from `contentPreview`.

Adds two fields: `ttftContentMs` (when the answer actually starts, after thinking) and `reasoningChunks`.

## Verification

Same bench (concurrency 1, 256 max tokens), before → after:

| | before | after |
|---|---|---|
| decode tok/s | **0** | **9.68** |
| TTFT | 0 ms | 23,893 ms |
| `ttftContentMs` | — | 39,013 ms |
| `reasoningChunks` | — | 40 |

Arithmetic checks out: 255 tokens ÷ (50,230 − 23,893) ms = 9.68 tok/s.

The absolute numbers are low because the endpoint was serving 6 concurrent requests from unrelated traffic throughout — the per-stream 9.68 tok/s is a fair share of the ~100 tok/s aggregate, not a regression.

`npm test` passes 25/25, including 8 new cases in `server/collectors/__tests__/DecodeBench.reasoning.test.js` pinning the delta shapes (both reasoning spellings, content-wins-when-both, role-only openers, usage-only chunks, non-string tool-call deltas).

## Not affected

The live **Generation tok/s** tile reads vLLM's Prometheus counters, not the SSE stream — it was always correct and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01468yQTuvWM62gnpMFhebq6