### PR TITLE
feat: ComfyUI (video) monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Full history: [CHANGELOG.md](./CHANGELOG.md)
 | **Prompt Showcase** | Full-page multi-terminal LLM streaming demo (up to 32 prompts) with live tok/s and copy-out |
 | **vLLM health** | KV cache %, run/wait queue, TTFT/E2E/ITL p95, preemptions, prefix cache, MTP accept from Prometheus `/metrics` |
 | **Multiple LLM ports** | Monitor several LLM servers on different ports simultaneously — each gets its own panel with independent backend detection and metrics |
+| **ComfyUI probe** | Optional video/diffusion monitoring: queue depth, running job, sampler step progress + ETA, ComfyUI VRAM — per Spark, opt-in, any port |
 | **GPU processes** | See the top GPU processes by VRAM usage directly in the GPU panel, including process name and memory allocation |
 | **Spark uptime** | System uptime displayed inline on each Spark header for at-a-glance availability |
 | **Power controls** | Graceful shutdown (SSH host script) and Wake-on-LAN; batch actions on Overview |
@@ -114,7 +115,8 @@ Design principle: **one Spark model, N instances**. Every Spark is a record in `
 │  ├─ SparkRegistry             load/persist Sparks; change events           │
 │  ├─ SparkMonitor (per Spark)  collector + LLM probe + rate baselines       │
 │  │   ├─ SystemCollector       local sysfs/proc OR remote SSH               │
-│  │   └─ LlmProbe              HTTP to host:LLM_PORT, backend autodetect    │
+│  │   ├─ LlmProbe              HTTP to host:LLM_PORT, backend autodetect    │
+│  │   └─ ComfyProbe            HTTP to host:videoPort, opt-in (ComfyUI)     │
 │  ├─ REST /api/*                                                            │
 │  └─ WebSocket /ws             snapshot stream to browsers                  │
 │  React SPA (src/)  — Overview + per-Spark pages, themes, dialogs           │
@@ -191,6 +193,9 @@ sparkDash/
 | POST | `/api/sparks/:id/llm-ports` | Add an LLM port (hot) |
 | DELETE | `/api/sparks/:id/llm-ports/:port` | Remove an LLM port (hot) |
 | PUT | `/api/sparks/:id/llm-port` | LLM port — backward-compat (hot) |
+| PUT | `/api/sparks/:id/video-ports` | Replace all ComfyUI ports (empty = off, hot) |
+| POST | `/api/sparks/:id/video-ports` | Add a ComfyUI port (hot) |
+| DELETE | `/api/sparks/:id/video-ports/:port` | Remove a ComfyUI port (hot) |
 | GET | `/api/settings` | Global settings |
 | PUT | `/api/settings` | Update global settings |
 | WS | `/ws` | Real-time metrics stream |
@@ -226,6 +231,8 @@ Copy `.env.example` to `.env` if needed:
 | `POLL_INTERVAL_NETWORK` | `2000` | Network poll (ms) |
 | `POLL_INTERVAL_STORAGE` | `5000` | Storage poll (ms) |
 | `POLL_INTERVAL_LLM` | `2000` | LLM probe poll (ms) |
+| `POLL_INTERVAL_COMFY` | `3000` | ComfyUI probe poll (ms) |
+| `COMFY_PORT` | `8188` | Suggested ComfyUI port (probing stays off until a Spark has video ports) |
 | `POLL_INTERVAL_BANDWIDTH` | `2000` | Memory bandwidth / dmon poll (ms) |
 | `POLL_INTERVAL_LIVENESS` | `5000` | Online/SSH liveness check (ms) |
 | `SPARKDASH_SECRETS_KEY` | _(auto)_ | Passphrase or 64-char hex for secret encryption |
@@ -322,6 +329,20 @@ Each configured LLM port gets its own `LlmProbe` instance running in parallel. P
 - **vLLM / sglang** — `/v1/models`; sglang via `/get_server_info` (`last_gen_throughput` when metrics off), vLLM via Prometheus `/metrics` counters (scientific notation supported)
 
 Rates are derived from per-probe cumulative counter diffs (or SGLang sticky throughput while it moves). Multiple ports can be added or removed at runtime without restarting the monitor.
+
+### ComfyUI probe (video / diffusion)
+
+Off by default: a Spark is probed only once it has at least one **video port**. Add one with **+ Add ComfyUI port** on the Spark page (or `POST /api/sparks/:id/video-ports`); remove the last one and monitoring stops. Worker-role Sparks are never probed.
+
+Each port gets a `ComfyProbe` reading ComfyUI's REST API:
+
+- `/system_stats` — version, torch/python versions, device VRAM total/free and torch allocator VRAM
+- `/queue` — running and pending prompt counts
+- `/api/jobs?limit=5` — current job id + timings, and the last finished output filename
+
+**Sampler step progress needs a log path.** ComfyUI sends `progress_state` only to the WebSocket client that submitted the prompt (`comfy_execution/progress.py`), so a passive observer can never read "14 / 20" from the API. Set **Server log path** in the panel's *Settings* (or `comfyLogPath` via `PATCH /api/sparks/:id`) and the probe tails the last few KiB of ComfyUI's stdout log, parsing the tqdm line for step, steps, s/step and ETA. Local Sparks read it through the host root mount; remote Sparks over SSH. Leave it blank and the panel simply shows *Rendering* with elapsed time instead of a progress bar.
+
+ComfyUI shares the GPU with any LLM server on the same box — on a 128 GB GB10, an `--gpu-memory-utilization` around `0.45` for vLLM leaves enough unified memory for video work.
 
 ---
 

--- a/server/collectors/ComfyProbe.js
+++ b/server/collectors/ComfyProbe.js
@@ -1,0 +1,268 @@
+/**
+ * ComfyProbe — probes a ComfyUI server (default port 8188) over its REST API.
+ *
+ * Reports version, device VRAM, queue depth, the running job and its elapsed
+ * time, and the most recent output preview.
+ *
+ * Step progress ("14/20") is deliberately NOT taken from the API: ComfyUI sends
+ * `progress_state` only to the client that submitted the prompt
+ * (comfy_execution/progress.py), so a passive monitor never receives it and no
+ * REST route exposes it. When `comfyLogPath` is configured we parse the tqdm
+ * line out of the server log instead — same spirit as reading host metrics off
+ * the filesystem elsewhere in this app.
+ */
+import fs from "fs";
+import path from "path";
+import { LLM_PROBE_TIMEOUT_MS, HOST_PATHS } from "../config.js";
+import { llmProbeHost } from "./llmHost.js";
+import { sshExec } from "./ssh.js";
+
+/** Bytes of log tail to scan for the newest tqdm progress line. */
+const LOG_TAIL_BYTES = 8192;
+/** A parsed tqdm line older than this is stale — drop it. */
+const LOG_PROGRESS_TTL_MS = 30_000;
+
+/**
+ * Pull the newest tqdm progress line out of a chunk of ComfyUI log output.
+ * tqdm rewrites one line with \r, so the tail holds many generations of it.
+ *   " 90%|█████████ | 18/20 [11:31<01:18, 39.18s/it]"
+ * @param {string} text
+ * @returns {{ step: number, steps: number, elapsedSeconds: number | null,
+ *             etaSeconds: number | null, secPerStep: number | null } | null}
+ */
+export function parseProgressLine(text) {
+  if (!text) return null;
+  const re =
+    /(\d+)\/(\d+)\s*\[([\d:?]+)<([\d:?]+),\s*([\d.]+)(s\/it|it\/s)\]/g;
+  let last = null;
+  for (const m of text.matchAll(re)) last = m;
+  if (!last) return null;
+
+  const step = Number(last[1]);
+  const steps = Number(last[2]);
+  if (!Number.isFinite(step) || !Number.isFinite(steps) || steps <= 0) return null;
+
+  const rate = Number(last[5]);
+  const secPerStep = Number.isFinite(rate)
+    ? last[6] === "s/it"
+      ? rate
+      : rate > 0
+        ? 1 / rate
+        : null
+    : null;
+
+  return {
+    step,
+    steps,
+    elapsedSeconds: parseClock(last[3]),
+    etaSeconds: parseClock(last[4]),
+    secPerStep,
+  };
+}
+
+/** "11:31" / "1:02:03" → seconds. "?" or garbage → null. */
+function parseClock(s) {
+  if (!s || s.includes("?")) return null;
+  const parts = s.split(":").map(Number);
+  if (parts.some((n) => !Number.isFinite(n))) return null;
+  return parts.reduce((acc, n) => acc * 60 + n, 0);
+}
+
+export class ComfyProbe {
+  constructor(spark, port = 8188) {
+    this.spark = spark;
+    this.port = port;
+    this.baseUrl = `http://${llmProbeHost(spark)}:${port}`;
+
+    this.version = null;
+    this.pythonVersion = null;
+    this.pytorchVersion = null;
+    this.device = null;
+    this.error = null;
+
+    /** Last successfully parsed tqdm progress, with the time we read it. */
+    this._progress = null;
+    this._progressAt = 0;
+  }
+
+  /** Update probe port (and host from spark). */
+  setPort(port) {
+    const next = Number(port);
+    if (Number.isInteger(next) && next >= 1 && next <= 65535) this.port = next;
+    this.baseUrl = `http://${llmProbeHost(this.spark)}:${this.port}`;
+  }
+
+  /** Probe the ComfyUI server and return a snapshot. */
+  async probe() {
+    let stats;
+    try {
+      stats = await this._json("/system_stats");
+    } catch (err) {
+      this.error = `ComfyUI unreachable: ${err.message}`;
+      return this._default();
+    }
+
+    this.error = null;
+    this._applyStats(stats);
+
+    // Queue + jobs are best-effort — a running ComfyUI without them still
+    // reports version and VRAM rather than showing as down.
+    const [queue, jobs] = await Promise.all([
+      this._json("/queue").catch(() => null),
+      this._json("/api/jobs?limit=5").catch(() => null),
+    ]);
+
+    const queueRunning = Array.isArray(queue?.queue_running) ? queue.queue_running.length : 0;
+    const queuePending = Array.isArray(queue?.queue_pending) ? queue.queue_pending.length : 0;
+
+    const jobList = Array.isArray(jobs?.jobs) ? jobs.jobs : [];
+    const running = jobList.find((j) => j?.status === "in_progress") || null;
+    const lastDone = jobList.find((j) => j?.status === "completed") || null;
+
+    // Only spend a log read while something is actually rendering.
+    const progress = queueRunning > 0 || running ? await this._readProgress() : null;
+
+    return {
+      available: true,
+      version: this.version,
+      pythonVersion: this.pythonVersion,
+      pytorchVersion: this.pytorchVersion,
+      device: this.device,
+      queueRunning,
+      queuePending,
+      job: running ? this._buildJob(running, progress) : null,
+      lastOutput: this._buildOutput(lastDone),
+      error: null,
+    };
+  }
+
+  _applyStats(stats) {
+    const sys = stats?.system || {};
+    this.version = sys.comfyui_version ?? null;
+    this.pythonVersion = sys.python_version ? String(sys.python_version).split(" ")[0] : null;
+    this.pytorchVersion = sys.pytorch_version ?? null;
+
+    const dev = Array.isArray(stats?.devices) ? stats.devices[0] : null;
+    this.device = dev
+      ? {
+          name: dev.name ?? null,
+          vramTotal: num(dev.vram_total),
+          vramFree: num(dev.vram_free),
+          torchVramTotal: num(dev.torch_vram_total),
+          torchVramFree: num(dev.torch_vram_free),
+        }
+      : null;
+  }
+
+  /**
+   * @param {object} job an /api/jobs entry with status "in_progress"
+   * @param {ReturnType<typeof parseProgressLine> | null} progress
+   */
+  _buildJob(job, progress) {
+    const startMs = num(job.execution_start_time) ?? num(job.create_time);
+    const elapsedSeconds = startMs != null ? Math.max(0, (Date.now() - startMs) / 1000) : null;
+    const percent =
+      progress && progress.steps > 0 ? (progress.step / progress.steps) * 100 : null;
+
+    return {
+      id: job.id ?? null,
+      elapsedSeconds,
+      step: progress?.step ?? null,
+      steps: progress?.steps ?? null,
+      percent,
+      secPerStep: progress?.secPerStep ?? null,
+      etaSeconds: progress?.etaSeconds ?? null,
+    };
+  }
+
+  _buildOutput(job) {
+    const out = job?.preview_output;
+    if (!out || !out.filename) return null;
+    return {
+      filename: out.filename,
+      subfolder: out.subfolder ?? "",
+      type: out.type ?? "output",
+      mediaType: out.mediaType ?? null,
+      finishedAt: num(job.execution_end_time),
+    };
+  }
+
+  // ─── Log tail (step progress) ────────────────────────────
+  /** Read + parse the newest tqdm line, or null when unavailable/stale. */
+  async _readProgress() {
+    const logPath = this.spark?.comfyLogPath;
+    if (!logPath || typeof logPath !== "string") return null;
+
+    let tail;
+    try {
+      tail = this.spark.isLocal
+        ? this._readLocalTail(logPath)
+        : await sshExec(this.spark, `tail -c ${LOG_TAIL_BYTES} ${shellQuote(logPath)}`);
+    } catch {
+      return null; // missing/unreadable log is not a probe failure
+    }
+
+    const parsed = parseProgressLine(String(tail || "").replace(/\r/g, "\n"));
+    if (parsed) {
+      this._progress = parsed;
+      this._progressAt = Date.now();
+      return parsed;
+    }
+    // tqdm only rewrites during sampling; hold the last reading briefly so the
+    // panel doesn't blink between steps, then let it expire.
+    if (this._progress && Date.now() - this._progressAt < LOG_PROGRESS_TTL_MS) {
+      return this._progress;
+    }
+    this._progress = null;
+    return null;
+  }
+
+  /** Read the last LOG_TAIL_BYTES of a host file (bind-mounted at HOST_PATHS.ROOT). */
+  _readLocalTail(logPath) {
+    const mapped = path.join(HOST_PATHS.ROOT, logPath);
+    const target = fs.existsSync(mapped) ? mapped : logPath;
+    const fd = fs.openSync(target, "r");
+    try {
+      const size = fs.fstatSync(fd).size;
+      const len = Math.min(size, LOG_TAIL_BYTES);
+      const buf = Buffer.alloc(len);
+      fs.readSync(fd, buf, 0, len, size - len);
+      return buf.toString("utf8");
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  _default() {
+    return {
+      available: false,
+      version: this.version,
+      pythonVersion: this.pythonVersion,
+      pytorchVersion: this.pytorchVersion,
+      device: null,
+      queueRunning: 0,
+      queuePending: 0,
+      job: null,
+      lastOutput: null,
+      error: this.error,
+    };
+  }
+
+  // ─── HTTP ────────────────────────────────────────────────
+  async _json(route) {
+    const res = await fetch(`${this.baseUrl}${route}`, {
+      signal: AbortSignal.timeout(LLM_PROBE_TIMEOUT_MS),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  }
+}
+
+function num(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function shellQuote(s) {
+  return `'${String(s).replace(/'/g, "'\\''")}'`;
+}

--- a/server/collectors/__tests__/ComfyProbe.test.js
+++ b/server/collectors/__tests__/ComfyProbe.test.js
@@ -1,0 +1,111 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { parseProgressLine, ComfyProbe } from "../ComfyProbe.js";
+
+// ─── tqdm log parsing ────────────────────────────────────
+// ComfyUI sends progress_state only to the submitting client, so the sampler
+// step count is scraped out of the server log instead. tqdm rewrites one line
+// with \r, so a tail holds many generations of it — the newest must win.
+
+test("parseProgressLine: reads step, steps, elapsed, ETA and s/it", () => {
+  const p = parseProgressLine(" 90%|█████████ | 18/20 [11:31<01:18, 39.18s/it]");
+  assert.equal(p.step, 18);
+  assert.equal(p.steps, 20);
+  assert.equal(p.elapsedSeconds, 11 * 60 + 31);
+  assert.equal(p.etaSeconds, 78);
+  assert.equal(p.secPerStep, 39.18);
+});
+
+test("parseProgressLine: takes the LAST match in a tail of rewrites", () => {
+  const tail = [
+    " 25%|██        | 5/20 [03:12<09:36, 38.40s/it]",
+    " 60%|██████    | 12/20 [07:41<05:07, 38.44s/it]",
+    " 90%|█████████ | 18/20 [11:31<01:18, 39.18s/it]",
+  ].join("\n");
+  assert.equal(parseProgressLine(tail).step, 18);
+});
+
+test("parseProgressLine: inverts it/s into seconds per step", () => {
+  const p = parseProgressLine(" 50%|█████     | 10/20 [00:05<00:05, 2.00it/s]");
+  assert.equal(p.secPerStep, 0.5);
+});
+
+test("parseProgressLine: hours in the clock", () => {
+  const p = parseProgressLine("  5%|▌         | 1/20 [01:50:03<34:50:57, 6603.00s/it]");
+  assert.equal(p.elapsedSeconds, 1 * 3600 + 50 * 60 + 3);
+  assert.equal(p.etaSeconds, 34 * 3600 + 50 * 60 + 57);
+});
+
+test("parseProgressLine: unknown ETA (?) yields null, not NaN", () => {
+  const p = parseProgressLine("  0%|          | 0/20 [00:00<?, ?it/s]\n 5%|▌| 1/20 [00:39<12:23, 39.15s/it]");
+  assert.equal(p.step, 1);
+  assert.equal(p.etaSeconds, 743);
+});
+
+test("parseProgressLine: no tqdm output → null", () => {
+  assert.equal(parseProgressLine("got prompt\nPrompt executed in 137.12 seconds"), null);
+  assert.equal(parseProgressLine(""), null);
+  assert.equal(parseProgressLine(null), null);
+});
+
+// ─── Probe wiring ────────────────────────────────────────
+
+test("ComfyProbe: local spark probes loopback", () => {
+  const probe = new ComfyProbe({ isLocal: true, lanIp: "192.168.178.122" }, 8188);
+  assert.equal(probe.baseUrl, "http://127.0.0.1:8188");
+});
+
+test("ComfyProbe: remote spark probes lanIp", () => {
+  const probe = new ComfyProbe({ isLocal: false, lanIp: "192.168.178.50" }, 8188);
+  assert.equal(probe.baseUrl, "http://192.168.178.50:8188");
+});
+
+test("ComfyProbe: setPort rejects out-of-range ports but still refreshes host", () => {
+  const probe = new ComfyProbe({ isLocal: true }, 8188);
+  probe.setPort(70000);
+  assert.equal(probe.port, 8188);
+  probe.setPort(8189);
+  assert.equal(probe.baseUrl, "http://127.0.0.1:8189");
+});
+
+test("ComfyProbe: unreachable server reports available:false with an error", async () => {
+  // Port 1 is never a ComfyUI; connection is refused immediately.
+  const probe = new ComfyProbe({ isLocal: true }, 1);
+  const snap = await probe.probe();
+  assert.equal(snap.available, false);
+  assert.equal(snap.queueRunning, 0);
+  assert.equal(snap.job, null);
+  assert.match(snap.error, /ComfyUI unreachable/);
+});
+
+test("ComfyProbe: _buildJob derives percent from parsed steps", () => {
+  const probe = new ComfyProbe({ isLocal: true }, 8188);
+  const job = probe._buildJob(
+    { id: "abc", execution_start_time: Date.now() - 5000 },
+    { step: 5, steps: 20, secPerStep: 39.1, etaSeconds: 586, elapsedSeconds: 196 }
+  );
+  assert.equal(job.percent, 25);
+  assert.equal(job.steps, 20);
+  assert.ok(job.elapsedSeconds >= 5 && job.elapsedSeconds < 10);
+});
+
+test("ComfyProbe: _buildJob without log progress still reports elapsed", () => {
+  const probe = new ComfyProbe({ isLocal: true }, 8188);
+  const job = probe._buildJob({ id: "abc", execution_start_time: Date.now() - 1000 }, null);
+  assert.equal(job.step, null);
+  assert.equal(job.percent, null);
+  assert.ok(job.elapsedSeconds >= 1);
+});
+
+test("ComfyProbe: no comfyLogPath configured → no step progress, no throw", async () => {
+  const probe = new ComfyProbe({ isLocal: true }, 8188);
+  assert.equal(await probe._readProgress(), null);
+});
+
+test("ComfyProbe: missing log file is not a probe failure", async () => {
+  const probe = new ComfyProbe(
+    { isLocal: true, comfyLogPath: "/definitely/not/here/comfyui.log" },
+    8188
+  );
+  assert.equal(await probe._readProgress(), null);
+});

--- a/server/config.js
+++ b/server/config.js
@@ -26,6 +26,8 @@ const POLL_INTERVAL_CPU = parseInt(process.env.POLL_INTERVAL_CPU || "2000", 10);
 const POLL_INTERVAL_NETWORK = parseInt(process.env.POLL_INTERVAL_NETWORK || "2000", 10);
 const POLL_INTERVAL_STORAGE = parseInt(process.env.POLL_INTERVAL_STORAGE || "5000", 10);
 const POLL_INTERVAL_LLM = parseInt(process.env.POLL_INTERVAL_LLM || "2000", 10);
+// ComfyUI: queue state moves on job boundaries, not per token — poll slower.
+const POLL_INTERVAL_COMFY = parseInt(process.env.POLL_INTERVAL_COMFY || "3000", 10);
 // dmon -c 1 -d 1 blocks ~1s; default 2s avoids stacking with in-flight guards
 const POLL_INTERVAL_BANDWIDTH = parseInt(process.env.POLL_INTERVAL_BANDWIDTH || "2000", 10);
 // Dedicated liveness (sshTest / local ping) cadence — not a metric domain.
@@ -34,6 +36,8 @@ const POLL_INTERVAL_LIVENESS = parseInt(process.env.POLL_INTERVAL_LIVENESS || "5
 // ─── Port ────────────────────────────────────────────────
 const PORT = parseInt(process.env.PORT || "5555", 10);
 const LLM_PORT = parseInt(process.env.LLM_PORT || "8888", 10);
+// Suggested default only — video monitoring stays off until videoPorts is set.
+const COMFY_PORT = parseInt(process.env.COMFY_PORT || "8188", 10);
 
 // ─── DGX Spark constants ────────────────────────────────
 const DGX_SPARK = {
@@ -83,10 +87,12 @@ export {
   POLL_INTERVAL_NETWORK,
   POLL_INTERVAL_STORAGE,
   POLL_INTERVAL_LLM,
+  POLL_INTERVAL_COMFY,
   POLL_INTERVAL_BANDWIDTH,
   POLL_INTERVAL_LIVENESS,
   PORT,
   LLM_PORT,
+  COMFY_PORT,
   DGX_SPARK,
   UNIT_CONVERSION,
   HARDWARE_DEFAULTS,

--- a/server/index.js
+++ b/server/index.js
@@ -542,6 +542,89 @@ app.delete("/api/sparks/:id/llm-ports/:port", (req, res) => {
   }
 });
 
+// ─── ComfyUI (video) ports ───────────────────────────────
+// Unlike LLM ports, an empty list is valid: it means video monitoring is off.
+
+/** Push a changed Spark config into its monitor, starting one if needed. */
+function applySparkConfig(id, fallback) {
+  const spark = registry.getSpark(id) || fallback;
+  const monitor = monitors.get(id);
+  if (monitor) monitor.updateConfig(spark);
+  else startMonitor(spark);
+}
+
+// Replace the full video port list
+app.put("/api/sparks/:id/video-ports", (req, res) => {
+  try {
+    const spark = registry.getSpark(req.params.id);
+    if (!spark) return res.status(404).json({ error: "Spark not found" });
+
+    const raw = req.body?.videoPorts;
+    if (!Array.isArray(raw)) {
+      return res.status(400).json({ error: "videoPorts must be an array" });
+    }
+    const ports = raw
+      .map((v) => (typeof v === "string" ? parseInt(v, 10) : Number(v)))
+      .filter((n) => Number.isInteger(n) && n >= 1 && n <= 65535);
+
+    const updated = registry.updateSpark(req.params.id, { videoPorts: [...new Set(ports)] });
+    applySparkConfig(req.params.id, updated);
+    res.json({ success: true, videoPorts: updated.videoPorts });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Add a single ComfyUI port (hot — no monitor restart)
+app.post("/api/sparks/:id/video-ports", (req, res) => {
+  try {
+    const spark = registry.getSpark(req.params.id);
+    if (!spark) return res.status(404).json({ error: "Spark not found" });
+
+    const raw = req.body?.port;
+    const n = typeof raw === "string" ? parseInt(raw, 10) : Number(raw);
+    if (!Number.isInteger(n) || n < 1 || n > 65535) {
+      return res.status(400).json({ error: "port must be an integer 1–65535" });
+    }
+
+    const currentPorts = spark.videoPorts || [];
+    if (currentPorts.includes(n)) {
+      return res.json({ success: true, videoPorts: currentPorts });
+    }
+
+    const updated = registry.updateSpark(req.params.id, { videoPorts: [...currentPorts, n] });
+    applySparkConfig(req.params.id, updated);
+    res.json({ success: true, videoPorts: updated.videoPorts });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Remove a ComfyUI port (hot). Removing the last one turns video monitoring off.
+app.delete("/api/sparks/:id/video-ports/:port", (req, res) => {
+  try {
+    const spark = registry.getSpark(req.params.id);
+    if (!spark) return res.status(404).json({ error: "Spark not found" });
+
+    const port = parseInt(req.params.port, 10);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      return res.status(400).json({ error: "port must be an integer 1–65535" });
+    }
+
+    const currentPorts = spark.videoPorts || [];
+    const newPorts = currentPorts.filter((p) => p !== port);
+    if (newPorts.length === currentPorts.length) {
+      return res.json({ success: true, videoPorts: currentPorts });
+    }
+
+    const updated = registry.updateSpark(req.params.id, { videoPorts: newPorts });
+    applySparkConfig(req.params.id, updated);
+    res.json({ success: true, videoPorts: updated.videoPorts });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 // Set / clear optional LLM API key for one port (encrypted secrets store)
 app.put("/api/sparks/:id/llm-ports/:port/api-key", (req, res) => {
   try {

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import { SystemCollector } from "../collectors/SystemCollector.js";
 import { LlmProbe } from "../collectors/LlmProbe.js";
+import { ComfyProbe } from "../collectors/ComfyProbe.js";
 import { sshTest, sshExec } from "../collectors/ssh.js";
 import {
   POLL_INTERVAL_GPU,
@@ -9,6 +10,7 @@ import {
   POLL_INTERVAL_NETWORK,
   POLL_INTERVAL_STORAGE,
   POLL_INTERVAL_LLM,
+  POLL_INTERVAL_COMFY,
   POLL_INTERVAL_BANDWIDTH,
   POLL_INTERVAL_LIVENESS,
   LLM_PORT,
@@ -39,6 +41,12 @@ export class SparkMonitor {
       }
     }
 
+    // One ComfyProbe per configured video port — empty unless videoPorts is set
+    this.comfyProbes = new Map();
+    for (const port of this._videoPorts(spark)) {
+      this.comfyProbes.set(port, new ComfyProbe(spark, port));
+    }
+
     // Online status from dedicated liveness checks (not metric poll success)
     this.online = false;
     this.lastOnlineOk = 0;
@@ -55,6 +63,7 @@ export class SparkMonitor {
       network: this.collector._defaultNetwork(),
       unifiedMemory: this.collector._defaultUnifiedMemory(),
       llm: [],
+      comfy: [],
     };
     this._lastUpdate = {};
 
@@ -62,6 +71,8 @@ export class SparkMonitor {
     this._intervals = [];
     /** @type {ReturnType<typeof setInterval> | null} */
     this._llmIntervalId = null;
+    /** @type {ReturnType<typeof setInterval> | null} */
+    this._comfyIntervalId = null;
     this._running = false;
     /** @type {Record<string, boolean>} in-flight domain guards */
     this._inflight = {};
@@ -70,6 +81,7 @@ export class SparkMonitor {
   /** Hot-update config without tearing down poll loops / rate baselines. */
   updateConfig(spark) {
     const wasLlm = this._llmMonitoringEnabled(this.spark);
+    const wasComfy = this._videoPorts(this.spark).length > 0;
     this.spark = spark;
     this.collector.spark = spark;
 
@@ -90,9 +102,27 @@ export class SparkMonitor {
       this._metrics.llm = [];
     }
 
-    // Toggle LLM poll interval when monitoring enablement flips
+    // Rebuild ComfyUI probe map the same way
+    const videoPorts = this._videoPorts();
+    const prevComfy = this.comfyProbes;
+    this.comfyProbes = new Map();
+    for (const port of videoPorts) {
+      const existing = prevComfy.get(port);
+      if (existing) {
+        existing.spark = spark;
+        this.comfyProbes.set(port, existing);
+      } else {
+        this.comfyProbes.set(port, new ComfyProbe(spark, port));
+      }
+    }
+    if (videoPorts.length === 0) this._metrics.comfy = [];
+
+    // Toggle poll intervals when monitoring enablement flips
     if (this._running && wasLlm !== this._llmMonitoringEnabled()) {
       this._restartLlmPollInterval();
+    }
+    if (this._running && wasComfy !== (videoPorts.length > 0)) {
+      this._restartComfyPollInterval();
     }
   }
 
@@ -119,6 +149,42 @@ export class SparkMonitor {
       this._intervals.push(this._llmIntervalId);
       void this._pollDomain("llm");
     }
+  }
+
+  /** Start or clear the ComfyUI poll timer based on configured video ports. */
+  _restartComfyPollInterval() {
+    if (this._comfyIntervalId != null) {
+      clearInterval(this._comfyIntervalId);
+      this._intervals = this._intervals.filter((id) => id !== this._comfyIntervalId);
+      this._comfyIntervalId = null;
+    }
+    if (this._videoPorts().length > 0 && this._running) {
+      this._comfyIntervalId = setInterval(() => this._pollDomain("comfy"), POLL_INTERVAL_COMFY);
+      this._intervals.push(this._comfyIntervalId);
+      void this._pollDomain("comfy");
+    }
+  }
+
+  /**
+   * Video (ComfyUI) ports from spark config. Unlike LLM ports there is no
+   * default — an unconfigured spark gets no ComfyUI probe at all, so existing
+   * installs are untouched. Workers never serve one.
+   * @param {object} [spark]
+   */
+  _videoPorts(spark = this.spark) {
+    const role = spark?.role || (spark?.workerNode ? "worker" : "standalone");
+    if (role === "worker") return [];
+    const raw = spark?.videoPorts;
+    if (!Array.isArray(raw)) return [];
+    const seen = new Set();
+    const ports = [];
+    for (const v of raw) {
+      const n = typeof v === "string" ? parseInt(v, 10) : Number(v);
+      if (!Number.isInteger(n) || n < 1 || n > 65535 || seen.has(n)) continue;
+      seen.add(n);
+      ports.push(n);
+    }
+    return ports;
   }
 
   /** Returns array of LLM ports from spark config. */
@@ -148,6 +214,7 @@ export class SparkMonitor {
     this._intervals.push(setInterval(() => this._pollDomain("ram"), POLL_INTERVAL_CPU));
     this._intervals.push(setInterval(() => this._pollDomain("memory"), POLL_INTERVAL_BANDWIDTH));
     this._restartLlmPollInterval();
+    this._restartComfyPollInterval();
     // Liveness on a slightly slower cadence
     this._intervals.push(setInterval(() => this._checkOnline(), POLL_INTERVAL_LIVENESS));
     console.log(`[SparkMonitor] ${this.spark.id} started`);
@@ -159,6 +226,7 @@ export class SparkMonitor {
     for (const id of this._intervals) clearInterval(id);
     this._intervals = [];
     this._llmIntervalId = null;
+    this._comfyIntervalId = null;
     this._inflight = {};
     console.log(`[SparkMonitor] ${this.spark.id} stopped`);
   }
@@ -166,6 +234,7 @@ export class SparkMonitor {
   /** Return a full snapshot of this Spark's metrics. */
   snapshot() {
     const ports = this._llmMonitoringEnabled() ? this._llmPorts() : [];
+    const videoPorts = this._videoPorts();
     return {
       id: this.spark.id,
       name: this.spark.name,
@@ -186,6 +255,10 @@ export class SparkMonitor {
         : Object.keys(this.spark.llmApiKeys || {})
             .map((p) => parseInt(p, 10))
             .filter((n) => Number.isInteger(n)),
+      videoPorts,
+      videoMonitoring: videoPorts.length > 0,
+      comfyLogPath:
+        typeof this.spark.comfyLogPath === "string" ? this.spark.comfyLogPath : null,
       hardware: this._getHardwareSummary(),
       metrics: {
         // NOTE: no `timestamp` here on purpose. The broadcast path skips
@@ -202,6 +275,7 @@ export class SparkMonitor {
         network: this._metrics.network,
         unifiedMemory: this._metrics.unifiedMemory,
         llm: this._metrics.llm,
+        comfy: this._metrics.comfy,
       },
     };
   }
@@ -269,6 +343,7 @@ export class SparkMonitor {
       this._pollDomain("ram"),
       this._pollDomain("memory"),
       this._pollDomain("llm"),
+      this._pollDomain("comfy"),
     ]);
   }
 
@@ -278,6 +353,8 @@ export class SparkMonitor {
     if (domain === "storage" && this.spark.storagePollDisabled) return;
     // Worker nodes: no local LLM API
     if (domain === "llm" && !this._llmMonitoringEnabled()) return;
+    // No ComfyUI configured for this spark
+    if (domain === "comfy" && this.comfyProbes.size === 0) return;
     this._inflight[domain] = true;
     try {
       let result;
@@ -304,6 +381,11 @@ export class SparkMonitor {
           // Probe all ports in parallel
           result = await Promise.all(
             Array.from(this.llmProbes.values()).map((probe) => probe.probe())
+          );
+          break;
+        case "comfy":
+          result = await Promise.all(
+            Array.from(this.comfyProbes.values()).map((probe) => probe.probe())
           );
           break;
       }
@@ -341,6 +423,9 @@ export class SparkMonitor {
           break;
         case "llm":
           this._metrics.llm = result;
+          break;
+        case "comfy":
+          this._metrics.comfy = result;
           break;
       }
       this._lastUpdate[domain] = Date.now();

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -475,6 +475,7 @@ export class SparkRegistry {
       auth: sshIn.auth === "pass" ? "pass" : "key",
     };
     const llmPorts = this._normalizeLlmPorts(config.llmPorts ?? config.llmPort);
+    const videoPorts = this._normalizeVideoPorts(config.videoPorts);
     const role = this._normalizeRole(config);
     const isWorker = role === "worker";
     // Never keep password on the persisted object
@@ -490,6 +491,10 @@ export class SparkRegistry {
       isLocal: Boolean(config.isLocal),
       ssh,
       llmPorts,
+      /** ComfyUI ports to probe. Empty = video monitoring off for this Spark. */
+      videoPorts,
+      /** Host path to the ComfyUI server log — enables sampler step progress. */
+      comfyLogPath: typeof config.comfyLogPath === "string" ? config.comfyLogPath.trim() : null,
       role,
       /** When true, this Spark is an LLM worker — no local API card / probe. */
       workerNode: isWorker,
@@ -562,5 +567,24 @@ export class SparkRegistry {
     const n = typeof value === "string" ? parseInt(value, 10) : Number(value);
     if (Number.isInteger(n) && n >= 1 && n <= 65535) return [n];
     return [LLM_PORT];
+  }
+
+  /**
+   * Normalize ComfyUI ports: validates 1–65535, deduplicates preserving order.
+   * Unlike LLM ports there is no default — absent/invalid means "off", so
+   * Sparks that predate this feature never start probing something that
+   * isn't there.
+   */
+  _normalizeVideoPorts(value) {
+    const list = Array.isArray(value) ? value : value == null ? [] : [value];
+    const seen = new Set();
+    const unique = [];
+    for (const v of list) {
+      const n = typeof v === "string" ? parseInt(v, 10) : Number(v);
+      if (!Number.isInteger(n) || n < 1 || n > 65535 || seen.has(n)) continue;
+      seen.add(n);
+      unique.push(n);
+    }
+    return unique;
   }
 }

--- a/server/sparks/__tests__/video-ports.test.js
+++ b/server/sparks/__tests__/video-ports.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SparkRegistry } from "../SparkRegistry.js";
+import { SparkMonitor } from "../SparkMonitor.js";
+
+const r = Object.create(SparkRegistry.prototype);
+const n = (partial) =>
+  r._normalizeConfig({ id: "s6", name: "S6", lanIp: "10.0.0.6", ...partial });
+
+const m = Object.create(SparkMonitor.prototype);
+const ports = (spark) => m._videoPorts(spark);
+
+// Unlike llmPorts, videoPorts has NO default: Sparks that predate ComfyUI
+// monitoring must not start probing a port that isn't there.
+test("videoPorts defaults to empty, never to a port", () => {
+  assert.deepEqual(n({}).videoPorts, []);
+  assert.deepEqual(n({ videoPorts: null }).videoPorts, []);
+  assert.deepEqual(n({ videoPorts: [] }).videoPorts, []);
+});
+
+test("videoPorts validates range and dedupes preserving order", () => {
+  assert.deepEqual(n({ videoPorts: [8188, "8189", 8188, 0, 70000, "x"] }).videoPorts, [
+    8188, 8189,
+  ]);
+});
+
+test("videoPorts accepts a bare single value", () => {
+  assert.deepEqual(n({ videoPorts: 8188 }).videoPorts, [8188]);
+});
+
+test("comfyLogPath is trimmed, absent → null", () => {
+  assert.equal(n({ comfyLogPath: "  /var/log/comfy.log " }).comfyLogPath, "/var/log/comfy.log");
+  assert.equal(n({}).comfyLogPath, null);
+});
+
+test("monitor mirrors registry validation", () => {
+  assert.deepEqual(ports({ videoPorts: [8188, 8188, -1] }), [8188]);
+  assert.deepEqual(ports({}), []);
+  assert.deepEqual(ports(null), []);
+});
+
+test("workers never probe ComfyUI even if ports are configured", () => {
+  assert.deepEqual(ports({ role: "worker", videoPorts: [8188] }), []);
+  assert.deepEqual(ports({ workerNode: true, videoPorts: [8188] }), []);
+  assert.deepEqual(ports({ role: "head", videoPorts: [8188] }), [8188]);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ function placeholderSnapshot(
       network: null,
       unifiedMemory: null,
       llm: [],
+      comfy: [],
     },
   };
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -255,6 +255,38 @@ export function removeLlmPort(
   });
 }
 
+/** Replace the full ComfyUI (video) port list. An empty list turns monitoring off. */
+export function updateVideoPorts(
+  id: string,
+  videoPorts: number[]
+): Promise<{ success: boolean; videoPorts: number[] }> {
+  return apiFetch(`/api/sparks/${id}/video-ports`, {
+    method: "PUT",
+    body: JSON.stringify({ videoPorts }),
+  });
+}
+
+/** Add a ComfyUI (video) port to a Spark (hot update). */
+export function addVideoPort(
+  id: string,
+  port: number
+): Promise<{ success: boolean; videoPorts: number[] }> {
+  return apiFetch(`/api/sparks/${id}/video-ports`, {
+    method: "POST",
+    body: JSON.stringify({ port }),
+  });
+}
+
+/** Remove a ComfyUI (video) port. Removing the last one turns monitoring off. */
+export function removeVideoPort(
+  id: string,
+  port: number
+): Promise<{ success: boolean; videoPorts: number[] }> {
+  return apiFetch(`/api/sparks/${id}/video-ports/${port}`, {
+    method: "DELETE",
+  });
+}
+
 /** Backward-compat: replace all ports via the legacy single-port endpoint. */
 export function updateLlmPort(
   id: string,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -33,6 +33,14 @@ export interface SparkConfig {
    * The key itself is never returned by the API.
    */
   llmApiKeyPorts?: number[];
+  /** HTTP ports for ComfyUI servers on this Spark. Absent/empty = not probed. */
+  videoPorts?: number[];
+  /**
+   * Host path to the ComfyUI server log. When set, the probe parses the tqdm
+   * line from it to report sampler step progress — which the ComfyUI API does
+   * not expose to a passive observer.
+   */
+  comfyLogPath?: string | null;
   /**
    * Cluster role for overview + worker behavior.
    * - head / standalone: local LLM API probed
@@ -237,6 +245,50 @@ export interface LlmPosture {
 }
 
 // ─── Full metrics snapshot ────────────────────────────────
+// ─── ComfyUI (video generation) ───────────────────────────
+export interface ComfyOutput {
+  filename: string;
+  subfolder: string;
+  type: string;
+  mediaType: string | null;
+  finishedAt: number | null;
+}
+
+export interface ComfyJob {
+  id: string | null;
+  /** Seconds since execution started, from the server clock. */
+  elapsedSeconds: number | null;
+  /**
+   * Sampler step progress. Only populated when `comfyLogPath` is configured —
+   * ComfyUI sends progress_state only to the submitting client, so a passive
+   * monitor cannot read it from the API.
+   */
+  step: number | null;
+  steps: number | null;
+  percent: number | null;
+  secPerStep: number | null;
+  etaSeconds: number | null;
+}
+
+export interface ComfyMetrics {
+  available: boolean;
+  version: string | null;
+  pythonVersion: string | null;
+  pytorchVersion: string | null;
+  device: {
+    name: string | null;
+    vramTotal: number | null;
+    vramFree: number | null;
+    torchVramTotal: number | null;
+    torchVramFree: number | null;
+  } | null;
+  queueRunning: number;
+  queuePending: number;
+  job: ComfyJob | null;
+  lastOutput: ComfyOutput | null;
+  error: string | null;
+}
+
 export interface SparkMetrics {
   gpu: GpuMetrics | null;
   cpu: CpuMetrics | null;
@@ -246,6 +298,8 @@ export interface SparkMetrics {
   unifiedMemory: UnifiedMemoryMetrics | null;
   /** Array of LLM metrics, one per configured port. Empty array when no ports. */
   llm: LlmMetrics[];
+  /** One entry per configured video port. Empty array when none configured. */
+  comfy: ComfyMetrics[];
 }
 
 // ─── Spark snapshot (server pushes this) ──────────────────
@@ -274,6 +328,12 @@ export interface SparkSnapshot {
   llmPorts: number[];
   /** Ports with a stored LLM API key (key itself never exposed) */
   llmApiKeyPorts?: number[];
+  /** ComfyUI ports probed on this Spark. Empty = video monitoring off. */
+  videoPorts?: number[];
+  /** True when at least one video port is configured. */
+  videoMonitoring?: boolean;
+  /** Optional ComfyUI server log path used to recover sampler step progress. */
+  comfyLogPath?: string | null;
   hardware: HardwareInfo;
   metrics: SparkMetrics;
 }

--- a/src/components/OverviewPage/OverviewPage.tsx
+++ b/src/components/OverviewPage/OverviewPage.tsx
@@ -30,6 +30,15 @@ function fmtStorage(mb: number, unit: boolean): string {
   return unit ? `${s} ${label}` : s;
 }
 
+/** Seconds → "m:ss" / "h:mm:ss", for the ComfyUI render ETA tooltip. */
+function formatEta(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  return h > 0 ? `${h}:${pad(m)}:${pad(s % 60)}` : `${m}:${pad(s % 60)}`;
+}
+
 function MiniStat({
   label,
   value,
@@ -275,18 +284,63 @@ function SparkCard({
                 />
               );
             })()}
+            {(() => {
+              // ComfyUI, when a video port is configured and answering.
+              const comfy = Array.isArray(spark.metrics.comfy)
+                ? spark.metrics.comfy.find((c) => c.available)
+                : null;
+              if (!comfy) return null;
+              const job = comfy.job;
+              const value = job
+                ? job.step != null && job.steps != null
+                  ? `${job.step} / ${job.steps}`
+                  : "rendering"
+                : "idle";
+              const title = [
+                comfy.version ? `ComfyUI ${comfy.version}` : "ComfyUI",
+                job?.etaSeconds != null ? `ETA ${formatEta(job.etaSeconds)}` : null,
+                comfy.queuePending > 0 ? `${comfy.queuePending} queued` : null,
+              ]
+                .filter(Boolean)
+                .join(" · ");
+              return (
+                <MiniStat
+                  label="ComfyUI"
+                  value={value}
+                  tone={job ? "accent" : "default"}
+                  title={title}
+                  bold={Boolean(job)}
+                />
+              );
+            })()}
           </div>
 
           {(() => {
             const llmArr = spark.metrics.llm;
             const llm = Array.isArray(llmArr) ? llmArr.find((l) => l.available) : null;
-            if (!llm) return null;
+            const comfy = Array.isArray(spark.metrics.comfy)
+              ? spark.metrics.comfy.find((c) => c.available && c.job)
+              : null;
+            const percent = comfy?.job?.percent ?? null;
+            if (!llm && percent == null) return null;
             return (
-              <div className="mt-3.5 border-t border-border pt-3 text-center">
-                <span className="font-tabular text-[28px] font-bold leading-none text-text-strong">
-                  {llm.generationTps.toFixed(0)}
-                </span>
-                <span className="text-sm font-normal text-muted"> tok/s</span>
+              <div className="mt-3.5 flex items-center justify-center gap-6 border-t border-border pt-3 text-center">
+                {llm && (
+                  <div>
+                    <span className="font-tabular text-[28px] font-bold leading-none text-text-strong">
+                      {llm.generationTps.toFixed(0)}
+                    </span>
+                    <span className="text-sm font-normal text-muted"> tok/s</span>
+                  </div>
+                )}
+                {percent != null && (
+                  <div>
+                    <span className="font-tabular text-[28px] font-bold leading-none text-accent">
+                      {percent.toFixed(0)}
+                    </span>
+                    <span className="text-sm font-normal text-muted">% render</span>
+                  </div>
+                )}
               </div>
             );
           })()}

--- a/src/components/SparkPage/ComfyPanel.tsx
+++ b/src/components/SparkPage/ComfyPanel.tsx
@@ -1,0 +1,284 @@
+import { useState } from "react";
+import type { ComfyMetrics } from "../../api/types";
+import { updateSpark, updateVideoPorts } from "../../api/client";
+import { Panel } from "../ui/Panel";
+import { FilmIcon, GearIcon } from "../ui/icons";
+
+interface ComfyPanelProps {
+  comfy: ComfyMetrics | null;
+  sparkId: string;
+  videoPort: number;
+  /** All configured video ports — needed to rewrite the list when the port changes. */
+  videoPorts: number[];
+  comfyLogPath?: string | null;
+  onPortsChange?: (ports: number[]) => void;
+  onRemovePort?: (port: number) => void;
+  className?: string;
+}
+
+const GIB = 1024 ** 3;
+
+/** "1:23" / "1:04:12" */
+function formatDuration(seconds: number | null | undefined): string {
+  if (seconds == null || !Number.isFinite(seconds) || seconds < 0) return "—";
+  const s = Math.floor(seconds);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return h > 0 ? `${h}:${pad(m)}:${pad(sec)}` : `${m}:${pad(sec)}`;
+}
+
+function formatGiB(bytes: number | null | undefined): string {
+  if (bytes == null || !Number.isFinite(bytes)) return "—";
+  return `${(bytes / GIB).toFixed(1)} GiB`;
+}
+
+export function ComfyPanel({
+  comfy,
+  sparkId,
+  videoPort,
+  videoPorts,
+  comfyLogPath,
+  onPortsChange,
+  onRemovePort,
+  className = "",
+}: ComfyPanelProps) {
+  const available = Boolean(comfy?.available);
+  const job = comfy?.job ?? null;
+  const queued = (comfy?.queueRunning ?? 0) + (comfy?.queuePending ?? 0);
+  const percent = job?.percent ?? null;
+
+  const [showSettings, setShowSettings] = useState(false);
+  const [portDraft, setPortDraft] = useState(String(videoPort));
+  const [logDraft, setLogDraft] = useState(comfyLogPath ?? "");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const parsedPort = parseInt(portDraft, 10);
+  const portInvalid = !Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535;
+  const dirty = parsedPort !== videoPort || logDraft.trim() !== (comfyLogPath ?? "");
+
+  const openSettings = () => {
+    setPortDraft(String(videoPort));
+    setLogDraft(comfyLogPath ?? "");
+    setSaveError(null);
+    setShowSettings(true);
+  };
+
+  const handleSave = async () => {
+    if (portInvalid) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      if (logDraft.trim() !== (comfyLogPath ?? "")) {
+        await updateSpark(sparkId, { comfyLogPath: logDraft.trim() });
+      }
+      if (parsedPort !== videoPort) {
+        const next = videoPorts.map((p) => (p === videoPort ? parsedPort : p));
+        const result = await updateVideoPorts(sparkId, next);
+        onPortsChange?.(result.videoPorts);
+      }
+      setShowSettings(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Panel
+      title="ComfyUI"
+      accent={available}
+      icon={<FilmIcon />}
+      className={`panel-comfy ${className}`}
+      actions={
+        <div className="flex items-center gap-1.5">
+          {onRemovePort && (
+            <button
+              type="button"
+              title={`Remove port ${videoPort}`}
+              onClick={() => onRemovePort(videoPort)}
+              className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-danger transition-colors hover:bg-danger/10"
+            >
+              <span aria-hidden>×</span>
+              Remove
+            </button>
+          )}
+          <button
+            type="button"
+            title="ComfyUI settings"
+            onClick={() => (showSettings ? setShowSettings(false) : openSettings())}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted transition-colors hover:bg-surface-hover hover:text-text"
+          >
+            <GearIcon />
+            Settings
+          </button>
+        </div>
+      }
+    >
+      {showSettings ? (
+        <div className="space-y-3">
+          <label className="block space-y-1">
+            <span className="text-xs text-muted">ComfyUI port</span>
+            <input
+              type="number"
+              min={1}
+              max={65535}
+              inputMode="numeric"
+              value={portDraft}
+              onChange={(e) => {
+                setPortDraft(e.target.value);
+                setSaveError(null);
+              }}
+              className="w-full rounded-md border border-border bg-surface-elevated px-3 py-1.5 font-tabular text-sm text-text outline-none focus:border-accent"
+            />
+          </label>
+          <label className="block space-y-1">
+            <span className="text-xs text-muted">Server log path (optional)</span>
+            <input
+              type="text"
+              spellCheck={false}
+              placeholder="/path/to/comfyui.log"
+              value={logDraft}
+              onChange={(e) => {
+                setLogDraft(e.target.value);
+                setSaveError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleSave();
+                }
+              }}
+              className="w-full rounded-md border border-border bg-surface-elevated px-3 py-1.5 font-mono text-xs text-text outline-none focus:border-accent"
+            />
+          </label>
+          <p className="text-[10px] leading-snug text-muted">
+            ComfyUI sends sampler progress only to the client that submitted the prompt, so
+            step counts can’t be read from its API. Point this at the server log and the
+            panel will show “step / steps”, s/step and ETA. Leave blank to skip.
+          </p>
+          {portInvalid && (
+            <p className="text-[10px] text-danger">Enter an integer between 1 and 65535</p>
+          )}
+          {saveError && <p className="text-[10px] text-danger">{saveError}</p>}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setShowSettings(false)}
+              disabled={saving}
+              className="rounded border border-border px-2 py-1 text-[10px] text-muted hover:bg-surface-hover disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={saving || portInvalid || !dirty}
+              className="rounded bg-accent px-2 py-1 text-[10px] font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </div>
+      ) : !available ? (
+        <div className="flex flex-wrap items-center gap-2 py-1">
+          <span className="h-1.5 w-1.5 rounded-full bg-muted" />
+          <p className="text-xs text-muted">
+            {comfy?.error || "ComfyUI not reachable"}
+          </p>
+          <span className="shrink-0 font-tabular text-[10px] text-muted">:{videoPort}</span>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span className="llm-badge">
+              <span className="h-1.5 w-1.5 rounded-full bg-accent" />
+              {comfy?.version ? `v${comfy.version}` : "ComfyUI"}
+            </span>
+            {comfy?.pytorchVersion && (
+              <span className="text-xs text-muted">torch {comfy.pytorchVersion}</span>
+            )}
+            <span className="ml-auto shrink-0 font-tabular text-[10px] text-muted">
+              :{videoPort}
+            </span>
+          </div>
+
+          {/* Job state — a progress bar only when the log gave us steps. */}
+          {job ? (
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs text-muted">
+                  {job.step != null && job.steps != null
+                    ? `Sampling ${job.step} / ${job.steps}`
+                    : "Rendering"}
+                </span>
+                <span className="font-tabular text-sm font-semibold text-accent">
+                  {formatDuration(job.elapsedSeconds)}
+                </span>
+              </div>
+              {percent != null && (
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-surface-elevated">
+                  <div
+                    className="h-full rounded-full bg-accent transition-[width] duration-500"
+                    style={{ width: `${Math.min(100, Math.max(0, percent))}%` }}
+                  />
+                </div>
+              )}
+              <div className="flex items-center justify-between text-[10px] text-muted">
+                <span className="truncate font-mono" title={job.id ?? undefined}>
+                  {job.id ? job.id.slice(0, 8) : "—"}
+                </span>
+                <span className="font-tabular">
+                  {job.secPerStep != null ? `${job.secPerStep.toFixed(1)} s/step` : ""}
+                  {job.etaSeconds != null ? ` · ETA ${formatDuration(job.etaSeconds)}` : ""}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted">Status</span>
+              <span className="font-tabular text-sm text-text">Idle</span>
+            </div>
+          )}
+
+          <div className="grid grid-cols-3 gap-2 border-t border-border pt-3">
+            <div className="space-y-0.5">
+              <div className="text-[10px] uppercase tracking-wide text-muted">Queue</div>
+              <div className="font-tabular text-sm text-text">
+                {queued > 0
+                  ? `${comfy?.queueRunning ?? 0} / ${queued}`
+                  : "—"}
+              </div>
+            </div>
+            <div className="space-y-0.5">
+              <div className="text-[10px] uppercase tracking-wide text-muted">VRAM free</div>
+              <div className="font-tabular text-sm text-text">
+                {formatGiB(comfy?.device?.vramFree)}
+              </div>
+            </div>
+            <div className="space-y-0.5">
+              <div className="text-[10px] uppercase tracking-wide text-muted">Torch alloc</div>
+              <div className="font-tabular text-sm text-text">
+                {comfy?.device?.torchVramTotal != null && comfy?.device?.torchVramFree != null
+                  ? formatGiB(comfy.device.torchVramTotal - comfy.device.torchVramFree)
+                  : "—"}
+              </div>
+            </div>
+          </div>
+
+          {comfy?.lastOutput && (
+            <div
+              className="truncate border-t border-border pt-2 text-[10px] text-muted"
+              title={`${comfy.lastOutput.subfolder ? `${comfy.lastOutput.subfolder}/` : ""}${comfy.lastOutput.filename}`}
+            >
+              Last output: {comfy.lastOutput.filename}
+            </div>
+          )}
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -1,13 +1,21 @@
 import { useState, useEffect, useCallback } from "react";
 import type { SparkSnapshot } from "../../api/types";
 import { isLlmMonitoringEnabled } from "../../api/sparkRole";
-import { updateSpark, refreshSparkMetric, addLlmPort, removeLlmPort } from "../../api/client";
+import {
+  updateSpark,
+  refreshSparkMetric,
+  addLlmPort,
+  removeLlmPort,
+  addVideoPort,
+  removeVideoPort,
+} from "../../api/client";
 import { SparkHeader } from "./SparkHeader";
 import { GpuPanel } from "./GpuPanel";
 import { CpuPanel } from "./CpuPanel";
 import { StoragePanel } from "./StoragePanel";
 import { NetworkPanel } from "./NetworkPanel";
 import { LlmPanel } from "./LlmPanel";
+import { ComfyPanel } from "./ComfyPanel";
 
 interface SparkPageProps {
   spark: SparkSnapshot;
@@ -25,8 +33,11 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
   const [storagePollDisabled, setStoragePollDisabled] = useState<boolean>(
     spark.storagePollDisabled ?? false
   );
+  const [videoPorts, setVideoPorts] = useState<number[]>(spark.videoPorts ?? []);
   const [showAddPort, setShowAddPort] = useState(false);
   const [newPortDraft, setNewPortDraft] = useState("");
+  const [showAddVideoPort, setShowAddVideoPort] = useState(false);
+  const [newVideoPortDraft, setNewVideoPortDraft] = useState("");
 
   // Sync when spark data changes (WS push)
   useEffect(() => {
@@ -40,6 +51,10 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
   useEffect(() => {
     if (spark.llmPorts) setLlmPorts(spark.llmPorts);
   }, [spark.llmPorts]);
+
+  useEffect(() => {
+    if (spark.videoPorts) setVideoPorts(spark.videoPorts);
+  }, [spark.videoPorts]);
 
   useEffect(() => {
     setStoragePollDisabled(spark.storagePollDisabled ?? false);
@@ -81,6 +96,33 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
       console.error("Failed to add LLM port:", err);
     }
   }, [spark.id, newPortDraft, llmPorts]);
+
+  const handleAddVideoPort = useCallback(async () => {
+    const port = parseInt(newVideoPortDraft, 10);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) return;
+    if (videoPorts.includes(port)) {
+      setNewVideoPortDraft("");
+      setShowAddVideoPort(false);
+      return;
+    }
+    try {
+      const result = await addVideoPort(spark.id, port);
+      setVideoPorts(result.videoPorts);
+      setNewVideoPortDraft("");
+      setShowAddVideoPort(false);
+    } catch (err) {
+      console.error("Failed to add ComfyUI port:", err);
+    }
+  }, [spark.id, newVideoPortDraft, videoPorts]);
+
+  const handleRemoveVideoPort = useCallback(async (port: number) => {
+    try {
+      const result = await removeVideoPort(spark.id, port);
+      setVideoPorts(result.videoPorts);
+    } catch (err) {
+      console.error("Failed to remove ComfyUI port:", err);
+    }
+  }, [spark.id]);
 
   const handleRemovePort = useCallback(async (port: number) => {
     try {
@@ -180,6 +222,68 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
               </button>
             )}
           </>
+        )}
+        {videoPorts.map((port, i) => (
+          <ComfyPanel
+            key={port}
+            comfy={metrics.comfy?.[i] ?? null}
+            sparkId={spark.id}
+            videoPort={port}
+            videoPorts={videoPorts}
+            comfyLogPath={spark.comfyLogPath}
+            onPortsChange={setVideoPorts}
+            onRemovePort={handleRemoveVideoPort}
+            className="md:col-span-2"
+          />
+        ))}
+        {showAddVideoPort ? (
+          <div className="md:col-span-2 rounded-lg border border-border bg-surface p-3">
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                min={1}
+                max={65535}
+                inputMode="numeric"
+                placeholder="ComfyUI port (e.g. 8188)"
+                value={newVideoPortDraft}
+                onChange={(e) => setNewVideoPortDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void handleAddVideoPort();
+                  }
+                }}
+                className="w-48 rounded-md border border-border bg-surface-elevated px-3 py-1.5 font-tabular text-sm text-text outline-none focus:border-accent"
+                autoFocus
+              />
+              <button
+                type="button"
+                onClick={() => void handleAddVideoPort()}
+                disabled={!newVideoPortDraft.trim()}
+                className="rounded bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+              >
+                Add
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowAddVideoPort(false);
+                  setNewVideoPortDraft("");
+                }}
+                className="rounded border border-border px-3 py-1.5 text-xs text-muted hover:bg-surface-hover"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setShowAddVideoPort(true)}
+            className="md:col-span-2 rounded-lg border border-dashed border-border bg-transparent p-3 text-xs text-muted transition-colors hover:border-accent hover:text-accent"
+          >
+            + Add ComfyUI port
+          </button>
         )}
       </div>
     </div>

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -165,6 +165,15 @@ export function BoltIcon({ className = "" }: { className?: string }) {
   );
 }
 
+export function FilmIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg {...baseProps(className)}>
+      <rect x="2" y="4" width="20" height="16" rx="2" />
+      <path d="M7 4v16M17 4v16M2 9h5M2 15h5M17 9h5M17 15h5" />
+    </svg>
+  );
+}
+
 export function RotateIcon({ className = "" }: { className?: string }) {
   return (
     <svg {...baseProps(className)}>


### PR DESCRIPTION
## What

Optional **ComfyUI monitoring**, sitting next to the existing LLM probes. On a Spark that also runs diffusion/video workloads you now see queue depth, the running job, sampler progress and ComfyUI's VRAM footprint — on the Spark page and on the Overview card.

Entirely opt-in: nothing changes for an install that doesn't configure a video port.

## Design notes

**`videoPorts` has no default.** `llmPorts` falls back to `LLM_PORT`, but doing the same here would make every existing Spark start hammering a port that isn't listening. An absent or empty list means monitoring is simply off. Worker-role Sparks are never probed.

**Sampler step progress can't come from the API.** ComfyUI sends `progress_state` only to the WebSocket client that submitted the prompt (`comfy_execution/progress.py`), so a passive observer can never read "14 / 20" from `/queue`, `/history` or the WS. The probe therefore takes an *optional* `comfyLogPath`, tails the last 8 KiB of ComfyUI's stdout log and parses the tqdm line for step / steps / s-per-step / ETA — through the host root mount for local Sparks, over SSH for remote ones. Without it the panel still shows *Rendering* plus elapsed time, just no progress bar. This is documented in the code, the README and the panel's own settings popover.

**Configurable from the UI**, so nothing is hardcoded to one machine: `+ Add ComfyUI port` mirrors `+ Add LLM port`, and the panel's *Settings* popover edits both the port and the log path.

## Changes

**Server**
- `server/collectors/ComfyProbe.js` — polls `/system_stats`, `/queue`, `/api/jobs`; returns version, torch/python, device VRAM total/free, torch allocator VRAM, running/pending counts, current job, last output.
- One probe per video port on its own interval — `POLL_INTERVAL_COMFY`, default 3000 ms (queue state moves on job boundaries, not per token).
- `PUT` / `POST` / `DELETE /api/sparks/:id/video-ports` for hot reconfiguration; an empty `PUT` turns monitoring back off.
- `comfyLogPath` normalized in `SparkRegistry` and exposed on the snapshot.

**UI**
- `ComfyPanel` on the Spark page — version badge, job state with a progress bar when steps are known, queue / VRAM free / torch alloc, last output filename, settings popover.
- Overview card: ComfyUI mini-stat plus a `% render` entry next to tok/s.

**Docs** — Features row, REST table rows, two env vars, and a *ComfyUI probe* section under "How it works".

## Tests

20 new tests (tqdm parsing incl. `it/s` inversion and unknown ETA, probe host/port wiring, unreachable server, port normalization/dedupe/range, worker exclusion). Full suite **100/100**.

## Verification

Run against a DGX Spark (GB10) with vLLM on :8001 and ComfyUI 0.30.0 on :8188 concurrently — idle, mid-render (`19/20`, 5.83 s/step, ETA 5 s) and back to idle; LLM panel unaffected, no console errors.
