### PR TITLE
fix(bench): surface ttftContentMs + reasoningChunks for reasoning models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format: version sections are listed newest first.
 
 ---
 
+## [Unreleased]
+
+### Added
+- **ComfyUI monitoring** — opt-in per Spark (`comfyMonitoring`, default port **8188**); Edit Spark checkbox + inline port; probe `/system_stats` + `/queue`; Spark page card shows **active/queued jobs** (workflow title, models, size/steps footprint) rather than host RAM/VRAM; connectivity Test includes ComfyUI when enabled
+
+### Changed
+- **Compact UI is the default** layout density (`density: "compact"`); comfortable remains available via Settings
+
+---
+
 ## [1.5.0] — 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ Format: version sections are listed newest first.
 ## [Unreleased]
 
 ### Added
-- **ComfyUI monitoring** — opt-in per Spark (`comfyMonitoring`, default port **8188**); Edit Spark checkbox + inline port; probe `/system_stats` + `/queue`; Spark page card shows **active/queued jobs** (workflow title, models, size/steps footprint) rather than host RAM/VRAM; connectivity Test includes ComfyUI when enabled
+- **ComfyUI monitoring** — opt-in per Spark (`comfyMonitoring`, default port **8188**); Edit Spark checkbox + inline port; probe `/system_stats` + `/queue`; job-centric Spark card
+- **ComfyUI live progress** — WebSocket when available, elapsed/avg estimate otherwise; progress bar on running job
+- **ComfyUI last job** — completed/failed/cancelled duration from `/api/jobs` (history fallback)
+- **ComfyUI cancel** — `POST /api/sparks/:id/comfy/cancel` to interrupt running or remove pending jobs
+- **ComfyUI Open link** — deep link to probe host:`port`
+- **Overview Comfy chip** — idle / run / Nq / offline when monitoring enabled
+- **ComfyUI model inventory** — checkpoints + loras from `/models/*`
+- **ComfyUI queue ETA** — estimate from recent job durations × pending (+ progress)
+- Collapsible **Resources** / **Services** sections; LLM+Comfy 2-column Services layout
 
 ### Changed
 - **Compact UI is the default** layout density (`density: "compact"`); comfortable remains available via Settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,28 @@ Format: version sections are listed newest first.
 
 ---
 
-## [Unreleased]
+## [1.6.0] — 2026-08-07
 
 ### Added
-- **ComfyUI monitoring** — opt-in per Spark (`comfyMonitoring`, default port **8188**); Edit Spark checkbox + inline port; probe `/system_stats` + `/queue`; job-centric Spark card
-- **ComfyUI live progress** — WebSocket when available, elapsed/avg estimate otherwise; progress bar on running job
-- **ComfyUI last job** — completed/failed/cancelled duration from `/api/jobs` (history fallback)
-- **ComfyUI cancel** — `POST /api/sparks/:id/comfy/cancel` to interrupt running or remove pending jobs
-- **ComfyUI Open link** — deep link to probe host:`port`
-- **Overview Comfy chip** — idle / run / Nq / offline when monitoring enabled
-- **ComfyUI model inventory** — checkpoints + loras from `/models/*`
-- **ComfyUI queue ETA** — estimate from recent job durations × pending (+ progress)
-- Collapsible **Resources** / **Services** sections; LLM+Comfy 2-column Services layout
+- **ComfyUI monitoring** — opt-in per Spark (`comfyMonitoring`, default port **8188**); Edit Spark checkbox + inline port field; connectivity Test includes ComfyUI when enabled
+- **ComfyUI probe** — `GET /system_stats` + `GET /queue` (job-centric card; no host RAM/VRAM duplicate of GPU/CPU panels)
+- **Active / queued jobs** — workflow title, model weight names from the graph, footprint (resolution · steps · sampler · batch · node count)
+- **Live progress** — Comfy WebSocket when events are available; elapsed/avg-duration estimate otherwise; progress bar on the running job
+- **Last finished job** — status + duration from `/api/jobs` (with `/history` fallback)
+- **Cancel / remove** — `POST /api/sparks/:id/comfy/cancel` to interrupt a running job or dequeue a pending one from the card
+- **Open ComfyUI** — deep link to `http://{lanIp}:{comfyPort}` (LAN IP preferred over localhost for remote browsers)
+- **Overview Comfy chip** — `Comfy · idle` / `run` / `Nq` / muted when unreachable (only when monitoring is on)
+- **Model inventory** — checkpoints + LoRAs from `/models/*` (section hidden when both lists are empty)
+- **Queue ETA** — estimate from recent job durations × pending (+ progress remainder when known)
+- **Collapsible sections** — **Resources** (GPU / CPU / Storage / Network) and **Services** (LLM / ComfyUI); open state persisted in `localStorage`
+- **Services layout** — primary LLM + ComfyUI side-by-side when both enabled; +1 extra LLM full-width; +2 extras as a pair; odd leftover full-width
 
 ### Changed
-- **Compact UI is the default** layout density (`density: "compact"`); comfortable remains available via Settings
+- **Compact UI is the default** layout density (`density: "compact"` in settings + CSS/`data-density`); comfortable remains available via Settings
+- Spark snapshot includes **`lanIp`** / **`isLocal`** for client deep-links
+
+### Fixed
+- Comfy progress WebSocket soft-reconnects on host/port change (no longer permanently closed after `setTarget`)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ sparkDash is a real-time web dashboard for one or more **NVIDIA DGX Spark (GB10)
 
 ## Latest version changelog
 
-### Version 1.5.0 — GPU thermal throttle meter
-- **Throttle signal** — NVIDIA `clocks_throttle_reasons` (thermal / HW / power cap) + SM clock headroom from `nvidia-smi` (local + remote)
-- **GPU panel** — Throttle chip (`OK` / `Thermal` / `Power` / `HW`) with SM clock bar and reason tooltip
-- **Overview** — red “Thermal throttle” hint when any Spark is thermally throttling
+### Version 1.6.0 — ComfyUI monitoring & compact default
+- **ComfyUI** — opt-in per Spark (port 8188): live jobs, progress, last run, cancel, queue ETA, Open on LAN IP, model inventory
+- **Overview** — Comfy status chip (`idle` / `run` / `Nq`)
+- **Layout** — collapsible Resources / Services; LLM + Comfy side-by-side; multi-LLM row rules
+- **Compact UI** — default density (comfortable still in Settings)
 
 Full history: [CHANGELOG.md](./CHANGELOG.md)
 
@@ -63,6 +64,7 @@ Full history: [CHANGELOG.md](./CHANGELOG.md)
 | **Live streaming** | WebSocket metrics with configurable poll intervals; central history store for sparklines across tab switches |
 | **Local + remote** | Host metrics via sysfs/proc/`nvidia-smi`; remotes over SSH (key or password) |
 | **LLM probe** | Auto-detects llama.cpp, vLLM, sglang, or ds4-server; live tok/s per server |
+| **ComfyUI** | Opt-in probe: queue/jobs, progress, cancel, Open link, inventory, overview chip |
 | **Decode benchmark** | Multi-concurrency streaming decode tok/s (server + per-stream), persisted last run |
 | **Prompt Showcase** | Full-page multi-terminal LLM streaming demo (up to 32 prompts) with live tok/s and copy-out |
 | **vLLM health** | KV cache %, run/wait queue, TTFT/E2E/ITL p95, preemptions, prefix cache, MTP accept from Prometheus `/metrics` |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,64 @@ Full history: [CHANGELOG.md](./CHANGELOG.md)
 
 ---
 
+## ComfyUI monitoring
+
+sparkDash can **optionally** monitor a [ComfyUI](https://github.com/comfyanonymous/ComfyUI) instance on each Spark — the same way it probes local LLMs, but focused on **jobs and queue**, not a second copy of GPU/RAM bars (those stay on the GPU / CPU panels).
+
+### What is supported
+
+| Capability | Details |
+|------------|---------|
+| **Opt-in per Spark** | `comfyMonitoring` (default **off**) + `comfyPort` (default **8188**) |
+| **Any role** | Head, worker, and standalone can enable ComfyUI independently of LLM cluster role |
+| **Liveness** | `GET /system_stats` — online, ComfyUI / PyTorch version, device type (cpu/cuda) |
+| **Queue / jobs** | `GET /queue` — running + pending items; workflow **title**, **model/LoRA** filenames from the graph, footprint (**resolution · steps · sampler · batch · node count**) |
+| **Progress** | Progress bar on the active job — Comfy WebSocket when events are available; otherwise elapsed / average-duration **estimate** |
+| **Last finished job** | Status + duration via `/api/jobs` (fallback `/history`) |
+| **Queue ETA** | Estimate from recent job durations × pending (+ progress remainder when known) |
+| **Cancel / remove** | From the Comfy card: interrupt a running job or dequeue a pending one (`POST /api/sparks/:id/comfy/cancel`) |
+| **Open ComfyUI** | One-click link to `http://{lanIp}:{comfyPort}` (LAN IP preferred so remote browsers do not hit localhost) |
+| **Model inventory** | Checkpoints + LoRAs from `/models/*` (UI section only when at least one file is listed) |
+| **Overview chip** | When monitoring is on: `Comfy · idle` / `run` / `Nq` / muted if unreachable |
+| **Layout** | Under **Services**: primary LLM + Comfy side-by-side when both are enabled; collapsible **Resources** / **Services** sections |
+
+**Not claimed:** true per-job VRAM (Comfy does not expose that cleanly over HTTP). Host GPU/VRAM remains on the GPU panel. Live step progress depends on Comfy broadcasting WS events; stock Comfy often scopes detailed progress to the client that submitted the prompt.
+
+### How to enable (per Spark)
+
+1. Open the Spark tab → **Edit** (pencil).
+2. Enable **ComfyUI monitoring**.
+3. Set **port** if needed (default **8188**).
+4. **Save**.
+
+The Spark page **Services** section shows the ComfyUI card. On Overview, a small Comfy chip appears for that unit.
+
+**Connectivity Test** (in Edit) includes ComfyUI when monitoring is enabled.
+
+### ComfyUI side requirements
+
+- ComfyUI must be reachable from the **sparkDash server** on the probe host:
+  - **Local Spark** (`isLocal`): sparkDash probes `127.0.0.1:{port}` (use Docker `network_mode: host` if the dashboard runs in a container).
+  - **Remote Spark**: probe uses the Spark **LAN IP** (same as LLM probes).
+- For **Open** from another machine’s browser, Comfy should listen on a reachable interface (e.g. `--listen 0.0.0.0`), not only loopback, and the Spark’s **LAN IP** must be set correctly in Edit.
+
+### Config fields (persisted on the Spark)
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `comfyMonitoring` | `false` | Probe ComfyUI and show the card / overview chip |
+| `comfyPort` | `8188` | ComfyUI HTTP port |
+
+### Related API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/api/sparks/:id/comfy/cancel` | Cancel a job (`{ "promptId": "<uuid>" }`) — interrupt running and/or remove from queue |
+
+Env (optional): `COMFY_PORT` (default `8188`), `COMFY_PROBE_TIMEOUT_MS`, `POLL_INTERVAL_COMFY`.
+
+---
+
 ## Quick start
 
 ```bash
@@ -185,8 +243,9 @@ sparkDash/
 | DELETE | `/api/sparks/:id` | Remove Spark and drain monitor |
 | PUT | `/api/sparks/order` | Persist tab order |
 | GET | `/api/sparks/:id/metrics` | One-shot metrics snapshot |
-| POST | `/api/sparks/test` | Ephemeral SSH + LLM test (no persist) |
+| POST | `/api/sparks/test` | Ephemeral SSH + LLM (+ Comfy if enabled) test (no persist) |
 | POST | `/api/sparks/:id/test` | Connectivity test (can save password) |
+| POST | `/api/sparks/:id/comfy/cancel` | Cancel ComfyUI job by `promptId` |
 | PUT | `/api/sparks/:id/password` | Save SSH password (works offline) |
 | PUT | `/api/sparks/:id/disabled-devices` | Hide storage devices (hot) |
 | PUT | `/api/sparks/:id/disabled-interfaces` | Hide network interfaces (hot) |
@@ -224,7 +283,9 @@ Copy `.env.example` to `.env` if needed:
 | `BIND_HOST` | `0.0.0.0` | HTTP and WebSocket listen address |
 | `PORT` | `5555` | HTTP + WebSocket listen port |
 | `LLM_PORT` | `8888` | Default LLM probe port |
+| `COMFY_PORT` | `8188` | Default ComfyUI probe port |
 | `POLL_INTERVAL_GPU` | `2000` | GPU poll (ms) |
+| `POLL_INTERVAL_COMFY` | `2000` | ComfyUI probe poll (ms) |
 | `POLL_INTERVAL_CPU` | `2000` | CPU / RAM poll (ms) |
 | `POLL_INTERVAL_NETWORK` | `2000` | Network poll (ms) |
 | `POLL_INTERVAL_STORAGE` | `5000` | Storage poll (ms) |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ sparkDash is a real-time web dashboard for one or more **NVIDIA DGX Spark (GB10)
 
 - [Latest version changelog](#latest-version-changelog)
 - [Features](#features)
+- [ComfyUI monitoring](#comfyui-monitoring)
 - [Full changelog](./CHANGELOG.md)
 - [Quick start](#quick-start)
 - [Architecture](#architecture)

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="dark" data-density="compact">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparkdash",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparkdash",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkdash",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "sparkDash — Multi-DGX Spark Monitoring Dashboard",
   "type": "module",
   "scripts": {

--- a/server/collectors/ComfyProbe.js
+++ b/server/collectors/ComfyProbe.js
@@ -1,15 +1,18 @@
 /**
  * ComfyProbe — polls a local ComfyUI HTTP server (default port 8188).
  *
- * Focus: what is running (job / workflow footprint), not host RAM/VRAM
- * (those already live on GPU / CPU panels).
+ * Focus: jobs, progress, inventory — not host RAM/VRAM.
  *
- * Endpoints (stock ComfyUI):
- *   GET /system_stats — reachability + version
- *   GET /queue        — running / pending items with full prompt graph
+ * Endpoints:
+ *   GET /system_stats
+ *   GET /queue
+ *   GET /api/jobs (fallback /history)
+ *   GET /models/checkpoints, /models/loras
+ *   WS  /ws (optional live progress — often client-scoped in Comfy)
  */
 import { COMFY_PROBE_TIMEOUT_MS, COMFY_PORT } from "../config.js";
 import { llmProbeHost } from "./llmHost.js";
+import { ComfyProgressSocket } from "./ComfyProgressSocket.js";
 
 /**
  * @param {unknown} n
@@ -28,6 +31,10 @@ function basename(path) {
 }
 
 const MODEL_FILE_RE = /\.(safetensors|sft|ckpt|pt|bin|gguf|pth|onnx)$/i;
+const MODELS_TTL_MS = 45_000;
+const HISTORY_TTL_MS = 8_000;
+const AVG_SAMPLES = 8;
+const ETA_FALLBACK_MS = 60_000;
 
 /**
  * Summarize a ComfyUI prompt graph into human-facing workload fields.
@@ -49,6 +56,8 @@ export function summarizeComfyPrompt(prompt) {
   let sampler = null;
   /** @type {Record<string, number>} */
   const classCounts = {};
+  /** @type {Record<string, string>} */
+  const nodeLabels = {};
 
   if (!prompt || typeof prompt !== "object" || Array.isArray(prompt)) {
     return {
@@ -60,17 +69,19 @@ export function summarizeComfyPrompt(prompt) {
       batchSize: null,
       sampler: null,
       classCounts: {},
+      nodeLabels: {},
     };
   }
 
-  for (const node of Object.values(prompt)) {
+  for (const [nid, node] of Object.entries(prompt)) {
     if (!node || typeof node !== "object") continue;
     nodeCount += 1;
     const ct =
-      /** @type {{ class_type?: unknown, inputs?: unknown }} */ (node).class_type != null
+      /** @type {{ class_type?: unknown }} */ (node).class_type != null
         ? String(/** @type {{ class_type?: unknown }} */ (node).class_type)
         : "Unknown";
     classCounts[ct] = (classCounts[ct] || 0) + 1;
+    nodeLabels[String(nid)] = ct;
     const inputs = /** @type {{ inputs?: Record<string, unknown> }} */ (node).inputs;
     if (!inputs || typeof inputs !== "object") continue;
 
@@ -97,7 +108,6 @@ export function summarizeComfyPrompt(prompt) {
     }
   }
 
-  // Dedupe models, preserve order
   const seen = new Set();
   const uniqueModels = [];
   for (const m of models) {
@@ -115,11 +125,36 @@ export function summarizeComfyPrompt(prompt) {
     batchSize,
     sampler,
     classCounts,
+    nodeLabels,
   };
 }
 
 /**
- * @param {unknown} item queue tuple from /queue
+ * Estimate queue ETA from average job duration and optional live progress.
+ * @param {{ avgDurationMs: number, queuePending: number, running: boolean, progressPercent: number | null }} p
+ */
+export function estimateQueueEtaMs({
+  avgDurationMs,
+  queuePending,
+  running,
+  progressPercent,
+}) {
+  const avg =
+    Number.isFinite(avgDurationMs) && avgDurationMs > 0 ? avgDurationMs : ETA_FALLBACK_MS;
+  let runningRemaining = 0;
+  if (running) {
+    if (progressPercent != null && Number.isFinite(progressPercent)) {
+      runningRemaining = avg * (1 - Math.min(100, Math.max(0, progressPercent)) / 100);
+    } else {
+      runningRemaining = avg * 0.5;
+    }
+  }
+  const pending = Math.max(0, Number(queuePending) || 0);
+  return Math.round(runningRemaining + pending * avg);
+}
+
+/**
+ * @param {unknown} item
  * @param {"running" | "pending"} status
  */
 function normalizeQueueJob(item, status) {
@@ -142,11 +177,6 @@ function normalizeQueueJob(item, status) {
   } catch {
     /* ignore */
   }
-  if (!title && typeof extra.client_id === "string" && extra.client_id) {
-    // weak fallback — usually not useful; leave null
-  }
-
-  const createTime = numOrNull(extra.create_time);
 
   return {
     id: promptId,
@@ -159,7 +189,40 @@ function normalizeQueueJob(item, status) {
     height: summary.height,
     batchSize: summary.batchSize,
     sampler: summary.sampler,
-    createTime,
+    createTime: numOrNull(extra.create_time),
+    _nodeLabels: summary.nodeLabels,
+  };
+}
+
+/**
+ * @param {object} job from /api/jobs
+ */
+function normalizeApiJob(job) {
+  if (!job || typeof job !== "object" || job.id == null) return null;
+  const statusRaw = String(job.status || "").toLowerCase();
+  let status = "completed";
+  if (statusRaw === "failed") status = "failed";
+  else if (statusRaw === "cancelled") status = "cancelled";
+  else if (statusRaw === "completed" || statusRaw === "success") status = "completed";
+  else status = statusRaw || "completed";
+
+  const start = numOrNull(job.execution_start_time);
+  const end = numOrNull(job.execution_end_time);
+  let durationMs = null;
+  if (start != null && end != null && end >= start) durationMs = end - start;
+
+  /** @type {string | null} */
+  let title = null;
+  if (job.workflow_id != null && String(job.workflow_id).trim()) {
+    title = String(job.workflow_id).trim();
+  }
+
+  return {
+    id: String(job.id),
+    status,
+    title,
+    durationMs,
+    endedAt: end,
   };
 }
 
@@ -173,9 +236,13 @@ export class ComfyProbe {
     this.port = Number.isInteger(port) && port >= 1 && port <= 65535 ? port : COMFY_PORT;
     this.baseUrl = `http://${llmProbeHost(spark)}:${this.port}`;
     this.error = null;
+    this._progress = new ComfyProgressSocket(spark, this.port);
+    /** @type {{ checkpoints: string[], loras: string[], fetchedAt: number } | null} */
+    this._modelsCache = null;
+    /** @type {{ lastJob: object | null, durationsMs: number[], fetchedAt: number } | null} */
+    this._historyCache = null;
   }
 
-  /** Update port / host from current spark config. */
   setTarget(spark, port) {
     this.spark = spark ?? this.spark;
     const next = Number(port);
@@ -183,10 +250,22 @@ export class ComfyProbe {
       this.port = next;
     }
     this.baseUrl = `http://${llmProbeHost(this.spark)}:${this.port}`;
+    this._progress.setTarget(this.spark, this.port);
+    this._modelsCache = null;
+    this._historyCache = null;
+  }
+
+  /** Tear down WS when monitoring disabled. */
+  dispose() {
+    this._progress.close();
+  }
+
+  openUrl() {
+    const host = llmProbeHost(this.spark);
+    return `http://${host}:${this.port}`;
   }
 
   /**
-   * Probe ComfyUI and return a snapshot for the Spark metrics payload.
    * @returns {Promise<object>}
    */
   async probe() {
@@ -199,12 +278,14 @@ export class ComfyProbe {
 
       if (!statsRes.ok) {
         this.error = `HTTP ${statsRes.status} on /system_stats`;
+        this._progress.disconnect();
         return this._default();
       }
 
       const stats = await statsRes.json().catch(() => null);
       if (!stats || typeof stats !== "object") {
         this.error = "Invalid /system_stats response";
+        this._progress.disconnect();
         return this._default();
       }
 
@@ -226,13 +307,49 @@ export class ComfyProbe {
         }
       }
 
+      const activeJob = runningJobs[0] || null;
+      if (activeJob?._nodeLabels) {
+        this._progress.setNodeLabels(activeJob._nodeLabels);
+      }
+
+      const busy = runningJobs.length > 0 || pendingJobs.length > 0;
+      this._progress.touchActivity(busy);
+
+      // Enrich history / models (throttled)
+      await Promise.all([this._refreshHistory(signal), this._refreshModels(signal)]);
+
       const system = stats.system && typeof stats.system === "object" ? stats.system : {};
-      // Device type only (cpu/cuda) — not VRAM totals (GPU panel owns those).
       const devicesRaw = Array.isArray(stats.devices) ? stats.devices : [];
       const deviceType =
         devicesRaw[0] && typeof devicesRaw[0] === "object" && devicesRaw[0].type != null
           ? String(devicesRaw[0].type)
           : null;
+
+      let progress = this._progress.getProgress();
+      // Time-based estimate when no live WS progress
+      if (busy && activeJob && (!progress || progress.source !== "ws")) {
+        progress = this._syntheticProgress(activeJob) ?? progress;
+      }
+      if (!busy) {
+        // clear stale progress when idle
+        if (progress && progress.source === "estimate") progress = null;
+      }
+
+      const avgDurationMs = this._avgDurationMs();
+      const progressPercent = progress?.percent ?? null;
+      const queueEtaMs = estimateQueueEtaMs({
+        avgDurationMs,
+        queuePending: pendingJobs.length,
+        running: runningJobs.length > 0,
+        progressPercent,
+      });
+
+      // Strip internal fields from jobs
+      const cleanJob = (j) => {
+        if (!j) return null;
+        const { _nodeLabels, ...rest } = j;
+        return rest;
+      };
 
       this.error = null;
       return {
@@ -243,15 +360,158 @@ export class ComfyProbe {
         deviceType,
         queueRunning: runningJobs.length,
         queuePending: pendingJobs.length,
-        /** First running job (ComfyUI is single-executor); null when idle. */
-        activeJob: runningJobs[0] || null,
-        /** Up to a few pending jobs for “N waiting” detail. */
-        pendingJobs: pendingJobs.slice(0, 5),
+        activeJob: cleanJob(activeJob),
+        pendingJobs: pendingJobs.slice(0, 5).map(cleanJob),
+        progress,
+        lastJob: this._historyCache?.lastJob ?? null,
+        modelsInstalled: this._modelsCache
+          ? {
+              checkpoints: this._modelsCache.checkpoints,
+              loras: this._modelsCache.loras,
+            }
+          : null,
+        queueEtaMs: busy ? queueEtaMs : null,
+        openUrl: this.openUrl(),
         error: null,
       };
     } catch (err) {
       this.error = err?.message || String(err);
+      this._progress.disconnect();
       return this._default();
+    }
+  }
+
+  _syntheticProgress(activeJob) {
+    const avg = this._avgDurationMs();
+    const create = activeJob.createTime;
+    if (create == null) {
+      return {
+        promptId: activeJob.id,
+        nodeId: null,
+        nodeLabel: null,
+        value: 0,
+        max: 0,
+        percent: null,
+        updatedAt: Date.now(),
+        source: "estimate",
+      };
+    }
+    const ms = create < 1e12 ? create * 1000 : create;
+    const elapsed = Math.max(0, Date.now() - ms);
+    const percent = Math.min(99, Math.round((elapsed / avg) * 100));
+    return {
+      promptId: activeJob.id,
+      nodeId: null,
+      nodeLabel: null,
+      value: percent,
+      max: 100,
+      percent,
+      updatedAt: Date.now(),
+      source: "estimate",
+    };
+  }
+
+  _avgDurationMs() {
+    const d = this._historyCache?.durationsMs;
+    if (!Array.isArray(d) || d.length === 0) return ETA_FALLBACK_MS;
+    const sum = d.reduce((a, b) => a + b, 0);
+    return Math.max(1000, Math.round(sum / d.length));
+  }
+
+  async _refreshHistory(signal) {
+    const now = Date.now();
+    if (this._historyCache && now - this._historyCache.fetchedAt < HISTORY_TTL_MS) return;
+    try {
+      const res = await fetch(
+        `${this.baseUrl}/api/jobs?status=completed,failed,cancelled&limit=${AVG_SAMPLES}&sort_by=created_at&sort_order=desc`,
+        { signal }
+      );
+      if (res.ok) {
+        const data = await res.json().catch(() => null);
+        const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
+        const normalized = jobs.map(normalizeApiJob).filter(Boolean);
+        const durationsMs = normalized
+          .map((j) => j.durationMs)
+          .filter((n) => n != null && n > 0);
+        this._historyCache = {
+          lastJob: normalized[0] || null,
+          durationsMs,
+          fetchedAt: now,
+        };
+        return;
+      }
+    } catch {
+      /* fallback history */
+    }
+    try {
+      const res = await fetch(`${this.baseUrl}/history?max_items=1`, { signal });
+      if (!res.ok) return;
+      const data = await res.json().catch(() => null);
+      if (!data || typeof data !== "object") return;
+      const ids = Object.keys(data);
+      if (!ids.length) {
+        this._historyCache = { lastJob: null, durationsMs: [], fetchedAt: now };
+        return;
+      }
+      const id = ids[ids.length - 1];
+      const item = data[id];
+      const statusInfo = item?.status || {};
+      let start = null;
+      let end = null;
+      let status = "completed";
+      for (const entry of statusInfo.messages || []) {
+        if (!Array.isArray(entry) || entry.length < 2) continue;
+        const [ev, payload] = entry;
+        if (ev === "execution_start") start = numOrNull(payload?.timestamp);
+        if (ev === "execution_success" || ev === "execution_error" || ev === "execution_interrupted") {
+          end = numOrNull(payload?.timestamp);
+          if (ev === "execution_error") status = "failed";
+          if (ev === "execution_interrupted") status = "cancelled";
+        }
+      }
+      const durationMs =
+        start != null && end != null && end >= start ? end - start : null;
+      this._historyCache = {
+        lastJob: {
+          id,
+          status,
+          title: null,
+          durationMs,
+          endedAt: end,
+        },
+        durationsMs: durationMs != null ? [durationMs] : [],
+        fetchedAt: now,
+      };
+    } catch {
+      /* keep prior cache */
+    }
+  }
+
+  async _refreshModels(signal) {
+    const now = Date.now();
+    if (this._modelsCache && now - this._modelsCache.fetchedAt < MODELS_TTL_MS) return;
+    try {
+      const [ckRes, loraRes] = await Promise.all([
+        fetch(`${this.baseUrl}/models/checkpoints`, { signal }),
+        fetch(`${this.baseUrl}/models/loras`, { signal }),
+      ]);
+      /** @param {Response} res */
+      const list = async (res) => {
+        if (!res.ok) return [];
+        const data = await res.json().catch(() => []);
+        if (!Array.isArray(data)) return [];
+        return data
+          .map((x) => (typeof x === "string" ? basename(x) : null))
+          .filter(Boolean)
+          .slice(0, 30);
+      };
+      this._modelsCache = {
+        checkpoints: await list(ckRes),
+        loras: await list(loraRes),
+        fetchedAt: now,
+      };
+    } catch {
+      /* keep prior */
     }
   }
 
@@ -266,6 +526,11 @@ export class ComfyProbe {
       queuePending: 0,
       activeJob: null,
       pendingJobs: [],
+      progress: null,
+      lastJob: null,
+      modelsInstalled: null,
+      queueEtaMs: null,
+      openUrl: this.openUrl(),
       error: this.error,
     };
   }

--- a/server/collectors/ComfyProbe.js
+++ b/server/collectors/ComfyProbe.js
@@ -260,8 +260,21 @@ export class ComfyProbe {
     this._progress.close();
   }
 
+  /**
+   * Browser deep-link host — always prefer LAN IP so "Open" works from other
+   * machines. Probe traffic still uses llmProbeHost (loopback when isLocal).
+   */
   openUrl() {
-    const host = llmProbeHost(this.spark);
+    const lan =
+      this.spark?.lanIp != null ? String(this.spark.lanIp).trim() : "";
+    const sshHost =
+      this.spark?.ssh?.host != null ? String(this.spark.ssh.host).trim() : "";
+    const host =
+      lan ||
+      (sshHost && sshHost !== "127.0.0.1" && sshHost !== "localhost"
+        ? sshHost
+        : "") ||
+      "127.0.0.1";
     return `http://${host}:${this.port}`;
   }
 

--- a/server/collectors/ComfyProbe.js
+++ b/server/collectors/ComfyProbe.js
@@ -1,0 +1,272 @@
+/**
+ * ComfyProbe — polls a local ComfyUI HTTP server (default port 8188).
+ *
+ * Focus: what is running (job / workflow footprint), not host RAM/VRAM
+ * (those already live on GPU / CPU panels).
+ *
+ * Endpoints (stock ComfyUI):
+ *   GET /system_stats — reachability + version
+ *   GET /queue        — running / pending items with full prompt graph
+ */
+import { COMFY_PROBE_TIMEOUT_MS, COMFY_PORT } from "../config.js";
+import { llmProbeHost } from "./llmHost.js";
+
+/**
+ * @param {unknown} n
+ * @returns {number | null}
+ */
+function numOrNull(n) {
+  const v = typeof n === "string" ? Number(n) : n;
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/** @param {string} path */
+function basename(path) {
+  const s = String(path);
+  const i = Math.max(s.lastIndexOf("/"), s.lastIndexOf("\\"));
+  return i >= 0 ? s.slice(i + 1) : s;
+}
+
+const MODEL_FILE_RE = /\.(safetensors|sft|ckpt|pt|bin|gguf|pth|onnx)$/i;
+
+/**
+ * Summarize a ComfyUI prompt graph into human-facing workload fields.
+ * @param {unknown} prompt
+ */
+export function summarizeComfyPrompt(prompt) {
+  /** @type {string[]} */
+  const models = [];
+  let nodeCount = 0;
+  /** @type {number | null} */
+  let steps = null;
+  /** @type {number | null} */
+  let width = null;
+  /** @type {number | null} */
+  let height = null;
+  /** @type {number | null} */
+  let batchSize = null;
+  /** @type {string | null} */
+  let sampler = null;
+  /** @type {Record<string, number>} */
+  const classCounts = {};
+
+  if (!prompt || typeof prompt !== "object" || Array.isArray(prompt)) {
+    return {
+      models: [],
+      nodeCount: 0,
+      steps: null,
+      width: null,
+      height: null,
+      batchSize: null,
+      sampler: null,
+      classCounts: {},
+    };
+  }
+
+  for (const node of Object.values(prompt)) {
+    if (!node || typeof node !== "object") continue;
+    nodeCount += 1;
+    const ct =
+      /** @type {{ class_type?: unknown, inputs?: unknown }} */ (node).class_type != null
+        ? String(/** @type {{ class_type?: unknown }} */ (node).class_type)
+        : "Unknown";
+    classCounts[ct] = (classCounts[ct] || 0) + 1;
+    const inputs = /** @type {{ inputs?: Record<string, unknown> }} */ (node).inputs;
+    if (!inputs || typeof inputs !== "object") continue;
+
+    for (const [key, val] of Object.entries(inputs)) {
+      if (typeof val === "string" && MODEL_FILE_RE.test(val)) {
+        models.push(basename(val));
+        continue;
+      }
+      if (key === "steps" && steps == null) {
+        const n = numOrNull(val);
+        if (n != null) steps = n;
+      } else if (key === "width" && width == null) {
+        const n = numOrNull(val);
+        if (n != null) width = n;
+      } else if (key === "height" && height == null) {
+        const n = numOrNull(val);
+        if (n != null) height = n;
+      } else if (key === "batch_size" && batchSize == null) {
+        const n = numOrNull(val);
+        if (n != null) batchSize = n;
+      } else if (key === "sampler_name" && sampler == null && typeof val === "string") {
+        sampler = val;
+      }
+    }
+  }
+
+  // Dedupe models, preserve order
+  const seen = new Set();
+  const uniqueModels = [];
+  for (const m of models) {
+    if (seen.has(m)) continue;
+    seen.add(m);
+    uniqueModels.push(m);
+  }
+
+  return {
+    models: uniqueModels,
+    nodeCount,
+    steps,
+    width,
+    height,
+    batchSize,
+    sampler,
+    classCounts,
+  };
+}
+
+/**
+ * @param {unknown} item queue tuple from /queue
+ * @param {"running" | "pending"} status
+ */
+function normalizeQueueJob(item, status) {
+  if (!Array.isArray(item) || item.length < 3) return null;
+  const promptId = item[1] != null ? String(item[1]) : null;
+  if (!promptId) return null;
+  const prompt = item[2];
+  const extra = item[3] && typeof item[3] === "object" ? item[3] : {};
+  const summary = summarizeComfyPrompt(prompt);
+
+  /** @type {string | null} */
+  let title = null;
+  try {
+    const png = /** @type {{ extra_pnginfo?: { workflow?: { title?: unknown, name?: unknown } } }} */ (
+      extra
+    ).extra_pnginfo;
+    const wf = png?.workflow;
+    if (wf?.title != null && String(wf.title).trim()) title = String(wf.title).trim();
+    else if (wf?.name != null && String(wf.name).trim()) title = String(wf.name).trim();
+  } catch {
+    /* ignore */
+  }
+  if (!title && typeof extra.client_id === "string" && extra.client_id) {
+    // weak fallback — usually not useful; leave null
+  }
+
+  const createTime = numOrNull(extra.create_time);
+
+  return {
+    id: promptId,
+    status,
+    title,
+    models: summary.models,
+    nodeCount: summary.nodeCount,
+    steps: summary.steps,
+    width: summary.width,
+    height: summary.height,
+    batchSize: summary.batchSize,
+    sampler: summary.sampler,
+    createTime,
+  };
+}
+
+export class ComfyProbe {
+  /**
+   * @param {object} spark
+   * @param {number} [port]
+   */
+  constructor(spark, port = COMFY_PORT) {
+    this.spark = spark;
+    this.port = Number.isInteger(port) && port >= 1 && port <= 65535 ? port : COMFY_PORT;
+    this.baseUrl = `http://${llmProbeHost(spark)}:${this.port}`;
+    this.error = null;
+  }
+
+  /** Update port / host from current spark config. */
+  setTarget(spark, port) {
+    this.spark = spark ?? this.spark;
+    const next = Number(port);
+    if (Number.isInteger(next) && next >= 1 && next <= 65535) {
+      this.port = next;
+    }
+    this.baseUrl = `http://${llmProbeHost(this.spark)}:${this.port}`;
+  }
+
+  /**
+   * Probe ComfyUI and return a snapshot for the Spark metrics payload.
+   * @returns {Promise<object>}
+   */
+  async probe() {
+    try {
+      const signal = AbortSignal.timeout(COMFY_PROBE_TIMEOUT_MS);
+      const [statsRes, queueRes] = await Promise.all([
+        fetch(`${this.baseUrl}/system_stats`, { signal }),
+        fetch(`${this.baseUrl}/queue`, { signal }),
+      ]);
+
+      if (!statsRes.ok) {
+        this.error = `HTTP ${statsRes.status} on /system_stats`;
+        return this._default();
+      }
+
+      const stats = await statsRes.json().catch(() => null);
+      if (!stats || typeof stats !== "object") {
+        this.error = "Invalid /system_stats response";
+        return this._default();
+      }
+
+      /** @type {object[]} */
+      let runningJobs = [];
+      /** @type {object[]} */
+      let pendingJobs = [];
+      if (queueRes.ok) {
+        const queue = await queueRes.json().catch(() => null);
+        if (queue && typeof queue === "object") {
+          const runningRaw = Array.isArray(queue.queue_running) ? queue.queue_running : [];
+          const pendingRaw = Array.isArray(queue.queue_pending) ? queue.queue_pending : [];
+          runningJobs = runningRaw
+            .map((item) => normalizeQueueJob(item, "running"))
+            .filter(Boolean);
+          pendingJobs = pendingRaw
+            .map((item) => normalizeQueueJob(item, "pending"))
+            .filter(Boolean);
+        }
+      }
+
+      const system = stats.system && typeof stats.system === "object" ? stats.system : {};
+      // Device type only (cpu/cuda) — not VRAM totals (GPU panel owns those).
+      const devicesRaw = Array.isArray(stats.devices) ? stats.devices : [];
+      const deviceType =
+        devicesRaw[0] && typeof devicesRaw[0] === "object" && devicesRaw[0].type != null
+          ? String(devicesRaw[0].type)
+          : null;
+
+      this.error = null;
+      return {
+        available: true,
+        port: this.port,
+        version: system.comfyui_version != null ? String(system.comfyui_version) : null,
+        pytorchVersion: system.pytorch_version != null ? String(system.pytorch_version) : null,
+        deviceType,
+        queueRunning: runningJobs.length,
+        queuePending: pendingJobs.length,
+        /** First running job (ComfyUI is single-executor); null when idle. */
+        activeJob: runningJobs[0] || null,
+        /** Up to a few pending jobs for “N waiting” detail. */
+        pendingJobs: pendingJobs.slice(0, 5),
+        error: null,
+      };
+    } catch (err) {
+      this.error = err?.message || String(err);
+      return this._default();
+    }
+  }
+
+  _default() {
+    return {
+      available: false,
+      port: this.port,
+      version: null,
+      pytorchVersion: null,
+      deviceType: null,
+      queueRunning: 0,
+      queuePending: 0,
+      activeJob: null,
+      pendingJobs: [],
+      error: this.error,
+    };
+  }
+}

--- a/server/collectors/ComfyProgressSocket.js
+++ b/server/collectors/ComfyProgressSocket.js
@@ -1,0 +1,315 @@
+/**
+ * ComfyProgressSocket — optional WebSocket client to a ComfyUI server.
+ *
+ * Note: stock ComfyUI sends `progress` / `progress_state` / many `executing`
+ * events only to the clientId that submitted the prompt. A monitor socket
+ * still receives `status` broadcasts; live step progress appears when Comfy
+ * broadcasts (client_id null) or when we observe messages. UI falls back to
+ * time-based estimates when no live frames arrive.
+ */
+import { randomUUID } from "crypto";
+import WebSocket from "ws";
+import { llmProbeHost } from "./llmHost.js";
+
+const IDLE_CLOSE_MS = 45_000;
+const RECONNECT_MIN_MS = 1_000;
+const RECONNECT_MAX_MS = 15_000;
+
+/**
+ * Reduce a Comfy WS JSON message into progress state.
+ * @param {object | null} prev
+ * @param {{ type?: string, data?: object }} msg
+ * @param {Record<string, string>} [nodeLabels] nodeId → class_type
+ * @returns {object | null}
+ */
+export function reduceComfyProgressMessage(prev, msg, nodeLabels = {}) {
+  if (!msg || typeof msg !== "object") return prev;
+  const type = msg.type;
+  const data = msg.data && typeof msg.data === "object" ? msg.data : {};
+
+  if (type === "execution_start") {
+    return {
+      promptId: data.prompt_id != null ? String(data.prompt_id) : prev?.promptId ?? null,
+      nodeId: null,
+      nodeLabel: null,
+      value: 0,
+      max: 0,
+      percent: null,
+      updatedAt: Date.now(),
+      source: "ws",
+    };
+  }
+
+  if (type === "executing") {
+    const nodeId = data.node != null ? String(data.node) : null;
+    // node null often means execution finished for that client
+    if (nodeId == null) {
+      return null;
+    }
+    const label = nodeLabels[nodeId] || nodeId;
+    return {
+      promptId: data.prompt_id != null ? String(data.prompt_id) : prev?.promptId ?? null,
+      nodeId,
+      nodeLabel: label,
+      value: prev?.value ?? 0,
+      max: prev?.max ?? 0,
+      percent: prev?.percent ?? null,
+      updatedAt: Date.now(),
+      source: "ws",
+    };
+  }
+
+  if (type === "progress") {
+    const value = Number(data.value);
+    const max = Number(data.max);
+    const nodeId =
+      data.node != null
+        ? String(data.node)
+        : prev?.nodeId != null
+          ? prev.nodeId
+          : null;
+    const percent =
+      Number.isFinite(value) && Number.isFinite(max) && max > 0
+        ? Math.min(100, Math.round((value / max) * 100))
+        : null;
+    return {
+      promptId: data.prompt_id != null ? String(data.prompt_id) : prev?.promptId ?? null,
+      nodeId,
+      nodeLabel: nodeId ? nodeLabels[nodeId] || nodeId : prev?.nodeLabel ?? null,
+      value: Number.isFinite(value) ? value : 0,
+      max: Number.isFinite(max) ? max : 0,
+      percent,
+      updatedAt: Date.now(),
+      source: "ws",
+    };
+  }
+
+  if (type === "progress_state") {
+    const nodes = data.nodes && typeof data.nodes === "object" ? data.nodes : {};
+    // Prefer a running node with the highest activity
+    let best = null;
+    for (const [nid, st] of Object.entries(nodes)) {
+      if (!st || typeof st !== "object") continue;
+      const state = st.state;
+      if (state !== "running" && state !== "Running") continue;
+      const value = Number(st.value);
+      const max = Number(st.max);
+      best = {
+        promptId: data.prompt_id != null ? String(data.prompt_id) : prev?.promptId ?? null,
+        nodeId: String(nid),
+        nodeLabel: nodeLabels[nid] || String(nid),
+        value: Number.isFinite(value) ? value : 0,
+        max: Number.isFinite(max) ? max : 0,
+        percent:
+          Number.isFinite(value) && Number.isFinite(max) && max > 0
+            ? Math.min(100, Math.round((value / max) * 100))
+            : null,
+        updatedAt: Date.now(),
+        source: "ws",
+      };
+      break;
+    }
+    return best ?? prev;
+  }
+
+  if (
+    type === "execution_success" ||
+    type === "execution_error" ||
+    type === "execution_interrupted"
+  ) {
+    return null;
+  }
+
+  return prev;
+}
+
+export class ComfyProgressSocket {
+  /**
+   * @param {object} spark
+   * @param {number} port
+   */
+  constructor(spark, port) {
+    this.spark = spark;
+    this.port = port;
+    this.clientId = randomUUID();
+    /** @type {import('ws').WebSocket | null} */
+    this._ws = null;
+    /** @type {object | null} */
+    this.progress = null;
+    /** @type {Record<string, string>} */
+    this.nodeLabels = {};
+    this._wantOpen = false;
+    this._reconnectTimer = null;
+    this._idleTimer = null;
+    this._reconnectAttempt = 0;
+    this._lastMessageAt = 0;
+    this._closed = false;
+  }
+
+  setTarget(spark, port) {
+    const hostChanged =
+      llmProbeHost(spark) !== llmProbeHost(this.spark) || Number(port) !== this.port;
+    this.spark = spark;
+    this.port = port;
+    if (hostChanged && this._ws) {
+      this.close();
+      if (this._wantOpen) this.open();
+    }
+  }
+
+  /** @param {Record<string, string>} labels */
+  setNodeLabels(labels) {
+    this.nodeLabels = labels && typeof labels === "object" ? labels : {};
+  }
+
+  getProgress() {
+    return this.progress;
+  }
+
+  open() {
+    if (this._closed) return;
+    this._wantOpen = true;
+    if (
+      this._ws &&
+      (this._ws.readyState === WebSocket.OPEN || this._ws.readyState === WebSocket.CONNECTING)
+    ) {
+      return;
+    }
+    this._connect();
+  }
+
+  /** Keep socket if running; schedule close when idle. */
+  touchActivity(isBusy) {
+    if (isBusy) {
+      this.open();
+      if (this._idleTimer) {
+        clearTimeout(this._idleTimer);
+        this._idleTimer = null;
+      }
+      return;
+    }
+    if (!this._wantOpen) return;
+    if (this._idleTimer) return;
+    this._idleTimer = setTimeout(() => {
+      this._idleTimer = null;
+      this._wantOpen = false;
+      this._teardownWs();
+    }, IDLE_CLOSE_MS);
+  }
+
+  close() {
+    this._wantOpen = false;
+    this._closed = true;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    if (this._idleTimer) {
+      clearTimeout(this._idleTimer);
+      this._idleTimer = null;
+    }
+    this._teardownWs();
+    this.progress = null;
+  }
+
+  /** Soft close (monitoring still on, host down). */
+  disconnect() {
+    this._wantOpen = false;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    if (this._idleTimer) {
+      clearTimeout(this._idleTimer);
+      this._idleTimer = null;
+    }
+    this._teardownWs();
+  }
+
+  _teardownWs() {
+    if (this._ws) {
+      try {
+        const ws = this._ws;
+        this._ws = null;
+        ws.removeAllListeners();
+        // Swallow late errors from in-flight handshake after tests/dispose.
+        ws.on("error", () => {});
+        if (ws.readyState === WebSocket.CONNECTING) {
+          ws.terminate();
+        } else {
+          ws.close();
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  _wsUrl() {
+    const host = llmProbeHost(this.spark);
+    return `ws://${host}:${this.port}/ws?clientId=${encodeURIComponent(this.clientId)}`;
+  }
+
+  _connect() {
+    if (this._closed || !this._wantOpen) return;
+    this._teardownWs();
+    let ws;
+    try {
+      ws = new WebSocket(this._wsUrl(), { handshakeTimeout: 5000 });
+    } catch {
+      this._scheduleReconnect();
+      return;
+    }
+    this._ws = ws;
+
+    ws.on("open", () => {
+      this._reconnectAttempt = 0;
+      this._lastMessageAt = Date.now();
+    });
+
+    ws.on("message", (raw) => {
+      this._lastMessageAt = Date.now();
+      let msg;
+      try {
+        const text = typeof raw === "string" ? raw : raw.toString("utf8");
+        // Binary preview frames — ignore
+        if (text.length && text.charCodeAt(0) < 32 && text.charCodeAt(0) !== 9) {
+          // might be binary; try parse only if looks like JSON
+          if (!text.trimStart().startsWith("{")) return;
+        }
+        msg = JSON.parse(text);
+      } catch {
+        return;
+      }
+      this.progress = reduceComfyProgressMessage(this.progress, msg, this.nodeLabels);
+    });
+
+    ws.on("close", () => {
+      this._ws = null;
+      if (this._wantOpen && !this._closed) this._scheduleReconnect();
+    });
+
+    ws.on("error", () => {
+      // close handler will reconnect
+      try {
+        ws.close();
+      } catch {
+        /* ignore */
+      }
+    });
+  }
+
+  _scheduleReconnect() {
+    if (!this._wantOpen || this._closed) return;
+    if (this._reconnectTimer) return;
+    const exp = Math.min(
+      RECONNECT_MAX_MS,
+      RECONNECT_MIN_MS * Math.pow(2, this._reconnectAttempt)
+    );
+    this._reconnectAttempt += 1;
+    this._reconnectTimer = setTimeout(() => {
+      this._reconnectTimer = null;
+      this._connect();
+    }, exp);
+  }
+}

--- a/server/collectors/ComfyProgressSocket.js
+++ b/server/collectors/ComfyProgressSocket.js
@@ -147,13 +147,20 @@ export class ComfyProgressSocket {
   }
 
   setTarget(spark, port) {
+    const nextPort = Number(port);
     const hostChanged =
-      llmProbeHost(spark) !== llmProbeHost(this.spark) || Number(port) !== this.port;
+      llmProbeHost(spark) !== llmProbeHost(this.spark) ||
+      (Number.isInteger(nextPort) ? nextPort : this.port) !== this.port;
     this.spark = spark;
-    this.port = port;
-    if (hostChanged && this._ws) {
-      this.close();
-      if (this._wantOpen) this.open();
+    if (Number.isInteger(nextPort) && nextPort >= 1 && nextPort <= 65535) {
+      this.port = nextPort;
+    }
+    // Soft reconnect on host/port change — do not use close() (that sets
+    // _closed permanently and is reserved for dispose/stop).
+    if (hostChanged) {
+      const want = this._wantOpen;
+      this.disconnect();
+      if (want && !this._closed) this.open();
     }
   }
 

--- a/server/collectors/DecodeBench.js
+++ b/server/collectors/DecodeBench.js
@@ -181,6 +181,8 @@ function streamPublicResult(r, index, prompt, reqMeta, debug = false) {
   /** @type {Record<string, unknown>} */
   const out = {
     index,
+    ttftContentMs: r?.ttftContentMs ?? null,
+    reasoningChunks: r?.reasoningChunks ?? 0,
     ttftMs: r?.ttftMs ?? 0,
     decodeTps: r?.decodeTps ?? 0,
     decodeTokens: r?.decodeTokens ?? 0,

--- a/server/collectors/LlmStreaming.js
+++ b/server/collectors/LlmStreaming.js
@@ -363,6 +363,10 @@ async function runStreamingRequestOnce(
   let tFirst = null;
   /** @type {number | null} */
   let tLast = null;
+  /** First answer (non-reasoning) token, for ttftContentMs. Stays null when a reply never leaves the reasoning phase. */
+  /** @type {number | null} */
+  let tFirstContent = null;
+  let reasoningChunkCount = 0;
   let chunkTokenCount = 0;
   let usageCompletionTokens = null;
   /** @type {Record<string, number> | null} */
@@ -470,6 +474,11 @@ async function runStreamingRequestOnce(
             const now = performance.now();
             if (tFirst == null) tFirst = now;
             tLast = now;
+            if (reasoning) {
+              reasoningChunkCount += 1;
+            } else if (tFirstContent == null) {
+              tFirstContent = now;
+            }
             chunkTokenCount += tokenChunks;
             const text = `${reasoning}${answer}`;
             if (keepContent) {
@@ -526,6 +535,9 @@ async function runStreamingRequestOnce(
   /** @type {Record<string, unknown>} */
   const out = {
     ttftMs: round2(ttftMs),
+    /** Time-to-first-answer-token (post-reasoning) in ms from request start. Null when the reply never leaves the reasoning phase. */
+    ttftContentMs: tFirstContent != null ? round2(tFirstContent - t0) : null,
+    reasoningChunks: reasoningChunkCount,
     decodeMs: round2(decodeMs),
     completionTokens,
     decodeTokens,

--- a/server/collectors/__tests__/ComfyProbe.test.js
+++ b/server/collectors/__tests__/ComfyProbe.test.js
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ComfyProbe, summarizeComfyPrompt } from "../ComfyProbe.js";
+
+test("ComfyProbe defaults when host unreachable", async () => {
+  const probe = new ComfyProbe(
+    { isLocal: true, lanIp: "127.0.0.1" },
+    1 // nothing listens on port 1
+  );
+  const snap = await probe.probe();
+  assert.equal(snap.available, false);
+  assert.equal(snap.port, 1);
+  assert.equal(snap.queueRunning, 0);
+  assert.equal(snap.queuePending, 0);
+  assert.equal(snap.activeJob, null);
+  assert.ok(snap.error);
+});
+
+test("ComfyProbe setTarget updates port and host", () => {
+  const probe = new ComfyProbe({ isLocal: false, lanIp: "10.0.0.5" }, 8188);
+  assert.match(probe.baseUrl, /10\.0\.0\.5:8188/);
+  probe.setTarget({ isLocal: true, lanIp: "10.0.0.5" }, 9001);
+  assert.equal(probe.port, 9001);
+  assert.match(probe.baseUrl, /127\.0\.0\.1:9001/);
+});
+
+test("summarizeComfyPrompt extracts models and footprint", () => {
+  const summary = summarizeComfyPrompt({
+    "3": {
+      class_type: "KSampler",
+      inputs: {
+        steps: 20,
+        sampler_name: "euler",
+        model: ["4", 0],
+      },
+    },
+    "4": {
+      class_type: "CheckpointLoaderSimple",
+      inputs: { ckpt_name: "models/checkpoints/v1-5-pruned-emaonly.safetensors" },
+    },
+    "5": {
+      class_type: "EmptyLatentImage",
+      inputs: { width: 512, height: 768, batch_size: 2 },
+    },
+    "6": {
+      class_type: "LoraLoader",
+      inputs: { lora_name: "style.safetensors", strength_model: 0.8 },
+    },
+  });
+
+  assert.equal(summary.nodeCount, 4);
+  assert.equal(summary.steps, 20);
+  assert.equal(summary.width, 512);
+  assert.equal(summary.height, 768);
+  assert.equal(summary.batchSize, 2);
+  assert.equal(summary.sampler, "euler");
+  assert.deepEqual(summary.models, [
+    "v1-5-pruned-emaonly.safetensors",
+    "style.safetensors",
+  ]);
+});
+
+test("ComfyProbe parses running queue item into activeJob", async () => {
+  const prompt = {
+    "4": {
+      class_type: "CheckpointLoaderSimple",
+      inputs: { ckpt_name: "flux1-dev.safetensors" },
+    },
+    "5": {
+      class_type: "EmptyLatentImage",
+      inputs: { width: 1024, height: 1024, batch_size: 1 },
+    },
+    "3": {
+      class_type: "KSampler",
+      inputs: { steps: 28, sampler_name: "euler" },
+    },
+  };
+  const queueItem = [
+    0,
+    "a1b2c3d4-e5f6-7a89-b0c1-d2e3f4a5b6c7",
+    prompt,
+    {
+      create_time: Date.now() - 5000,
+      extra_pnginfo: { workflow: { title: "Portrait run" } },
+    },
+    [],
+  ];
+
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.endsWith("/system_stats")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          system: {
+            comfyui_version: "0.29.0",
+            pytorch_version: "2.13.0+cpu",
+          },
+          devices: [{ type: "cpu", name: "cpu" }],
+        }),
+      };
+    }
+    if (u.endsWith("/queue")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          queue_running: [queueItem],
+          queue_pending: [],
+        }),
+      };
+    }
+    return { ok: false, status: 404, json: async () => ({}) };
+  };
+
+  try {
+    const probe = new ComfyProbe({ isLocal: true }, 8188);
+    const snap = await probe.probe();
+    assert.equal(snap.available, true);
+    assert.equal(snap.queueRunning, 1);
+    assert.ok(snap.activeJob);
+    assert.equal(snap.activeJob.title, "Portrait run");
+    assert.equal(snap.activeJob.steps, 28);
+    assert.equal(snap.activeJob.width, 1024);
+    assert.deepEqual(snap.activeJob.models, ["flux1-dev.safetensors"]);
+    assert.equal(snap.deviceType, "cpu");
+    assert.equal(snap.ramTotal, undefined);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});

--- a/server/collectors/__tests__/ComfyProbe.test.js
+++ b/server/collectors/__tests__/ComfyProbe.test.js
@@ -156,11 +156,22 @@ test("ComfyProbe parses running queue into activeJob + openUrl", async () => {
     assert.equal(snap.modelsInstalled?.checkpoints?.[0], "a.safetensors");
     assert.ok(snap.queueEtaMs > 0);
     assert.ok(snap.progress); // estimate while running
-    assert.equal(snap.openUrl, "http://127.0.0.1:8188");
+    // openUrl prefers LAN IP for browser deep links (not loopback probe host)
+    assert.equal(snap.openUrl, "http://127.0.0.1:8188"); // no lanIp on this spark
     probe.dispose();
     // Allow any in-flight WS handshake to settle without failing the suite
     await new Promise((r) => setTimeout(r, 30));
   } finally {
     globalThis.fetch = origFetch;
   }
+});
+
+test("openUrl prefers lanIp over localhost probe host", () => {
+  const probe = new ComfyProbe(
+    { isLocal: true, lanIp: "192.168.1.50", ssh: { host: "192.168.1.50" } },
+    8188
+  );
+  assert.equal(probe.openUrl(), "http://192.168.1.50:8188");
+  assert.match(probe.baseUrl, /127\.0\.0\.1:8188/); // probe still loopback when local
+  probe.dispose();
 });

--- a/server/collectors/__tests__/ComfyProbe.test.js
+++ b/server/collectors/__tests__/ComfyProbe.test.js
@@ -1,19 +1,22 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { ComfyProbe, summarizeComfyPrompt } from "../ComfyProbe.js";
+import {
+  ComfyProbe,
+  summarizeComfyPrompt,
+  estimateQueueEtaMs,
+} from "../ComfyProbe.js";
+import { reduceComfyProgressMessage } from "../ComfyProgressSocket.js";
 
 test("ComfyProbe defaults when host unreachable", async () => {
-  const probe = new ComfyProbe(
-    { isLocal: true, lanIp: "127.0.0.1" },
-    1 // nothing listens on port 1
-  );
+  const probe = new ComfyProbe({ isLocal: true, lanIp: "127.0.0.1" }, 1);
   const snap = await probe.probe();
   assert.equal(snap.available, false);
   assert.equal(snap.port, 1);
   assert.equal(snap.queueRunning, 0);
-  assert.equal(snap.queuePending, 0);
   assert.equal(snap.activeJob, null);
+  assert.ok(snap.openUrl.includes(":1"));
   assert.ok(snap.error);
+  probe.dispose();
 });
 
 test("ComfyProbe setTarget updates port and host", () => {
@@ -22,53 +25,66 @@ test("ComfyProbe setTarget updates port and host", () => {
   probe.setTarget({ isLocal: true, lanIp: "10.0.0.5" }, 9001);
   assert.equal(probe.port, 9001);
   assert.match(probe.baseUrl, /127\.0\.0\.1:9001/);
+  probe.dispose();
 });
 
 test("summarizeComfyPrompt extracts models and footprint", () => {
   const summary = summarizeComfyPrompt({
     "3": {
       class_type: "KSampler",
-      inputs: {
-        steps: 20,
-        sampler_name: "euler",
-        model: ["4", 0],
-      },
+      inputs: { steps: 20, sampler_name: "euler", model: ["4", 0] },
     },
     "4": {
       class_type: "CheckpointLoaderSimple",
-      inputs: { ckpt_name: "models/checkpoints/v1-5-pruned-emaonly.safetensors" },
+      inputs: { ckpt_name: "models/checkpoints/v1-5.safetensors" },
     },
     "5": {
       class_type: "EmptyLatentImage",
       inputs: { width: 512, height: 768, batch_size: 2 },
     },
-    "6": {
-      class_type: "LoraLoader",
-      inputs: { lora_name: "style.safetensors", strength_model: 0.8 },
-    },
   });
-
-  assert.equal(summary.nodeCount, 4);
+  assert.equal(summary.nodeCount, 3);
   assert.equal(summary.steps, 20);
   assert.equal(summary.width, 512);
-  assert.equal(summary.height, 768);
-  assert.equal(summary.batchSize, 2);
-  assert.equal(summary.sampler, "euler");
-  assert.deepEqual(summary.models, [
-    "v1-5-pruned-emaonly.safetensors",
-    "style.safetensors",
-  ]);
+  assert.deepEqual(summary.models, ["v1-5.safetensors"]);
+  assert.equal(summary.nodeLabels["3"], "KSampler");
 });
 
-test("ComfyProbe parses running queue item into activeJob", async () => {
+test("estimateQueueEtaMs uses progress and pending", () => {
+  const eta = estimateQueueEtaMs({
+    avgDurationMs: 100_000,
+    queuePending: 2,
+    running: true,
+    progressPercent: 50,
+  });
+  // 50% remaining of 100s + 2 * 100s = 250s
+  assert.equal(eta, 250_000);
+});
+
+test("reduceComfyProgressMessage handles progress and executing", () => {
+  let st = null;
+  st = reduceComfyProgressMessage(st, {
+    type: "executing",
+    data: { node: "3", prompt_id: "abc" },
+  }, { "3": "KSampler" });
+  assert.equal(st.nodeLabel, "KSampler");
+  st = reduceComfyProgressMessage(st, {
+    type: "progress",
+    data: { value: 5, max: 20, prompt_id: "abc", node: "3" },
+  }, { "3": "KSampler" });
+  assert.equal(st.percent, 25);
+  st = reduceComfyProgressMessage(st, {
+    type: "execution_success",
+    data: { prompt_id: "abc" },
+  });
+  assert.equal(st, null);
+});
+
+test("ComfyProbe parses running queue into activeJob + openUrl", async () => {
   const prompt = {
     "4": {
       class_type: "CheckpointLoaderSimple",
       inputs: { ckpt_name: "flux1-dev.safetensors" },
-    },
-    "5": {
-      class_type: "EmptyLatentImage",
-      inputs: { width: 1024, height: 1024, batch_size: 1 },
     },
     "3": {
       class_type: "KSampler",
@@ -89,28 +105,42 @@ test("ComfyProbe parses running queue item into activeJob", async () => {
   const origFetch = globalThis.fetch;
   globalThis.fetch = async (url) => {
     const u = String(url);
-    if (u.endsWith("/system_stats")) {
+    if (u.includes("/system_stats")) {
       return {
         ok: true,
         status: 200,
         json: async () => ({
-          system: {
-            comfyui_version: "0.29.0",
-            pytorch_version: "2.13.0+cpu",
-          },
-          devices: [{ type: "cpu", name: "cpu" }],
+          system: { comfyui_version: "0.29.0", pytorch_version: "2.13.0+cpu" },
+          devices: [{ type: "cpu" }],
         }),
       };
     }
-    if (u.endsWith("/queue")) {
+    if (u.includes("/queue") && !u.includes("api")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ queue_running: [queueItem], queue_pending: [] }),
+      };
+    }
+    if (u.includes("/api/jobs")) {
       return {
         ok: true,
         status: 200,
         json: async () => ({
-          queue_running: [queueItem],
-          queue_pending: [],
+          jobs: [
+            {
+              id: "prev",
+              status: "completed",
+              workflow_id: "Upscale pass",
+              execution_start_time: 1000,
+              execution_end_time: 31000,
+            },
+          ],
         }),
       };
+    }
+    if (u.includes("/models/")) {
+      return { ok: true, status: 200, json: async () => ["a.safetensors"] };
     }
     return { ok: false, status: 404, json: async () => ({}) };
   };
@@ -119,14 +149,17 @@ test("ComfyProbe parses running queue item into activeJob", async () => {
     const probe = new ComfyProbe({ isLocal: true }, 8188);
     const snap = await probe.probe();
     assert.equal(snap.available, true);
-    assert.equal(snap.queueRunning, 1);
-    assert.ok(snap.activeJob);
     assert.equal(snap.activeJob.title, "Portrait run");
-    assert.equal(snap.activeJob.steps, 28);
-    assert.equal(snap.activeJob.width, 1024);
     assert.deepEqual(snap.activeJob.models, ["flux1-dev.safetensors"]);
-    assert.equal(snap.deviceType, "cpu");
-    assert.equal(snap.ramTotal, undefined);
+    assert.equal(snap.lastJob?.title, "Upscale pass");
+    assert.equal(snap.lastJob?.durationMs, 30000);
+    assert.equal(snap.modelsInstalled?.checkpoints?.[0], "a.safetensors");
+    assert.ok(snap.queueEtaMs > 0);
+    assert.ok(snap.progress); // estimate while running
+    assert.equal(snap.openUrl, "http://127.0.0.1:8188");
+    probe.dispose();
+    // Allow any in-flight WS handshake to settle without failing the suite
+    await new Promise((r) => setTimeout(r, 30));
   } finally {
     globalThis.fetch = origFetch;
   }

--- a/server/collectors/comfyActions.js
+++ b/server/collectors/comfyActions.js
@@ -1,0 +1,94 @@
+/**
+ * ComfyUI mutation helpers (cancel / interrupt) — server-side only.
+ */
+import { COMFY_PORT, COMFY_PROBE_TIMEOUT_MS } from "../config.js";
+import { isAllowedTargetHost } from "../validate.js";
+import { llmProbeHost } from "./llmHost.js";
+
+/**
+ * @param {object} spark
+ * @param {number} [port]
+ */
+function baseUrl(spark, port) {
+  const host = llmProbeHost(spark);
+  if (!isAllowedTargetHost(host)) {
+    throw new Error(`Invalid or disallowed ComfyUI host: ${host}`);
+  }
+  const p =
+    Number.isInteger(port) && port >= 1 && port <= 65535
+      ? port
+      : Number(spark?.comfyPort) || COMFY_PORT;
+  return `http://${host}:${p}`;
+}
+
+/**
+ * Cancel a ComfyUI job by prompt id.
+ * Prefers /api/jobs/:id/cancel; falls back to interrupt + queue delete.
+ *
+ * @param {object} spark
+ * @param {string} promptId
+ * @param {number} [port]
+ * @returns {Promise<{ ok: boolean, method: string, message: string }>}
+ */
+export async function comfyCancelJob(spark, promptId, port) {
+  if (!promptId || typeof promptId !== "string") {
+    return { ok: false, method: "none", message: "promptId required" };
+  }
+  const root = baseUrl(spark, port);
+  const signal = AbortSignal.timeout(COMFY_PROBE_TIMEOUT_MS);
+
+  // 1) Modern jobs API
+  try {
+    const res = await fetch(`${root}/api/jobs/${encodeURIComponent(promptId)}/cancel`, {
+      method: "POST",
+      signal,
+    });
+    if (res.ok || res.status === 200 || res.status === 204) {
+      return { ok: true, method: "api_jobs_cancel", message: "cancelled" };
+    }
+    // 404 → try legacy paths
+    if (res.status !== 404) {
+      const text = await res.text().catch(() => "");
+      // still try legacy below if not clearly ok
+      if (res.status >= 500) {
+        return {
+          ok: false,
+          method: "api_jobs_cancel",
+          message: `HTTP ${res.status} ${text.slice(0, 120)}`,
+        };
+      }
+    }
+  } catch {
+    /* fall through */
+  }
+
+  // 2) Interrupt running (targeted)
+  try {
+    await fetch(`${root}/interrupt`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt_id: promptId }),
+      signal: AbortSignal.timeout(COMFY_PROBE_TIMEOUT_MS),
+    });
+  } catch {
+    /* ignore */
+  }
+
+  // 3) Delete from pending queue
+  try {
+    const res = await fetch(`${root}/queue`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ delete: [promptId] }),
+      signal: AbortSignal.timeout(COMFY_PROBE_TIMEOUT_MS),
+    });
+    if (res.ok) {
+      return { ok: true, method: "queue_delete", message: "removed from queue / interrupted" };
+    }
+  } catch (err) {
+    return { ok: false, method: "queue_delete", message: err.message };
+  }
+
+  // Interrupt alone may have worked for running jobs
+  return { ok: true, method: "interrupt", message: "interrupt requested" };
+}

--- a/server/collectors/ssh.js
+++ b/server/collectors/ssh.js
@@ -7,7 +7,7 @@
  */
 import { execFile } from "child_process";
 import fs from "fs";
-import { SSH_CONNECT_TIMEOUT } from "../config.js";
+import { COMFY_PORT, COMFY_PROBE_TIMEOUT_MS, SSH_CONNECT_TIMEOUT } from "../config.js";
 import { isAllowedTargetHost, isValidSshUser } from "../validate.js";
 import { llmProbeHost } from "./llmHost.js";
 
@@ -206,4 +206,36 @@ export async function llmTestAll(spark) {
   );
   const allOk = results.every((r) => r.ok);
   return { ok: allOk, ports: results };
+}
+
+/**
+ * Test ComfyUI connectivity on a single port (GET /system_stats).
+ * Returns { ok: boolean, message: string, skipped?: boolean }
+ */
+export async function comfyTest(spark, port) {
+  try {
+    const host = llmProbeHost(spark);
+    if (!isAllowedTargetHost(host)) {
+      return { ok: false, message: `Invalid or disallowed ComfyUI host: ${host}` };
+    }
+    const resolvedPort =
+      Number.isInteger(port) && port >= 1 && port <= 65535
+        ? port
+        : Number(spark?.comfyPort) || COMFY_PORT;
+    const url = `http://${host}:${resolvedPort}/system_stats`;
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(COMFY_PROBE_TIMEOUT_MS),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, message: `HTTP ${res.status}` };
+    }
+    const ver = data?.system?.comfyui_version;
+    return {
+      ok: true,
+      message: ver ? `ComfyUI ${ver}` : "reachable",
+    };
+  } catch (err) {
+    return { ok: false, message: err.message };
+  }
 }

--- a/server/config.js
+++ b/server/config.js
@@ -16,8 +16,9 @@ const SPARKS_SECRETS_PATH =
 const SECRETS_KEY_PATH =
   process.env.SECRETS_KEY_PATH || path.join(ROOT, "config", ".secrets-key");
 
-// ─── LLM probe timeout ──────────────────────────────────
+// ─── LLM / Comfy probe timeouts ──────────────────────────
 const LLM_PROBE_TIMEOUT_MS = 3000;
+const COMFY_PROBE_TIMEOUT_MS = parseInt(process.env.COMFY_PROBE_TIMEOUT_MS || "3000", 10);
 const SSH_CONNECT_TIMEOUT = 5; // seconds
 
 // ─── Poll intervals (milliseconds) ───────────────────────
@@ -26,6 +27,7 @@ const POLL_INTERVAL_CPU = parseInt(process.env.POLL_INTERVAL_CPU || "2000", 10);
 const POLL_INTERVAL_NETWORK = parseInt(process.env.POLL_INTERVAL_NETWORK || "2000", 10);
 const POLL_INTERVAL_STORAGE = parseInt(process.env.POLL_INTERVAL_STORAGE || "5000", 10);
 const POLL_INTERVAL_LLM = parseInt(process.env.POLL_INTERVAL_LLM || "2000", 10);
+const POLL_INTERVAL_COMFY = parseInt(process.env.POLL_INTERVAL_COMFY || "2000", 10);
 // dmon -c 1 -d 1 blocks ~1s; default 2s avoids stacking with in-flight guards
 const POLL_INTERVAL_BANDWIDTH = parseInt(process.env.POLL_INTERVAL_BANDWIDTH || "2000", 10);
 // Dedicated liveness (sshTest / local ping) cadence — not a metric domain.
@@ -34,6 +36,8 @@ const POLL_INTERVAL_LIVENESS = parseInt(process.env.POLL_INTERVAL_LIVENESS || "5
 // ─── Port ────────────────────────────────────────────────
 const PORT = parseInt(process.env.PORT || "5555", 10);
 const LLM_PORT = parseInt(process.env.LLM_PORT || "8888", 10);
+/** Default ComfyUI HTTP port. */
+const COMFY_PORT = parseInt(process.env.COMFY_PORT || "8188", 10);
 
 // ─── DGX Spark constants ────────────────────────────────
 const DGX_SPARK = {
@@ -77,16 +81,19 @@ export {
   SPARKS_SECRETS_PATH,
   SECRETS_KEY_PATH,
   LLM_PROBE_TIMEOUT_MS,
+  COMFY_PROBE_TIMEOUT_MS,
   SSH_CONNECT_TIMEOUT,
   POLL_INTERVAL_GPU,
   POLL_INTERVAL_CPU,
   POLL_INTERVAL_NETWORK,
   POLL_INTERVAL_STORAGE,
   POLL_INTERVAL_LLM,
+  POLL_INTERVAL_COMFY,
   POLL_INTERVAL_BANDWIDTH,
   POLL_INTERVAL_LIVENESS,
   PORT,
   LLM_PORT,
+  COMFY_PORT,
   DGX_SPARK,
   UNIT_CONVERSION,
   HARDWARE_DEFAULTS,

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,7 @@ import { fileURLToPath } from "url";
 import dotenv from "dotenv";
 import { SparkRegistry } from "./sparks/SparkRegistry.js";
 import { SparkMonitor } from "./sparks/SparkMonitor.js";
-import { sshExec, sshTest, llmTest } from "./collectors/ssh.js";
+import { sshExec, sshTest, llmTest, comfyTest } from "./collectors/ssh.js";
 import { validateSparkTarget, createRateLimiter } from "./validate.js";
 import { getSettings, updateSettings, loadSettings } from "./settings.js";
 import { broadcastForLanIp, effectiveMac, normalizeMac, sendWol } from "./wol.js";
@@ -28,6 +28,7 @@ const ROOT = path.resolve(__dirname, "..");
 const BIND_HOST = process.env.BIND_HOST || "0.0.0.0";
 const PORT = parseInt(process.env.PORT || "5555", 10);
 const LLM_PORT = parseInt(process.env.LLM_PORT || "8888", 10);
+const COMFY_PORT = parseInt(process.env.COMFY_PORT || "8188", 10);
 
 /** Per-spark LLM HTTP port (1–65535), else env default. */
 function resolveLlmPort(sparkOrPort) {
@@ -47,6 +48,20 @@ function resolveLlmPort(sparkOrPort) {
   const n = typeof raw === "string" ? parseInt(raw, 10) : Number(raw);
   if (Number.isInteger(n) && n >= 1 && n <= 65535) return n;
   return LLM_PORT;
+}
+
+/** Per-spark ComfyUI HTTP port (1–65535), else env default 8188. */
+function resolveComfyPort(sparkOrPort) {
+  if (sparkOrPort && typeof sparkOrPort === "object") {
+    const raw = sparkOrPort.comfyPort;
+    const n = typeof raw === "string" ? parseInt(raw, 10) : Number(raw);
+    if (Number.isInteger(n) && n >= 1 && n <= 65535) return n;
+    return COMFY_PORT;
+  }
+  const raw = sparkOrPort;
+  const n = typeof raw === "string" ? parseInt(raw, 10) : Number(raw);
+  if (Number.isInteger(n) && n >= 1 && n <= 65535) return n;
+  return COMFY_PORT;
 }
 
 /** Optional Bearer token for a Spark LLM port (from encrypted secrets). */
@@ -141,6 +156,8 @@ app.post("/api/sparks/test", async (req, res) => {
       cx7Ip: body.cx7Ip || null,
       isLocal: Boolean(body.isLocal),
       llmPort: resolveLlmPort(body),
+      comfyPort: resolveComfyPort(body),
+      comfyMonitoring: Boolean(body.comfyMonitoring),
       ssh: {
         host: body.ssh?.host || body.lanIp || "",
         user: body.ssh?.user || "root",
@@ -152,15 +169,20 @@ app.post("/api/sparks/test", async (req, res) => {
       return res.status(400).json({ error: "lanIp or ssh.host required" });
     }
     const llmPort = resolveLlmPort(spark);
-    const [sshResult, llmResult] = await Promise.all([
+    const comfyPort = resolveComfyPort(spark);
+    const [sshResult, llmResult, comfyResult] = await Promise.all([
       spark.isLocal ? Promise.resolve({ ok: true, message: "local (skipped SSH)" }) : sshTest(spark),
       llmTest(spark, llmPort),
+      spark.comfyMonitoring
+        ? comfyTest(spark, comfyPort)
+        : Promise.resolve({ ok: true, message: "disabled", skipped: true }),
     ]);
     res.json({
       id: spark.id,
       ssh: sshResult,
       llm: llmResult,
-      ok: sshResult.ok || llmResult.ok,
+      comfy: comfyResult,
+      ok: sshResult.ok || llmResult.ok || (comfyResult.ok && !comfyResult.skipped),
     });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -294,15 +316,19 @@ app.post("/api/sparks/:id/test", async (req, res) => {
     const spark = registry.getSpark(req.params.id);
     if (!spark) return res.status(404).json({ error: "Spark not found" });
 
-    const [sshResult, llmResult] = await Promise.all([
+    const [sshResult, llmResult, comfyResult] = await Promise.all([
       spark.isLocal ? Promise.resolve({ ok: true, message: "local (skipped SSH)" }) : sshTest(spark),
       llmTest(spark, resolveLlmPort(spark)),
+      spark.comfyMonitoring
+        ? comfyTest(spark, resolveComfyPort(spark))
+        : Promise.resolve({ ok: true, message: "disabled", skipped: true }),
     ]);
     res.json({
       id: req.params.id,
       ssh: sshResult,
       llm: llmResult,
-      ok: sshResult.ok || llmResult.ok,
+      comfy: comfyResult,
+      ok: sshResult.ok || llmResult.ok || (comfyResult.ok && !comfyResult.skipped),
       hasPassword: registry.hasPassword(req.params.id),
     });
   } catch (err) {

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ import dotenv from "dotenv";
 import { SparkRegistry } from "./sparks/SparkRegistry.js";
 import { SparkMonitor } from "./sparks/SparkMonitor.js";
 import { sshExec, sshTest, llmTest, comfyTest } from "./collectors/ssh.js";
+import { comfyCancelJob } from "./collectors/comfyActions.js";
 import { validateSparkTarget, createRateLimiter } from "./validate.js";
 import { getSettings, updateSettings, loadSettings } from "./settings.js";
 import { broadcastForLanIp, effectiveMac, normalizeMac, sendWol } from "./wol.js";
@@ -331,6 +332,31 @@ app.post("/api/sparks/:id/test", async (req, res) => {
       ok: sshResult.ok || llmResult.ok || (comfyResult.ok && !comfyResult.skipped),
       hasPassword: registry.hasPassword(req.params.id),
     });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Cancel a ComfyUI job (running interrupt and/or pending dequeue).
+app.post("/api/sparks/:id/comfy/cancel", async (req, res) => {
+  if (!allowTest(clientKey(req))) {
+    return res.status(429).json({ error: "Too many requests; try again shortly" });
+  }
+  try {
+    const spark = registry.getSpark(req.params.id);
+    if (!spark) return res.status(404).json({ error: "Spark not found" });
+    if (!spark.comfyMonitoring) {
+      return res.status(400).json({ error: "ComfyUI monitoring is disabled for this Spark" });
+    }
+    const promptId = req.body?.promptId ?? req.body?.prompt_id;
+    if (!promptId || typeof promptId !== "string") {
+      return res.status(400).json({ error: "promptId is required" });
+    }
+    const result = await comfyCancelJob(spark, promptId, resolveComfyPort(spark));
+    // Nudge a comfy re-poll so UI updates quickly
+    const mon = monitors.get(req.params.id);
+    if (mon) void mon._pollDomain?.("comfy");
+    res.json({ success: result.ok, ...result });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/server/settings.js
+++ b/server/settings.js
@@ -17,8 +17,8 @@ const DEFAULTS = Object.freeze({
   temperatureUnit: "celsius",
   /** Persist prompts / HTTP traces / GPU samples on decode benchmark runs. */
   benchDebugTraces: false,
-  /** Layout density — comfortable (default) or compact. */
-  density: "comfortable",
+  /** Layout density — compact (default) or comfortable. */
+  density: "compact",
 });
 
 /** @type {typeof DEFAULTS} */

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -112,6 +112,13 @@ export class SparkMonitor {
         this.comfyProbe = new ComfyProbe(spark, port);
       }
     } else {
+      if (this.comfyProbe) {
+        try {
+          this.comfyProbe.dispose();
+        } catch {
+          /* ignore */
+        }
+      }
       this.comfyProbe = null;
       this._metrics.comfy = null;
     }
@@ -222,6 +229,13 @@ export class SparkMonitor {
     this._llmIntervalId = null;
     this._comfyIntervalId = null;
     this._inflight = {};
+    if (this.comfyProbe) {
+      try {
+        this.comfyProbe.dispose();
+      } catch {
+        /* ignore */
+      }
+    }
     console.log(`[SparkMonitor] ${this.spark.id} stopped`);
   }
 

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import { SystemCollector } from "../collectors/SystemCollector.js";
 import { LlmProbe } from "../collectors/LlmProbe.js";
+import { ComfyProbe } from "../collectors/ComfyProbe.js";
 import { sshTest, sshExec } from "../collectors/ssh.js";
 import {
   POLL_INTERVAL_GPU,
@@ -9,9 +10,11 @@ import {
   POLL_INTERVAL_NETWORK,
   POLL_INTERVAL_STORAGE,
   POLL_INTERVAL_LLM,
+  POLL_INTERVAL_COMFY,
   POLL_INTERVAL_BANDWIDTH,
   POLL_INTERVAL_LIVENESS,
   LLM_PORT,
+  COMFY_PORT,
   HOST_PATHS,
 } from "../config.js";
 
@@ -39,6 +42,11 @@ export class SparkMonitor {
       }
     }
 
+    /** @type {ComfyProbe | null} */
+    this.comfyProbe = this._comfyMonitoringEnabled(spark)
+      ? new ComfyProbe(spark, this._comfyPort(spark))
+      : null;
+
     // Online status from dedicated liveness checks (not metric poll success)
     this.online = false;
     this.lastOnlineOk = 0;
@@ -55,6 +63,7 @@ export class SparkMonitor {
       network: this.collector._defaultNetwork(),
       unifiedMemory: this.collector._defaultUnifiedMemory(),
       llm: [],
+      comfy: null,
     };
     this._lastUpdate = {};
 
@@ -62,6 +71,8 @@ export class SparkMonitor {
     this._intervals = [];
     /** @type {ReturnType<typeof setInterval> | null} */
     this._llmIntervalId = null;
+    /** @type {ReturnType<typeof setInterval> | null} */
+    this._comfyIntervalId = null;
     this._running = false;
     /** @type {Record<string, boolean>} in-flight domain guards */
     this._inflight = {};
@@ -70,6 +81,8 @@ export class SparkMonitor {
   /** Hot-update config without tearing down poll loops / rate baselines. */
   updateConfig(spark) {
     const wasLlm = this._llmMonitoringEnabled(this.spark);
+    const wasComfy = this._comfyMonitoringEnabled(this.spark);
+    const prevComfyPort = this._comfyPort(this.spark);
     this.spark = spark;
     this.collector.spark = spark;
 
@@ -90,9 +103,27 @@ export class SparkMonitor {
       this._metrics.llm = [];
     }
 
+    // ComfyUI probe — create / update / clear
+    if (this._comfyMonitoringEnabled()) {
+      const port = this._comfyPort();
+      if (this.comfyProbe) {
+        this.comfyProbe.setTarget(spark, port);
+      } else {
+        this.comfyProbe = new ComfyProbe(spark, port);
+      }
+    } else {
+      this.comfyProbe = null;
+      this._metrics.comfy = null;
+    }
+
     // Toggle LLM poll interval when monitoring enablement flips
     if (this._running && wasLlm !== this._llmMonitoringEnabled()) {
       this._restartLlmPollInterval();
+    }
+    const comfyOn = this._comfyMonitoringEnabled();
+    const comfyPortChanged = comfyOn && prevComfyPort !== this._comfyPort();
+    if (this._running && (wasComfy !== comfyOn || comfyPortChanged)) {
+      this._restartComfyPollInterval();
     }
   }
 
@@ -118,6 +149,35 @@ export class SparkMonitor {
       this._llmIntervalId = setInterval(() => this._pollDomain("llm"), POLL_INTERVAL_LLM);
       this._intervals.push(this._llmIntervalId);
       void this._pollDomain("llm");
+    }
+  }
+
+  /**
+   * Opt-in ComfyUI monitoring (all roles; default off).
+   * @param {object} [spark]
+   */
+  _comfyMonitoringEnabled(spark = this.spark) {
+    return Boolean(spark?.comfyMonitoring);
+  }
+
+  /** @param {object} [spark] */
+  _comfyPort(spark = this.spark) {
+    const n = Number(spark?.comfyPort);
+    if (Number.isInteger(n) && n >= 1 && n <= 65535) return n;
+    return COMFY_PORT;
+  }
+
+  /** Start or clear the ComfyUI poll timer based on monitoring flag. */
+  _restartComfyPollInterval() {
+    if (this._comfyIntervalId != null) {
+      clearInterval(this._comfyIntervalId);
+      this._intervals = this._intervals.filter((id) => id !== this._comfyIntervalId);
+      this._comfyIntervalId = null;
+    }
+    if (this._comfyMonitoringEnabled() && this._running) {
+      this._comfyIntervalId = setInterval(() => this._pollDomain("comfy"), POLL_INTERVAL_COMFY);
+      this._intervals.push(this._comfyIntervalId);
+      void this._pollDomain("comfy");
     }
   }
 
@@ -148,6 +208,7 @@ export class SparkMonitor {
     this._intervals.push(setInterval(() => this._pollDomain("ram"), POLL_INTERVAL_CPU));
     this._intervals.push(setInterval(() => this._pollDomain("memory"), POLL_INTERVAL_BANDWIDTH));
     this._restartLlmPollInterval();
+    this._restartComfyPollInterval();
     // Liveness on a slightly slower cadence
     this._intervals.push(setInterval(() => this._checkOnline(), POLL_INTERVAL_LIVENESS));
     console.log(`[SparkMonitor] ${this.spark.id} started`);
@@ -159,6 +220,7 @@ export class SparkMonitor {
     for (const id of this._intervals) clearInterval(id);
     this._intervals = [];
     this._llmIntervalId = null;
+    this._comfyIntervalId = null;
     this._inflight = {};
     console.log(`[SparkMonitor] ${this.spark.id} stopped`);
   }
@@ -166,6 +228,7 @@ export class SparkMonitor {
   /** Return a full snapshot of this Spark's metrics. */
   snapshot() {
     const ports = this._llmMonitoringEnabled() ? this._llmPorts() : [];
+    const comfyOn = this._comfyMonitoringEnabled();
     return {
       id: this.spark.id,
       name: this.spark.name,
@@ -186,6 +249,8 @@ export class SparkMonitor {
         : Object.keys(this.spark.llmApiKeys || {})
             .map((p) => parseInt(p, 10))
             .filter((n) => Number.isInteger(n)),
+      comfyMonitoring: comfyOn,
+      comfyPort: this._comfyPort(),
       hardware: this._getHardwareSummary(),
       metrics: {
         // NOTE: no `timestamp` here on purpose. The broadcast path skips
@@ -202,6 +267,7 @@ export class SparkMonitor {
         network: this._metrics.network,
         unifiedMemory: this._metrics.unifiedMemory,
         llm: this._metrics.llm,
+        comfy: comfyOn ? this._metrics.comfy : null,
       },
     };
   }
@@ -269,6 +335,7 @@ export class SparkMonitor {
       this._pollDomain("ram"),
       this._pollDomain("memory"),
       this._pollDomain("llm"),
+      this._pollDomain("comfy"),
     ]);
   }
 
@@ -278,6 +345,7 @@ export class SparkMonitor {
     if (domain === "storage" && this.spark.storagePollDisabled) return;
     // Worker nodes: no local LLM API
     if (domain === "llm" && !this._llmMonitoringEnabled()) return;
+    if (domain === "comfy" && !this._comfyMonitoringEnabled()) return;
     this._inflight[domain] = true;
     try {
       let result;
@@ -305,6 +373,9 @@ export class SparkMonitor {
           result = await Promise.all(
             Array.from(this.llmProbes.values()).map((probe) => probe.probe())
           );
+          break;
+        case "comfy":
+          result = this.comfyProbe ? await this.comfyProbe.probe() : null;
           break;
       }
       // Re-check after the await — `stop()`/`updateSpark()` may have torn
@@ -341,6 +412,9 @@ export class SparkMonitor {
           break;
         case "llm":
           this._metrics.llm = result;
+          break;
+        case "comfy":
+          this._metrics.comfy = result;
           break;
       }
       this._lastUpdate[domain] = Date.now();

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -248,6 +248,8 @@ export class SparkMonitor {
       name: this.spark.name,
       online: this.online,
       uptime: this._uptimeSeconds,
+      lanIp: this.spark.lanIp || "",
+      isLocal: Boolean(this.spark.isLocal),
       disabledDevices: this.spark.disabledDevices || [],
       disabledInterfaces: this.spark.disabledInterfaces || [],
       storagePollDisabled: Boolean(this.spark.storagePollDisabled),

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -505,10 +505,23 @@ export class SparkRegistry {
        */
       llmMonitoring:
         role === "worker" ? false : role === "head" ? true : config.llmMonitoring !== false,
+      /**
+       * Probe local ComfyUI and show the ComfyUI card (default false; all roles).
+       */
+      comfyMonitoring: Boolean(config.comfyMonitoring),
+      /** ComfyUI HTTP port (default 8188). */
+      comfyPort: this._normalizeComfyPort(config.comfyPort),
       disabledDevices: Array.isArray(config.disabledDevices) ? config.disabledDevices : [],
       disabledInterfaces: Array.isArray(config.disabledInterfaces) ? config.disabledInterfaces : [],
       storagePollDisabled: Boolean(config.storagePollDisabled),
     };
+  }
+
+  /** Normalize ComfyUI port to 1–65535 (default 8188). */
+  _normalizeComfyPort(value) {
+    const n = typeof value === "string" ? parseInt(value, 10) : Number(value);
+    if (Number.isInteger(n) && n >= 1 && n <= 65535) return n;
+    return 8188;
   }
 
   /** Normalize role; legacy workerNode=true → worker. */

--- a/server/sparks/__tests__/role-normalize.test.js
+++ b/server/sparks/__tests__/role-normalize.test.js
@@ -15,6 +15,18 @@ test("roles derive workerNode and llmMonitoring", () => {
   assert.equal(n({ role: "standalone", llmMonitoring: false }).llmMonitoring, false);
 });
 
+test("comfyMonitoring is opt-in for all roles; comfyPort defaults to 8188", () => {
+  assert.equal(n({ role: "head" }).comfyMonitoring, false);
+  assert.equal(n({ role: "worker" }).comfyMonitoring, false);
+  assert.equal(n({ role: "standalone" }).comfyMonitoring, false);
+  assert.equal(n({ role: "standalone", comfyMonitoring: true }).comfyMonitoring, true);
+  assert.equal(n({ role: "worker", comfyMonitoring: true }).comfyMonitoring, true);
+  assert.equal(n({}).comfyPort, 8188);
+  assert.equal(n({ comfyPort: 9000 }).comfyPort, 9000);
+  assert.equal(n({ comfyPort: 0 }).comfyPort, 8188);
+  assert.equal(n({ comfyPort: "8190" }).comfyPort, 8190);
+});
+
 test("legacy workerNode-only becomes worker", () => {
   const out = n({ workerNode: true, workerLabel: "  DS  ", workerHeadId: "s5" });
   assert.equal(out.role, "worker");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,8 @@ function placeholderSnapshot(
     workerLabel?: string | null;
     workerHeadId?: string | null;
     llmMonitoring?: boolean;
+    comfyMonitoring?: boolean;
+    comfyPort?: number;
   }
 ): SparkSnapshot {
   const role =
@@ -56,6 +58,8 @@ function placeholderSnapshot(
         : role === "head"
           ? true
           : roleFields?.llmMonitoring !== false,
+    comfyMonitoring: Boolean(roleFields?.comfyMonitoring),
+    comfyPort: roleFields?.comfyPort ?? 8188,
     hardware: {
       device: "NVIDIA DGX Spark",
       cpuModel: "…",
@@ -73,6 +77,7 @@ function placeholderSnapshot(
       network: null,
       unifiedMemory: null,
       llm: [],
+      comfy: null,
     },
   };
 }
@@ -158,6 +163,8 @@ function DashboardApp() {
               workerLabel: c.workerLabel ?? existing.workerLabel,
               workerHeadId: c.workerHeadId ?? existing.workerHeadId,
               llmMonitoring: c.llmMonitoring ?? existing.llmMonitoring,
+              comfyMonitoring: c.comfyMonitoring ?? existing.comfyMonitoring,
+              comfyPort: c.comfyPort ?? existing.comfyPort,
               disabledDevices: c.disabledDevices || existing.disabledDevices,
               disabledInterfaces: c.disabledInterfaces || existing.disabledInterfaces,
               llmPorts: c.llmPorts ?? existing.llmPorts,
@@ -176,6 +183,8 @@ function DashboardApp() {
               workerLabel: c.workerLabel,
               workerHeadId: c.workerHeadId,
               llmMonitoring: c.llmMonitoring,
+              comfyMonitoring: c.comfyMonitoring,
+              comfyPort: c.comfyPort,
             }
           );
         })

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -100,6 +100,17 @@ export function testSparkConfig(config: Omit<SparkConfig, "id"> & { id?: string 
   });
 }
 
+/** Cancel a ComfyUI job (interrupt running and/or remove from queue). */
+export function cancelComfyJob(
+  sparkId: string,
+  promptId: string
+): Promise<{ success: boolean; ok?: boolean; method?: string; message?: string }> {
+  return apiFetch(`/api/sparks/${encodeURIComponent(sparkId)}/comfy/cancel`, {
+    method: "POST",
+    body: JSON.stringify({ promptId }),
+  });
+}
+
 // ─── Disabled storage devices ─────────────────────────────
 export function updateDisabledDevices(
   id: string,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -261,6 +261,32 @@ export interface ComfyJob {
   createTime: number | null;
 }
 
+/** Live or estimated progress for the active Comfy job. */
+export interface ComfyProgress {
+  promptId: string | null;
+  nodeId: string | null;
+  nodeLabel: string | null;
+  value: number;
+  max: number;
+  percent: number | null;
+  updatedAt: number;
+  /** ws = Comfy WebSocket frames; estimate = elapsed/avg heuristic */
+  source?: "ws" | "estimate";
+}
+
+export interface ComfyLastJob {
+  id: string;
+  status: "completed" | "failed" | "cancelled" | string;
+  title: string | null;
+  durationMs: number | null;
+  endedAt: number | null;
+}
+
+export interface ComfyModelsInstalled {
+  checkpoints: string[];
+  loras: string[];
+}
+
 export interface ComfyMetrics {
   available: boolean;
   port: number;
@@ -274,6 +300,13 @@ export interface ComfyMetrics {
   activeJob?: ComfyJob | null;
   /** Next pending jobs (capped server-side). */
   pendingJobs?: ComfyJob[];
+  progress?: ComfyProgress | null;
+  lastJob?: ComfyLastJob | null;
+  modelsInstalled?: ComfyModelsInstalled | null;
+  /** Estimated ms until queue idle (running remainder + pending × avg). */
+  queueEtaMs?: number | null;
+  /** Browser-openable ComfyUI base URL (probe host + port). */
+  openUrl?: string | null;
   error: string | null;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -59,6 +59,12 @@ export interface SparkConfig {
    * Forced true for head, forced false for worker.
    */
   llmMonitoring?: boolean;
+  /**
+   * Probe local ComfyUI and show the ComfyUI card (default false; all roles).
+   */
+  comfyMonitoring?: boolean;
+  /** ComfyUI HTTP port (default 8188). */
+  comfyPort?: number;
   /** When true, storage is only updated on manual refresh, not auto-polled. */
   storagePollDisabled?: boolean;
 }
@@ -236,6 +242,41 @@ export interface LlmPosture {
   detail: string;
 }
 
+// ─── ComfyUI metrics ─────────────────────────────────────
+/** Active or queued ComfyUI job (parsed from /queue prompt graph). */
+export interface ComfyJob {
+  id: string;
+  status: "running" | "pending";
+  /** Workflow title when present in extra_pnginfo. */
+  title: string | null;
+  /** Model weight files referenced by loader nodes. */
+  models: string[];
+  nodeCount: number;
+  steps: number | null;
+  width: number | null;
+  height: number | null;
+  batchSize: number | null;
+  sampler: string | null;
+  /** Queue entry create time (ms epoch when available). */
+  createTime: number | null;
+}
+
+export interface ComfyMetrics {
+  available: boolean;
+  port: number;
+  version: string | null;
+  pytorchVersion: string | null;
+  /** Primary device type from /system_stats (e.g. cpu, cuda) — not VRAM. */
+  deviceType?: string | null;
+  queueRunning: number;
+  queuePending: number;
+  /** Currently executing job, if any. */
+  activeJob?: ComfyJob | null;
+  /** Next pending jobs (capped server-side). */
+  pendingJobs?: ComfyJob[];
+  error: string | null;
+}
+
 // ─── Full metrics snapshot ────────────────────────────────
 export interface SparkMetrics {
   gpu: GpuMetrics | null;
@@ -246,6 +287,8 @@ export interface SparkMetrics {
   unifiedMemory: UnifiedMemoryMetrics | null;
   /** Array of LLM metrics, one per configured port. Empty array when no ports. */
   llm: LlmMetrics[];
+  /** ComfyUI probe result when monitoring is enabled; null when off or not yet polled. */
+  comfy?: ComfyMetrics | null;
 }
 
 // ─── Spark snapshot (server pushes this) ──────────────────
@@ -274,6 +317,10 @@ export interface SparkSnapshot {
   llmPorts: number[];
   /** Ports with a stored LLM API key (key itself never exposed) */
   llmApiKeyPorts?: number[];
+  /** Whether ComfyUI is probed (opt-in; all roles) */
+  comfyMonitoring?: boolean;
+  /** ComfyUI HTTP port (default 8188) */
+  comfyPort?: number;
   hardware: HardwareInfo;
   metrics: SparkMetrics;
 }
@@ -293,7 +340,7 @@ export interface Settings {
   temperatureUnit: "celsius" | "fahrenheit";
   /** Persist prompts / HTTP traces / GPU samples on decode benchmark runs. */
   benchDebugTraces: boolean;
-  /** Layout density — comfortable (default) or compact. */
+  /** Layout density — compact (default) or comfortable. */
   density: "comfortable" | "compact";
 }
 
@@ -305,6 +352,7 @@ export interface SparkTestResponse {
   id: string;
   ssh: { ok: boolean; message: string };
   llm: { ok: boolean; message: string };
+  comfy?: { ok: boolean; message: string; skipped?: boolean };
   ok: boolean;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -331,6 +331,9 @@ export interface SparkSnapshot {
   online: boolean;
   /** Uptime in seconds, or null when offline */
   uptime: number | null;
+  /** LAN IP for browser deep-links (e.g. Open ComfyUI). */
+  lanIp?: string;
+  isLocal?: boolean;
   disabledDevices: string[];
   disabledInterfaces: string[];
   storagePollDisabled?: boolean;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -323,6 +323,10 @@ export interface DecodeBenchConfig {
 export interface DecodeBenchStreamResult {
   index: number;
   ttftMs: number;
+  /** First answer token (post-reasoning) in ms from request start; null when the reply never leaves the reasoning phase. */
+  ttftContentMs: number | null;
+  /** Number of streamed chunks that carried reasoning (not answer) text. */
+  reasoningChunks: number;
   decodeTps: number;
   decodeTokens: number;
   completionTokens: number;

--- a/src/components/EditSparkDialog.tsx
+++ b/src/components/EditSparkDialog.tsx
@@ -178,7 +178,9 @@ export function EditSparkDialog({
         config.isLocal !== savedConfig.isLocal ||
         (config.ssh?.host || config.lanIp) !== (savedConfig.ssh?.host || savedConfig.lanIp) ||
         config.ssh?.user !== savedConfig.ssh?.user ||
-        config.ssh?.auth !== savedConfig.ssh?.auth;
+        config.ssh?.auth !== savedConfig.ssh?.auth ||
+        Boolean(config.comfyMonitoring) !== Boolean(savedConfig.comfyMonitoring) ||
+        (config.comfyPort ?? 8188) !== (savedConfig.comfyPort ?? 8188);
 
       const result = formDirty
         ? await testSparkConfig({
@@ -196,10 +198,16 @@ export function EditSparkDialog({
       else parts.push(`SSH ✗ ${result.ssh.message}`);
       if (result.llm.ok) parts.push("LLM ✓");
       else parts.push(`LLM ✗ ${result.llm.message}`);
+      if (result.comfy && !result.comfy.skipped) {
+        if (result.comfy.ok) parts.push("ComfyUI ✓");
+        else parts.push(`ComfyUI ✗ ${result.comfy.message}`);
+      }
       setTestResult({
         ok: result.ok,
         message: result.ok
-          ? "Connection successful"
+          ? parts.length
+            ? `Connection successful (${parts.join(" · ")})`
+            : "Connection successful"
           : `${parts.join(" | ")} — password is still saved for when the host is back.`,
       });
       if (password) setPassword("");
@@ -236,6 +244,11 @@ export function EditSparkDialog({
         workerHeadId: role === "worker" ? (config.workerHeadId?.trim() || null) : null,
         llmMonitoring:
           role === "worker" ? false : role === "head" ? true : config.llmMonitoring !== false,
+        comfyMonitoring: Boolean(config.comfyMonitoring),
+        comfyPort: (() => {
+          const n = Number(config.comfyPort);
+          return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : 8188;
+        })(),
         ssh: {
           host: config.ssh.host || config.lanIp,
           user: config.ssh.user,
@@ -392,6 +405,63 @@ export function EditSparkDialog({
                   </span>
                 </label>
               )}
+
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted">
+                <label className="flex min-w-0 items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(config.comfyMonitoring)}
+                    onChange={(e) =>
+                      update({
+                        comfyMonitoring: e.target.checked,
+                        comfyPort: config.comfyPort ?? 8188,
+                      })
+                    }
+                    className="rounded border-border"
+                  />
+                  <span>ComfyUI monitoring</span>
+                  <span
+                    className="inline-flex shrink-0 cursor-help text-muted hover:text-text"
+                    title="When enabled, probe ComfyUI on this host and show a ComfyUI card. Default port is 8188 — change the port value on the right if needed."
+                    aria-label="Enable probing ComfyUI and showing the ComfyUI card."
+                  >
+                    <InfoIcon className="h-3.5 w-3.5" />
+                  </span>
+                </label>
+                {/* Compact “port 8188” control on the same row. */}
+                <div
+                  className={`ml-auto flex items-center gap-1 font-tabular ${
+                    config.comfyMonitoring ? "text-text" : "pointer-events-none opacity-40"
+                  }`}
+                  title="ComfyUI HTTP port (default 8188)"
+                >
+                  <span className="select-none text-muted" aria-hidden>
+                    port
+                  </span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={65535}
+                    inputMode="numeric"
+                    disabled={!config.comfyMonitoring}
+                    aria-label="ComfyUI port"
+                    value={config.comfyPort ?? 8188}
+                    onChange={(e) => {
+                      const n = parseInt(e.target.value, 10);
+                      if (Number.isInteger(n) && n >= 1 && n <= 65535) {
+                        update({ comfyPort: n });
+                      }
+                    }}
+                    onBlur={() => {
+                      const n = Number(config.comfyPort);
+                      if (!Number.isInteger(n) || n < 1 || n > 65535) {
+                        update({ comfyPort: 8188 });
+                      }
+                    }}
+                    className="w-14 border-0 bg-transparent px-0.5 py-0.5 text-center font-tabular text-xs text-inherit outline-none focus:rounded focus:bg-surface-elevated focus:ring-1 focus:ring-accent disabled:cursor-not-allowed"
+                  />
+                </div>
+              </div>
 
               {role === "worker" && (
                 <div className="space-y-3">

--- a/src/components/OverviewPage/OverviewPage.tsx
+++ b/src/components/OverviewPage/OverviewPage.tsx
@@ -155,6 +155,38 @@ function SparkCard({
             </span>
           );
         })()}
+        {spark.comfyMonitoring ? (
+          <span
+            className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+              !spark.metrics?.comfy?.available
+                ? "bg-border/60 text-muted"
+                : (spark.metrics.comfy.queueRunning ?? 0) > 0
+                  ? "bg-accent/15 text-accent"
+                  : (spark.metrics.comfy.queuePending ?? 0) > 0
+                    ? "bg-warning/15 text-warning"
+                    : "bg-border/60 text-muted"
+            }`}
+            title={
+              !spark.metrics?.comfy?.available
+                ? "ComfyUI monitoring on — not reachable"
+                : (spark.metrics.comfy.queueRunning ?? 0) > 0
+                  ? spark.metrics.comfy.activeJob?.title
+                    ? `ComfyUI running: ${spark.metrics.comfy.activeJob.title}`
+                    : "ComfyUI job running"
+                  : (spark.metrics.comfy.queuePending ?? 0) > 0
+                    ? `ComfyUI queue: ${spark.metrics.comfy.queuePending} pending`
+                    : "ComfyUI idle"
+            }
+          >
+            {!spark.metrics?.comfy?.available
+              ? "Comfy"
+              : (spark.metrics.comfy.queueRunning ?? 0) > 0
+                ? "Comfy · run"
+                : (spark.metrics.comfy.queuePending ?? 0) > 0
+                  ? `Comfy · ${spark.metrics.comfy.queuePending}q`
+                  : "Comfy · idle"}
+          </span>
+        ) : null}
         <span className="text-[10px] uppercase tracking-wide text-muted">
           {online ? "online" : "offline"}
         </span>

--- a/src/components/SparkPage/ComfyPanel.tsx
+++ b/src/components/SparkPage/ComfyPanel.tsx
@@ -1,0 +1,194 @@
+import type { ComfyJob, ComfyMetrics } from "../../api/types";
+import { Panel } from "../ui/Panel";
+import { ComfyIcon } from "../ui/icons";
+
+interface ComfyPanelProps {
+  comfy: ComfyMetrics | null;
+  comfyPort: number;
+  className?: string;
+}
+
+function shortId(id: string): string {
+  if (id.length <= 12) return id;
+  return `${id.slice(0, 8)}…`;
+}
+
+function formatElapsed(createTimeMs: number | null | undefined): string | null {
+  if (createTimeMs == null || !Number.isFinite(createTimeMs)) return null;
+  // Comfy create_time is usually ms epoch; tolerate seconds.
+  const ms = createTimeMs < 1e12 ? createTimeMs * 1000 : createTimeMs;
+  const elapsedSec = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+  if (elapsedSec < 60) return `${elapsedSec}s`;
+  const m = Math.floor(elapsedSec / 60);
+  const s = elapsedSec % 60;
+  if (m < 60) return `${m}m ${s}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+function jobFootprint(job: ComfyJob): string {
+  const parts: string[] = [];
+  if (job.width != null && job.height != null) {
+    parts.push(`${job.width}×${job.height}`);
+  }
+  if (job.steps != null) parts.push(`${job.steps} steps`);
+  if (job.batchSize != null && job.batchSize !== 1) parts.push(`batch ${job.batchSize}`);
+  if (job.sampler) parts.push(job.sampler);
+  if (job.nodeCount > 0) parts.push(`${job.nodeCount} nodes`);
+  return parts.join(" · ");
+}
+
+function JobBlock({
+  job,
+  variant,
+}: {
+  job: ComfyJob;
+  variant: "running" | "pending";
+}) {
+  const title = job.title?.trim() || shortId(job.id);
+  const footprint = jobFootprint(job);
+  const elapsed = variant === "running" ? formatElapsed(job.createTime) : null;
+  const models = job.models ?? [];
+
+  return (
+    <div className="space-y-2 rounded-md border border-border bg-surface-elevated/40 px-3 py-2.5">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`llm-badge ${variant === "running" ? "" : "opacity-80"}`}
+              title={job.id}
+            >
+              <span
+                className={`h-1.5 w-1.5 rounded-full ${
+                  variant === "running" ? "bg-accent" : "bg-muted"
+                }`}
+              />
+              {variant === "running" ? "Running" : "Queued"}
+            </span>
+            {elapsed ? (
+              <span className="font-tabular text-[11px] text-muted" title="Elapsed since queue entry">
+                {elapsed}
+              </span>
+            ) : null}
+          </div>
+          <p className="mt-1 truncate text-sm font-medium text-text" title={job.title || job.id}>
+            {title}
+          </p>
+        </div>
+      </div>
+
+      {footprint ? (
+        <p className="font-tabular text-[11px] text-muted" title="Workflow compute footprint">
+          {footprint}
+        </p>
+      ) : null}
+
+      {models.length > 0 ? (
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-wide text-muted">Models</div>
+          <ul className="space-y-0.5">
+            {models.slice(0, 6).map((m) => (
+              <li
+                key={m}
+                className="truncate font-tabular text-[12px] text-text"
+                title={m}
+              >
+                {m}
+              </li>
+            ))}
+            {models.length > 6 ? (
+              <li className="text-[11px] text-muted">+{models.length - 6} more</li>
+            ) : null}
+          </ul>
+        </div>
+      ) : (
+        <p className="text-[11px] text-muted">No model files found in this graph.</p>
+      )}
+    </div>
+  );
+}
+
+export function ComfyPanel({ comfy, comfyPort, className = "" }: ComfyPanelProps) {
+  const available = Boolean(comfy?.available);
+  const pending = comfy?.queuePending ?? 0;
+  const active = comfy?.activeJob ?? null;
+  const pendingJobs = comfy?.pendingJobs ?? [];
+
+  return (
+    <Panel
+      title="ComfyUI"
+      icon={<ComfyIcon />}
+      className={`panel-comfy ${className}`}
+      bodyClassName="space-y-3"
+      accent
+      actions={
+        <span className="font-tabular text-[11px] text-muted" title="Probe port">
+          :{comfyPort}
+        </span>
+      }
+    >
+      {!available ? (
+        <div className="space-y-1 text-sm">
+          <p className="text-muted">Not reachable</p>
+          {comfy?.error ? (
+            <p className="text-[11px] text-muted break-all">{comfy.error}</p>
+          ) : (
+            <p className="text-[11px] text-muted">
+              Ensure ComfyUI is running on this host (default port 8188).
+            </p>
+          )}
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-2 text-xs">
+            <span className="llm-badge">
+              <span className="h-1.5 w-1.5 rounded-full bg-accent" />
+              Online
+            </span>
+            {comfy?.version ? (
+              <span className="text-muted" title="ComfyUI version">
+                v{comfy.version}
+              </span>
+            ) : null}
+            {comfy?.deviceType ? (
+              <span className="text-muted" title="ComfyUI compute device">
+                {comfy.deviceType}
+              </span>
+            ) : null}
+            {comfy?.pytorchVersion ? (
+              <span className="text-muted" title="PyTorch version">
+                torch {comfy.pytorchVersion}
+              </span>
+            ) : null}
+          </div>
+
+          {active ? (
+            <JobBlock job={active} variant="running" />
+          ) : (
+            <div className="rounded-md border border-dashed border-border px-3 py-3 text-sm text-muted">
+              Idle — no running job
+            </div>
+          )}
+
+          {pending > 0 ? (
+            <div className="space-y-2">
+              <div className="flex items-baseline justify-between gap-2 text-[10px] uppercase tracking-wide text-muted">
+                <span>Queue</span>
+                <span className="font-tabular normal-case text-muted">{pending} pending</span>
+              </div>
+              {pendingJobs.slice(0, 2).map((job) => (
+                <JobBlock key={job.id} job={job} variant="pending" />
+              ))}
+              {pending > Math.min(2, pendingJobs.length) ? (
+                <p className="text-[11px] text-muted">
+                  +{pending - Math.min(2, pendingJobs.length)} more waiting
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </>
+      )}
+    </Panel>
+  );
+}

--- a/src/components/SparkPage/ComfyPanel.tsx
+++ b/src/components/SparkPage/ComfyPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, type MouseEvent } from "react";
 import type { ComfyJob, ComfyMetrics, ComfyProgress } from "../../api/types";
 import { cancelComfyJob } from "../../api/client";
 import { Panel } from "../ui/Panel";
@@ -8,7 +8,35 @@ interface ComfyPanelProps {
   comfy: ComfyMetrics | null;
   comfyPort: number;
   sparkId: string;
+  /** Spark LAN IP — preferred host for the Open ComfyUI deep link. */
+  lanIp?: string | null;
   className?: string;
+}
+
+/** Browser URL for ComfyUI UI — always LAN IP when known (never dashboard origin). */
+function comfyOpenUrl(lanIp: string | null | undefined, comfyPort: number, serverOpenUrl?: string | null): string {
+  const port =
+    Number.isInteger(comfyPort) && comfyPort >= 1 && comfyPort <= 65535 ? comfyPort : 8188;
+  const lan = lanIp != null ? String(lanIp).trim() : "";
+  if (lan && lan !== "127.0.0.1" && lan !== "localhost") {
+    return `http://${lan}:${port}`;
+  }
+  // Prefer server-provided URL if it is absolute and not the dashboard path
+  if (serverOpenUrl && /^https?:\/\//i.test(serverOpenUrl)) {
+    try {
+      const u = new URL(serverOpenUrl);
+      if (u.port !== "5555" && !u.pathname.startsWith("/spark")) {
+        return serverOpenUrl;
+      }
+      // If server sent a loopback URL, still use host when non-local path
+      if (u.hostname !== "127.0.0.1" && u.hostname !== "localhost") {
+        return `http://${u.hostname}:${port}`;
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+  return `http://127.0.0.1:${port}`;
 }
 
 function shortId(id: string): string {
@@ -182,7 +210,13 @@ function JobBlock({
   );
 }
 
-export function ComfyPanel({ comfy, comfyPort, sparkId, className = "" }: ComfyPanelProps) {
+export function ComfyPanel({
+  comfy,
+  comfyPort,
+  sparkId,
+  lanIp,
+  className = "",
+}: ComfyPanelProps) {
   const available = Boolean(comfy?.available);
   const pending = comfy?.queuePending ?? 0;
   const active = comfy?.activeJob ?? null;
@@ -191,11 +225,21 @@ export function ComfyPanel({ comfy, comfyPort, sparkId, className = "" }: ComfyP
   const lastJob = comfy?.lastJob ?? null;
   const modelsInstalled = comfy?.modelsInstalled ?? null;
   const etaLabel = formatEtaMs(comfy?.queueEtaMs ?? null);
-  const openUrl = comfy?.openUrl ?? `http://127.0.0.1:${comfyPort}`;
+  const openUrl = comfyOpenUrl(lanIp, comfyPort, comfy?.openUrl ?? null);
 
   const [cancellingId, setCancellingId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [modelsOpen, setModelsOpen] = useState(false);
+
+  const handleOpenComfy = useCallback(
+    (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      // Force a real top-level navigation off the sparkDash SPA origin.
+      window.open(openUrl, "_blank", "noopener,noreferrer");
+    },
+    [openUrl]
+  );
 
   const handleCancel = useCallback(
     async (promptId: string) => {
@@ -229,7 +273,8 @@ export function ComfyPanel({ comfy, comfyPort, sparkId, className = "" }: ComfyP
             href={openUrl}
             target="_blank"
             rel="noopener noreferrer"
-            title={`Open ComfyUI (${openUrl}) — host must be reachable from your browser`}
+            onClick={handleOpenComfy}
+            title={`Open ComfyUI at ${openUrl} (must be reachable from your browser)`}
             className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[11px] text-muted transition-colors hover:border-accent hover:text-accent"
           >
             <ExternalLinkIcon className="h-3 w-3" />
@@ -350,7 +395,8 @@ export function ComfyPanel({ comfy, comfyPort, sparkId, className = "" }: ComfyP
             </p>
           ) : null}
 
-          {modelsInstalled ? (
+          {modelsInstalled &&
+          (modelsInstalled.checkpoints.length > 0 || modelsInstalled.loras.length > 0) ? (
             <div className="border-t border-border pt-2">
               <button
                 type="button"
@@ -365,11 +411,11 @@ export function ComfyPanel({ comfy, comfyPort, sparkId, className = "" }: ComfyP
               </button>
               {modelsOpen ? (
                 <div className="mt-1.5 grid gap-2 sm:grid-cols-2">
-                  <div>
-                    <div className="text-[10px] uppercase tracking-wide text-muted">Checkpoints</div>
-                    {modelsInstalled.checkpoints.length === 0 ? (
-                      <p className="text-[11px] text-muted">None</p>
-                    ) : (
+                  {modelsInstalled.checkpoints.length > 0 ? (
+                    <div>
+                      <div className="text-[10px] uppercase tracking-wide text-muted">
+                        Checkpoints
+                      </div>
                       <ul className="mt-0.5 space-y-0.5">
                         {modelsInstalled.checkpoints.slice(0, 12).map((m) => (
                           <li
@@ -381,13 +427,11 @@ export function ComfyPanel({ comfy, comfyPort, sparkId, className = "" }: ComfyP
                           </li>
                         ))}
                       </ul>
-                    )}
-                  </div>
-                  <div>
-                    <div className="text-[10px] uppercase tracking-wide text-muted">LoRAs</div>
-                    {modelsInstalled.loras.length === 0 ? (
-                      <p className="text-[11px] text-muted">None</p>
-                    ) : (
+                    </div>
+                  ) : null}
+                  {modelsInstalled.loras.length > 0 ? (
+                    <div>
+                      <div className="text-[10px] uppercase tracking-wide text-muted">LoRAs</div>
                       <ul className="mt-0.5 space-y-0.5">
                         {modelsInstalled.loras.slice(0, 12).map((m) => (
                           <li
@@ -399,8 +443,8 @@ export function ComfyPanel({ comfy, comfyPort, sparkId, className = "" }: ComfyP
                           </li>
                         ))}
                       </ul>
-                    )}
-                  </div>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
             </div>

--- a/src/components/SparkPage/ComfyPanel.tsx
+++ b/src/components/SparkPage/ComfyPanel.tsx
@@ -1,10 +1,13 @@
-import type { ComfyJob, ComfyMetrics } from "../../api/types";
+import { useState, useCallback } from "react";
+import type { ComfyJob, ComfyMetrics, ComfyProgress } from "../../api/types";
+import { cancelComfyJob } from "../../api/client";
 import { Panel } from "../ui/Panel";
-import { ComfyIcon } from "../ui/icons";
+import { ComfyIcon, ExternalLinkIcon } from "../ui/icons";
 
 interface ComfyPanelProps {
   comfy: ComfyMetrics | null;
   comfyPort: number;
+  sparkId: string;
   className?: string;
 }
 
@@ -15,7 +18,6 @@ function shortId(id: string): string {
 
 function formatElapsed(createTimeMs: number | null | undefined): string | null {
   if (createTimeMs == null || !Number.isFinite(createTimeMs)) return null;
-  // Comfy create_time is usually ms epoch; tolerate seconds.
   const ms = createTimeMs < 1e12 ? createTimeMs * 1000 : createTimeMs;
   const elapsedSec = Math.max(0, Math.floor((Date.now() - ms) / 1000));
   if (elapsedSec < 60) return `${elapsedSec}s`;
@@ -24,6 +26,22 @@ function formatElapsed(createTimeMs: number | null | undefined): string | null {
   if (m < 60) return `${m}m ${s}s`;
   const h = Math.floor(m / 60);
   return `${h}h ${m % 60}m`;
+}
+
+function formatDurationMs(ms: number | null | undefined): string | null {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return null;
+  const sec = Math.round(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  if (m < 60) return s ? `${m}m ${s}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+function formatEtaMs(ms: number | null | undefined): string | null {
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) return null;
+  return `~${formatDurationMs(ms)}`;
 }
 
 function jobFootprint(job: ComfyJob): string {
@@ -38,12 +56,58 @@ function jobFootprint(job: ComfyJob): string {
   return parts.join(" · ");
 }
 
+function ProgressBar({ progress }: { progress: ComfyProgress }) {
+  const pct =
+    progress.percent != null
+      ? progress.percent
+      : progress.max > 0
+        ? Math.min(100, Math.round((progress.value / progress.max) * 100))
+        : 0;
+  const label =
+    progress.nodeLabel ||
+    (progress.source === "estimate" ? "Elapsed (est.)" : "Progress");
+  const detail =
+    progress.max > 0 && progress.source === "ws"
+      ? `${Math.round(progress.value)}/${Math.round(progress.max)}`
+      : progress.percent != null
+        ? `${pct}%`
+        : null;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2 text-[11px]">
+        <span className="truncate text-muted" title={label}>
+          {label}
+          {progress.source === "estimate" ? (
+            <span className="ml-1 text-[10px] opacity-70">est.</span>
+          ) : null}
+        </span>
+        {detail ? <span className="font-tabular text-text">{detail}</span> : null}
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-border">
+        <div
+          className="h-full rounded-full bg-accent transition-[width] duration-300"
+          style={{ width: `${Math.min(100, Math.max(0, pct))}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
 function JobBlock({
   job,
   variant,
+  progress,
+  etaLabel,
+  onCancel,
+  cancelling,
 }: {
   job: ComfyJob;
   variant: "running" | "pending";
+  progress?: ComfyProgress | null;
+  etaLabel?: string | null;
+  onCancel?: () => void;
+  cancelling?: boolean;
 }) {
   const title = job.title?.trim() || shortId(job.id);
   const footprint = jobFootprint(job);
@@ -53,7 +117,7 @@ function JobBlock({
   return (
     <div className="space-y-2 rounded-md border border-border bg-surface-elevated/40 px-3 py-2.5">
       <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
             <span
               className={`llm-badge ${variant === "running" ? "" : "opacity-80"}`}
@@ -67,8 +131,11 @@ function JobBlock({
               {variant === "running" ? "Running" : "Queued"}
             </span>
             {elapsed ? (
-              <span className="font-tabular text-[11px] text-muted" title="Elapsed since queue entry">
-                {elapsed}
+              <span className="font-tabular text-[11px] text-muted">{elapsed}</span>
+            ) : null}
+            {etaLabel ? (
+              <span className="font-tabular text-[11px] text-muted" title="Estimated time remaining">
+                {etaLabel} left
               </span>
             ) : null}
           </div>
@@ -76,7 +143,19 @@ function JobBlock({
             {title}
           </p>
         </div>
+        {onCancel ? (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={cancelling}
+            className="shrink-0 rounded border border-border px-2 py-0.5 text-[11px] text-muted transition-colors hover:border-danger hover:text-danger disabled:opacity-50"
+          >
+            {cancelling ? "…" : variant === "running" ? "Cancel" : "Remove"}
+          </button>
+        ) : null}
       </div>
+
+      {variant === "running" && progress ? <ProgressBar progress={progress} /> : null}
 
       {footprint ? (
         <p className="font-tabular text-[11px] text-muted" title="Workflow compute footprint">
@@ -89,11 +168,7 @@ function JobBlock({
           <div className="text-[10px] uppercase tracking-wide text-muted">Models</div>
           <ul className="space-y-0.5">
             {models.slice(0, 6).map((m) => (
-              <li
-                key={m}
-                className="truncate font-tabular text-[12px] text-text"
-                title={m}
-              >
+              <li key={m} className="truncate font-tabular text-[12px] text-text" title={m}>
                 {m}
               </li>
             ))}
@@ -102,18 +177,41 @@ function JobBlock({
             ) : null}
           </ul>
         </div>
-      ) : (
-        <p className="text-[11px] text-muted">No model files found in this graph.</p>
-      )}
+      ) : null}
     </div>
   );
 }
 
-export function ComfyPanel({ comfy, comfyPort, className = "" }: ComfyPanelProps) {
+export function ComfyPanel({ comfy, comfyPort, sparkId, className = "" }: ComfyPanelProps) {
   const available = Boolean(comfy?.available);
   const pending = comfy?.queuePending ?? 0;
   const active = comfy?.activeJob ?? null;
   const pendingJobs = comfy?.pendingJobs ?? [];
+  const progress = comfy?.progress ?? null;
+  const lastJob = comfy?.lastJob ?? null;
+  const modelsInstalled = comfy?.modelsInstalled ?? null;
+  const etaLabel = formatEtaMs(comfy?.queueEtaMs ?? null);
+  const openUrl = comfy?.openUrl ?? `http://127.0.0.1:${comfyPort}`;
+
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [modelsOpen, setModelsOpen] = useState(false);
+
+  const handleCancel = useCallback(
+    async (promptId: string) => {
+      if (!confirm("Cancel this ComfyUI job?")) return;
+      setActionError(null);
+      setCancellingId(promptId);
+      try {
+        await cancelComfyJob(sparkId, promptId);
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setCancellingId(null);
+      }
+    },
+    [sparkId]
+  );
 
   return (
     <Panel
@@ -123,16 +221,28 @@ export function ComfyPanel({ comfy, comfyPort, className = "" }: ComfyPanelProps
       bodyClassName="space-y-3"
       accent
       actions={
-        <span className="font-tabular text-[11px] text-muted" title="Probe port">
-          :{comfyPort}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="font-tabular text-[11px] text-muted" title="Probe port">
+            :{comfyPort}
+          </span>
+          <a
+            href={openUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`Open ComfyUI (${openUrl}) — host must be reachable from your browser`}
+            className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[11px] text-muted transition-colors hover:border-accent hover:text-accent"
+          >
+            <ExternalLinkIcon className="h-3 w-3" />
+            Open
+          </a>
+        </div>
       }
     >
       {!available ? (
         <div className="space-y-1 text-sm">
           <p className="text-muted">Not reachable</p>
           {comfy?.error ? (
-            <p className="text-[11px] text-muted break-all">{comfy.error}</p>
+            <p className="break-all text-[11px] text-muted">{comfy.error}</p>
           ) : (
             <p className="text-[11px] text-muted">
               Ensure ComfyUI is running on this host (default port 8188).
@@ -163,11 +273,44 @@ export function ComfyPanel({ comfy, comfyPort, className = "" }: ComfyPanelProps
             ) : null}
           </div>
 
+          {actionError ? (
+            <p className="text-[11px] text-danger">{actionError}</p>
+          ) : null}
+
           {active ? (
-            <JobBlock job={active} variant="running" />
+            <JobBlock
+              job={active}
+              variant="running"
+              progress={progress}
+              etaLabel={etaLabel}
+              onCancel={() => void handleCancel(active.id)}
+              cancelling={cancellingId === active.id}
+            />
           ) : (
-            <div className="rounded-md border border-dashed border-border px-3 py-3 text-sm text-muted">
-              Idle — no running job
+            <div className="space-y-2">
+              <div className="rounded-md border border-dashed border-border px-3 py-3 text-sm text-muted">
+                Idle — no running job
+              </div>
+              {lastJob ? (
+                <p
+                  className={`text-[11px] ${
+                    lastJob.status === "failed"
+                      ? "text-danger"
+                      : lastJob.status === "cancelled"
+                        ? "text-muted"
+                        : "text-muted"
+                  }`}
+                >
+                  Last:{" "}
+                  <span className="text-text">
+                    {lastJob.title?.trim() || shortId(lastJob.id)}
+                  </span>
+                  {formatDurationMs(lastJob.durationMs)
+                    ? ` · ${formatDurationMs(lastJob.durationMs)}`
+                    : ""}
+                  {` · ${lastJob.status}`}
+                </p>
+              ) : null}
             </div>
           )}
 
@@ -175,15 +318,90 @@ export function ComfyPanel({ comfy, comfyPort, className = "" }: ComfyPanelProps
             <div className="space-y-2">
               <div className="flex items-baseline justify-between gap-2 text-[10px] uppercase tracking-wide text-muted">
                 <span>Queue</span>
-                <span className="font-tabular normal-case text-muted">{pending} pending</span>
+                <span className="font-tabular normal-case text-muted">
+                  {pending} pending
+                  {etaLabel ? ` · ${etaLabel}` : ""}
+                </span>
               </div>
               {pendingJobs.slice(0, 2).map((job) => (
-                <JobBlock key={job.id} job={job} variant="pending" />
+                <JobBlock
+                  key={job.id}
+                  job={job}
+                  variant="pending"
+                  onCancel={() => void handleCancel(job.id)}
+                  cancelling={cancellingId === job.id}
+                />
               ))}
               {pending > Math.min(2, pendingJobs.length) ? (
                 <p className="text-[11px] text-muted">
                   +{pending - Math.min(2, pendingJobs.length)} more waiting
                 </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {active && lastJob ? (
+            <p className="text-[11px] text-muted">
+              Last: {lastJob.title?.trim() || shortId(lastJob.id)}
+              {formatDurationMs(lastJob.durationMs)
+                ? ` · ${formatDurationMs(lastJob.durationMs)}`
+                : ""}
+              {` · ${lastJob.status}`}
+            </p>
+          ) : null}
+
+          {modelsInstalled ? (
+            <div className="border-t border-border pt-2">
+              <button
+                type="button"
+                onClick={() => setModelsOpen((o) => !o)}
+                className="flex w-full items-center justify-between text-left text-[11px] text-muted hover:text-text"
+              >
+                <span>
+                  Installed: {modelsInstalled.checkpoints.length} checkpoints ·{" "}
+                  {modelsInstalled.loras.length} loras
+                </span>
+                <span className="text-[10px]">{modelsOpen ? "Hide" : "Show"}</span>
+              </button>
+              {modelsOpen ? (
+                <div className="mt-1.5 grid gap-2 sm:grid-cols-2">
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-muted">Checkpoints</div>
+                    {modelsInstalled.checkpoints.length === 0 ? (
+                      <p className="text-[11px] text-muted">None</p>
+                    ) : (
+                      <ul className="mt-0.5 space-y-0.5">
+                        {modelsInstalled.checkpoints.slice(0, 12).map((m) => (
+                          <li
+                            key={m}
+                            className="truncate font-tabular text-[11px] text-text"
+                            title={m}
+                          >
+                            {m}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-muted">LoRAs</div>
+                    {modelsInstalled.loras.length === 0 ? (
+                      <p className="text-[11px] text-muted">None</p>
+                    ) : (
+                      <ul className="mt-0.5 space-y-0.5">
+                        {modelsInstalled.loras.slice(0, 12).map((m) => (
+                          <li
+                            key={m}
+                            className="truncate font-tabular text-[11px] text-text"
+                            title={m}
+                          >
+                            {m}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </div>
               ) : null}
             </div>
           ) : null}

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -271,6 +271,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
               <ComfyPanel
                 comfy={metrics.comfy ?? null}
                 comfyPort={spark.comfyPort ?? 8188}
+                sparkId={spark.id}
                 className={primarySideBySide ? undefined : "md:col-span-2"}
               />
             )}

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, type CSSProperties } from "react";
 import type { SparkSnapshot } from "../../api/types";
 import { isLlmMonitoringEnabled } from "../../api/sparkRole";
 import { updateSpark, refreshSparkMetric, addLlmPort, removeLlmPort } from "../../api/client";
@@ -8,11 +8,70 @@ import { CpuPanel } from "./CpuPanel";
 import { StoragePanel } from "./StoragePanel";
 import { NetworkPanel } from "./NetworkPanel";
 import { LlmPanel } from "./LlmPanel";
+import { ComfyPanel } from "./ComfyPanel";
+import { ChevronDownIcon } from "../ui/icons";
 
 interface SparkPageProps {
   spark: SparkSnapshot;
   temperatureUnit: "celsius" | "fahrenheit";
   onEdit?: () => void;
+}
+
+const SECTION_OPEN_KEYS = {
+  resources: "sparkdash.ui.section.resources",
+  services: "sparkdash.ui.section.services",
+} as const;
+
+function readSectionOpen(key: string, fallback = true): boolean {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === "0" || raw === "false") return false;
+    if (raw === "1" || raw === "true") return true;
+  } catch {
+    /* private mode / blocked storage */
+  }
+  return fallback;
+}
+
+function writeSectionOpen(key: string, open: boolean) {
+  try {
+    localStorage.setItem(key, open ? "1" : "0");
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Clickable section title with chevron; collapses/expands the panels below. */
+function SectionHeading({
+  title,
+  open,
+  onToggle,
+  style,
+}: {
+  title: string;
+  open: boolean;
+  onToggle: () => void;
+  style?: CSSProperties;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={open}
+      className="md:col-span-2 flex w-full items-center gap-2 text-left font-normal leading-tight tracking-tight text-text-strong transition-colors hover:text-accent"
+      style={{
+        fontSize: "var(--density-overview-title)",
+        ...style,
+      }}
+    >
+      <ChevronDownIcon
+        className={`h-5 w-5 shrink-0 text-muted transition-transform duration-150 ${
+          open ? "" : "-rotate-90"
+        }`}
+      />
+      <span>{title}</span>
+    </button>
+  );
 }
 
 export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
@@ -27,6 +86,28 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
   );
   const [showAddPort, setShowAddPort] = useState(false);
   const [newPortDraft, setNewPortDraft] = useState("");
+  const [resourcesOpen, setResourcesOpen] = useState(() =>
+    readSectionOpen(SECTION_OPEN_KEYS.resources, true)
+  );
+  const [servicesOpen, setServicesOpen] = useState(() =>
+    readSectionOpen(SECTION_OPEN_KEYS.services, true)
+  );
+
+  const toggleResources = useCallback(() => {
+    setResourcesOpen((prev) => {
+      const next = !prev;
+      writeSectionOpen(SECTION_OPEN_KEYS.resources, next);
+      return next;
+    });
+  }, []);
+
+  const toggleServices = useCallback(() => {
+    setServicesOpen((prev) => {
+      const next = !prev;
+      writeSectionOpen(SECTION_OPEN_KEYS.services, next);
+      return next;
+    });
+  }, []);
 
   // Sync when spark data changes (WS push)
   useEffect(() => {
@@ -91,94 +172,166 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
     }
   }, [spark.id]);
 
+  const llmOn = isLlmMonitoringEnabled(spark);
+  const comfyOn = Boolean(spark.comfyMonitoring);
+  /** First LLM + Comfy share a row when both are on. */
+  const primarySideBySide = llmOn && comfyOn;
+  const showServices = llmOn || comfyOn;
+  const primaryPort = llmPorts[0];
+  const extraPorts = llmPorts.slice(1);
+
+  /**
+   * Extra LLM ports (after the primary):
+   * - 1 extra → full-width own row
+   * - 2+ extras → 2-column pairs; if odd count, last one full-width alone
+   */
+  const extraLlmFullWidth = (extraIndex: number, extraCount: number) => {
+    if (extraCount === 1) return true;
+    if (extraCount % 2 === 1 && extraIndex === extraCount - 1) return true;
+    return false;
+  };
+
+  const renderLlmPanel = (port: number, portIndex: number, className?: string) => {
+    const llmMetrics = metrics.llm?.[portIndex] ?? null;
+    const canRemove = portIndex > 0;
+    return (
+      <LlmPanel
+        key={port}
+        llm={llmMetrics}
+        sparkId={spark.id}
+        llmPort={port}
+        llmPorts={llmPorts}
+        hasApiKey={Boolean(spark.llmApiKeyPorts?.includes(port))}
+        onRemovePort={canRemove ? handleRemovePort : undefined}
+        className={className}
+      />
+    );
+  };
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--density-page-gap)" }}>
       <SparkHeader spark={spark} onEdit={onEdit} />
       <div className="spark-page grid md:grid-cols-2" style={{ gap: "var(--density-page-gap)" }}>
-        <GpuPanel gpu={metrics.gpu} sparkId={spark.id} temperatureUnit={temperatureUnit} />
-        <CpuPanel cpu={metrics.cpu} ram={metrics.ram} sparkId={spark.id} unifiedMemory={metrics.unifiedMemory} />
-        <StoragePanel
-          storage={metrics.storage}
-          sparkId={spark.id}
-          disabledDevices={disabledDevices}
-          onDisabledChange={setDisabledDevices}
-          storagePollDisabled={storagePollDisabled}
-          onStoragePollModeChange={handleStoragePollModeChange}
+        <SectionHeading
+          title="Resources"
+          open={resourcesOpen}
+          onToggle={toggleResources}
+          style={{ marginTop: "var(--density-page-gap)" }}
         />
-        <NetworkPanel
-          network={metrics.network}
-          sparkId={spark.id}
-          disabledInterfaces={disabledInterfaces}
-          onDisabledChange={setDisabledInterfaces}
-        />
-        {isLlmMonitoringEnabled(spark) && (
+        {resourcesOpen && (
           <>
-            {llmPorts.map((port, i) => {
-              const llmMetrics = metrics.llm?.[i] ?? null;
-              // First port is primary — only additional ports can be removed
-              const canRemove = i > 0;
-              return (
-                <LlmPanel
-                  key={port}
-                  llm={llmMetrics}
-                  sparkId={spark.id}
-                  llmPort={port}
-                  llmPorts={llmPorts}
-                  hasApiKey={Boolean(spark.llmApiKeyPorts?.includes(port))}
-                  onRemovePort={canRemove ? handleRemovePort : undefined}
-                  className="md:col-span-2"
-                />
-              );
-            })}
-            {showAddPort ? (
-              <div className="md:col-span-2 rounded-lg border border-border bg-surface p-3">
-                <div className="flex items-center gap-2">
-                  <input
-                    type="number"
-                    min={1}
-                    max={65535}
-                    inputMode="numeric"
-                    placeholder="Port number"
-                    value={newPortDraft}
-                    onChange={(e) => setNewPortDraft(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        void handleAddPort();
-                      }
-                    }}
-                    className="w-32 rounded-md border border-border bg-surface-elevated px-3 py-1.5 font-tabular text-sm text-text outline-none focus:border-accent"
-                    autoFocus
-                  />
-                  <button
-                    type="button"
-                    onClick={() => void handleAddPort()}
-                    disabled={!newPortDraft.trim()}
-                    className="rounded bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
-                  >
-                    Add
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setShowAddPort(false);
-                      setNewPortDraft("");
-                    }}
-                    className="rounded border border-border px-3 py-1.5 text-xs text-muted hover:bg-surface-hover"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            ) : (
-              <button
-                type="button"
-                onClick={() => setShowAddPort(true)}
-                className="md:col-span-2 rounded-lg border border-dashed border-border bg-transparent p-3 text-xs text-muted hover:border-accent hover:text-accent transition-colors"
-              >
-                + Add LLM port
-              </button>
+            <GpuPanel gpu={metrics.gpu} sparkId={spark.id} temperatureUnit={temperatureUnit} />
+            <CpuPanel
+              cpu={metrics.cpu}
+              ram={metrics.ram}
+              sparkId={spark.id}
+              unifiedMemory={metrics.unifiedMemory}
+            />
+            <StoragePanel
+              storage={metrics.storage}
+              sparkId={spark.id}
+              disabledDevices={disabledDevices}
+              onDisabledChange={setDisabledDevices}
+              storagePollDisabled={storagePollDisabled}
+              onStoragePollModeChange={handleStoragePollModeChange}
+            />
+            <NetworkPanel
+              network={metrics.network}
+              sparkId={spark.id}
+              disabledInterfaces={disabledInterfaces}
+              onDisabledChange={setDisabledInterfaces}
+            />
+          </>
+        )}
+        {/*
+          Services layout:
+          - Primary LLM + ComfyUI → always same row, 2 columns (when both on)
+          - Alone → full width
+          - +1 LLM → own full-width row
+          - +2 LLMs → 2-column row; odd leftover → full-width row
+        */}
+        {showServices && (
+          <SectionHeading
+            title="Services"
+            open={servicesOpen}
+            onToggle={toggleServices}
+            style={{ marginTop: "var(--density-page-gap)" }}
+          />
+        )}
+        {showServices && servicesOpen && (
+          <>
+            {llmOn &&
+              primaryPort != null &&
+              renderLlmPanel(
+                primaryPort,
+                0,
+                primarySideBySide ? undefined : "md:col-span-2"
+              )}
+            {comfyOn && (
+              <ComfyPanel
+                comfy={metrics.comfy ?? null}
+                comfyPort={spark.comfyPort ?? 8188}
+                className={primarySideBySide ? undefined : "md:col-span-2"}
+              />
             )}
+            {llmOn &&
+              extraPorts.map((port, j) =>
+                renderLlmPanel(
+                  port,
+                  j + 1,
+                  extraLlmFullWidth(j, extraPorts.length) ? "md:col-span-2" : undefined
+                )
+              )}
+            {llmOn &&
+              (showAddPort ? (
+                <div className="md:col-span-2 rounded-lg border border-border bg-surface p-3">
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min={1}
+                      max={65535}
+                      inputMode="numeric"
+                      placeholder="Port number"
+                      value={newPortDraft}
+                      onChange={(e) => setNewPortDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          void handleAddPort();
+                        }
+                      }}
+                      className="w-32 rounded-md border border-border bg-surface-elevated px-3 py-1.5 font-tabular text-sm text-text outline-none focus:border-accent"
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void handleAddPort()}
+                      disabled={!newPortDraft.trim()}
+                      className="rounded bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+                    >
+                      Add
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setShowAddPort(false);
+                        setNewPortDraft("");
+                      }}
+                      className="rounded border border-border px-3 py-1.5 text-xs text-muted hover:bg-surface-hover"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setShowAddPort(true)}
+                  className="md:col-span-2 rounded-lg border border-dashed border-border bg-transparent p-3 text-xs text-muted hover:border-accent hover:text-accent transition-colors"
+                >
+                  + Add LLM port
+                </button>
+              ))}
           </>
         )}
       </div>

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -272,6 +272,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
                 comfy={metrics.comfy ?? null}
                 comfyPort={spark.comfyPort ?? 8188}
                 sparkId={spark.id}
+                lanIp={spark.lanIp}
                 className={primarySideBySide ? undefined : "md:col-span-2"}
               />
             )}

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -82,6 +82,17 @@ export function ChevronDownIcon({ className }: IconProps) {
   );
 }
 
+/** External link (open ComfyUI). */
+export function ExternalLinkIcon({ className }: IconProps) {
+  return (
+    <svg {...baseProps(className)}>
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <path d="M15 3h6v6" />
+      <path d="M10 14L21 3" />
+    </svg>
+  );
+}
+
 /** ComfyUI / image-workflow service. */
 export function ComfyIcon({ className }: IconProps) {
   return (

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -73,6 +73,26 @@ export function BotIcon({ className }: IconProps) {
   );
 }
 
+/** Chevron pointing down; rotate -90° when a section is collapsed. */
+export function ChevronDownIcon({ className }: IconProps) {
+  return (
+    <svg {...baseProps(className)}>
+      <path d="M6 9l6 6 6-6" />
+    </svg>
+  );
+}
+
+/** ComfyUI / image-workflow service. */
+export function ComfyIcon({ className }: IconProps) {
+  return (
+    <svg {...baseProps(className)}>
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <circle cx="9" cy="11" r="2" />
+      <path d="M3 16l5-4 3 2 4-5 6 7" />
+    </svg>
+  );
+}
+
 export function GearIcon({ className = "" }: { className?: string }) {
   return (
     <svg {...baseProps(className)}>

--- a/src/hooks/metricsStore.ts
+++ b/src/hooks/metricsStore.ts
@@ -106,6 +106,9 @@ export function ingestSnapshots(sparks: SparkSnapshot[]): void {
         pushHistory(`${s.id}:llm${portKey}.tps`, llm.generationTps);
       }
     }
+    if (m.comfy?.available) {
+      pushHistory(`${s.id}:comfy.queue`, (m.comfy.queueRunning ?? 0) + (m.comfy.queuePending ?? 0));
+    }
   }
 
   // Drop series for Sparks no longer in the registry (deleted / removed from WS).

--- a/src/index.css
+++ b/src/index.css
@@ -154,21 +154,10 @@
 }
 
 /* ─── Density tokens (layout spacing) ───────────────────── */
-/* Comfortable is the default. The override block sits AFTER all theme */
-/* blocks so its --radius-* overrides win on source order (equal specificity). */
-:root {
-  --density-root-font: 121%;
-  --density-shell-pad: 32px;
-  --density-header-gap: 28px;   /* header bottom margin (mb-7) */
-  --density-page-gap: 18px;    /* per-Spark grid + vertical rhythm */
-  --density-panel-pad: 20px;   /* .panel + .spark-header padding (p-5) */
-  --density-panel-title-mb: 16px;
-  --density-card-pad: 22px;    /* overview card padding (p-[22px]) */
-  --density-card-gap: 12px;    /* overview card internal stack gap */
-  --density-overview-rhythm: 24px; /* overview page space-y-6 */
-  --density-overview-title: 32px; /* Overview h1 */
-}
-
+/* Compact is the default (matches server settings DEFAULTS.density).
+   Comfortable is the roomier override. Both density attribute blocks sit
+   AFTER theme blocks so --radius-* wins on source order (equal specificity). */
+:root,
 [data-density="compact"] {
   --density-root-font: 112%;
   --density-shell-pad: 20px;
@@ -184,9 +173,27 @@
   --radius-sm: 8px;
 }
 
+[data-density="comfortable"] {
+  --density-root-font: 121%;
+  --density-shell-pad: 32px;
+  --density-header-gap: 28px;
+  --density-page-gap: 18px;
+  --density-panel-pad: 20px;
+  --density-panel-title-mb: 16px;
+  --density-card-pad: 22px;
+  --density-card-gap: 12px;
+  --density-overview-rhythm: 24px;
+  --density-overview-title: 32px;
+  --radius-panel: 22px;
+  --radius-sm: 12px;
+}
+
 /* Compact: pin metric label/value text (Usage, GPU Power, VRAM caption, etc.)
    to 14px. Tailwind's `.text-sm` (0,1,0) loses on specificity here. Only
-   `text-sm` inside surfaces is affected — buttons use text-xs/[10px]/[11px]. */
+   `text-sm` inside surfaces is affected — buttons use text-xs/[10px]/[11px].
+   :root is compact by default, so bare .panel/.overview-card also pin. */
+:root:not([data-density="comfortable"]) .panel .text-sm,
+:root:not([data-density="comfortable"]) .overview-card .text-sm,
 [data-density="compact"] .panel .text-sm,
 [data-density="compact"] .overview-card .text-sm {
   font-size: 14px;


### PR DESCRIPTION
Reasoning models (DeepSeek-V4-Flash, R1-style) stream their thinking phase as `delta.reasoning` / `delta.reasoning_content` before switching to `delta.content`, while `usage.completion_tokens` counts **both**. Timing the decode window on `content` alone paired the full token count with a fraction of the wall clock, or collapsed to a zero-length window when a reply spent its whole budget reasoning — so the bench reported `0 tok/s` and `0 ms` TTFT.

## Status of the underlying bug on `main`
The core fix is **already on `main`**: `extractDeltaPieces` (in `LlmStreaming.js`, moved there in the 1.3.0 refactor) counts both `delta.reasoning` and `delta.reasoning_content` toward the decode window, so pure-reasoning replies no longer collapse to `tok/s = 0`.

## What this PR adds
The two telemetry fields introduced by #36, but targeted at the file where the streaming code actually lives post-refactor (`LlmStreaming.js`):

| field | meaning |
| --- | --- |
| `ttftContentMs` | wall-clock ms to the first **answer** token (after the thinking phase). `null` when the reply never leaves reasoning. |
| `reasoningChunks` | count of streamed chunks carrying reasoning (not answer) text |

Both are threaded through `streamPublicResult` (DecodeBench) and the `DecodeBenchStreamResult` TS type, so wave/aggregate results expose them. The fields are **additive and nullable**, so existing consumers (`BenchmarkDialog`, `ShowcasePage`) keep working unchanged.

## Why not rebase #36?
#36 is built against a pre-1.3.0 file layout — it edits `server/collectors/DecodeBench.js`, but as of 1.3.0 the streaming code (`runStreamingRequest`, `pollServerGenerationRates`, the SSE-parsing loop) was refactored into `server/collectors/LlmStreaming.js` (see `extractDeltaPieces`). The patch no longer applies to `main`, and its headline fix is already merged — only the two fields above are net-new value. This PR supersedes #36.

## Validation
- `npm run typecheck` — clean
- `npm test` — 80/80 passing
- `node --check` on both edited server files — OK

## Files
- `server/collectors/LlmStreaming.js` — track `tFirstContent` / `reasoningChunkCount`; add `ttftContentMs` + `reasoningChunks` to the streaming result object.
- `server/collectors/DecodeBench.js` — pass the two fields through `streamPublicResult`.
- `src/api/types.ts` — add the fields to `DecodeBenchStreamResult`.

Supersedes #36. 
