### PR TITLE
feat: add NV_ERR_NO_MEMORY counter to CPU panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:client": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node --test server/collectors/__tests__/*.test.js server/sparks/__tests__/*.test.js",
+    "test": "node --experimental-test-module-mocks --test server/collectors/__tests__/*.test.js server/sparks/__tests__/*.test.js",
     "preview": "vite preview",
     "start": "node server/index.js",
     "docker:up": "docker compose up -d",

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -897,6 +897,22 @@ export class SystemCollector {
       }
     } catch {}
 
+    // NV_ERR_NO_MEMORY kernel error count from the NVRM driver (host journal).
+    let nvErrNoMemory = 0;
+    try {
+      const js = "journalctl -k --no-pager 2>/dev/null | grep -c \"NV_ERR_NO_MEMORY\" || true";
+      const out = this._hasHostProc() ? await this._execOnHost(js) : await this._exec(js);
+      const n = Number(String(out).trim());
+      if (!Number.isNaN(n) && n > 0) nvErrNoMemory = Math.round(n);
+    } catch {
+      try {
+        const dmesg = "dmesg 2>/dev/null | grep -c \"NV_ERR_NO_MEMORY\" || true";
+        const out = this._hasHostProc() ? await this._execOnHost(dmesg) : await this._exec(dmesg);
+        const n = Number(String(out).trim());
+        if (!Number.isNaN(n) && n > 0) nvErrNoMemory = Math.round(n);
+      } catch {}
+    }
+
     return {
       total: totalMB,
       gpuUsed: gpuUsedMB,
@@ -906,6 +922,7 @@ export class SystemCollector {
       percentage,
       oomRisk,
       bandwidth,
+      nvErrNoMemory,
     };
   }
 
@@ -1248,6 +1265,17 @@ export class SystemCollector {
       const percentage = totalMB > 0 ? Math.round((usedMB / totalMB) * 100) : 0;
       const oomRisk = percentage > 85 ? "high" : percentage > 60 ? "medium" : "low";
 
+      // NV_ERR_NO_MEMORY kernel error count from the NVRM driver (remote host).
+      let nvErrNoMemory = 0;
+      try {
+        const countRaw = await sshExec(
+          this.spark,
+          "journalctl -k --no-pager 2>/dev/null | grep -c \"NV_ERR_NO_MEMORY\" || true"
+        );
+        const n = Number(String(countRaw).trim());
+        if (!Number.isNaN(n) && n > 0) nvErrNoMemory = Math.round(n);
+      } catch {}
+
       return {
         total: totalMB,
         gpuUsed: gpuUsedMB,
@@ -1257,6 +1285,7 @@ export class SystemCollector {
         percentage,
         oomRisk,
         bandwidth: { current: 0, peak: 400 },
+        nvErrNoMemory,
       };
     } catch (err) {
       console.error(`[SystemCollector] Remote Unified Memory error for ${this.spark.id}:`, err.message);
@@ -1411,6 +1440,7 @@ export class SystemCollector {
       percentage: 0,
       oomRisk: "low",
       bandwidth: { current: 0, peak: 0 },
+      nvErrNoMemory: 0,
     };
   }
 

--- a/server/collectors/__tests__/SystemCollector.nvErr.test.js
+++ b/server/collectors/__tests__/SystemCollector.nvErr.test.js
@@ -1,0 +1,79 @@
+import { test, mock } from "node:test";
+import { strict as assert } from "node:assert";
+
+// The remote unified-memory path calls the module-level sshExec() imported by
+// SystemCollector.js. ESM namespace bindings are non-configurable, so we mock
+// the whole ssh.js module via mock.module() (requires --experimental-test-module-mocks).
+let journalCount = 0;
+let failSsh = false;
+mock.module("../ssh.js", {
+  exports: {
+    sshExec: async (_spark, cmd) => {
+      if (failSsh) throw new Error("ssh exec failed");
+      if (cmd.includes("journalctl")) {
+        journalCount += 1;
+        return "43";
+      }
+      return "MemTotal:       16000000 kB\nMemAvailable:   4000000 kB\n---\n";
+    },
+  },
+});
+
+// Import after registering the mock so SystemCollector picks up the stubbed sshExec.
+const { SystemCollector } = await import("../SystemCollector.js");
+
+const MEMINFO =
+  "MemTotal:       8000000 kB\nMemFree:        1000000 kB\nMemAvailable:   2000000 kB\n";
+
+function makeLocalCollector() {
+  const c = new SystemCollector({ id: "gx10", isLocal: true });
+  mock.method(c, "_readHostFile", async () => MEMINFO);
+  mock.method(c, "_parseMemTotal", (raw) => {
+    const m = raw.match(/MemTotal:\s+(\d+)\s+kB/);
+    return m ? parseInt(m[1], 10) : 0;
+  });
+  mock.method(c, "_readGpuMemoryFile", () => 0);
+  mock.method(c, "_nvidiaSmi", async () => "");
+  mock.method(c, "_hasHostProc", () => false);
+  mock.method(c, "_exec", async () => "12");
+  mock.method(c, "_execOnHost", async () => "12");
+  return c;
+}
+
+test("nvErrNoMemory: local collection returns the journal count", async () => {
+  const c = makeLocalCollector();
+  const result = await c._getUnifiedMemory();
+  assert.equal(typeof result.nvErrNoMemory, "number");
+  assert.equal(result.nvErrNoMemory, 12);
+});
+
+test("nvErrNoMemory: defaults to 0 when the journal command fails", async () => {
+  const c = makeLocalCollector();
+  mock.method(c, "_hasHostProc", () => false);
+  mock.method(c, "_exec", async () => {
+    throw new Error("no journal");
+  });
+  const result = await c._getUnifiedMemory();
+  assert.equal(result.nvErrNoMemory, 0);
+});
+
+test("nvErrNoMemory: remote collection includes the count over SSH", async () => {
+  journalCount = 0;
+
+  const c = new SystemCollector({ id: "gx11", isLocal: false, lanIp: "10.200.0.2" });
+  const result = await c._getRemoteUnifiedMemory();
+
+  assert.ok(journalCount === 1, "journalctl count command should be issued once");
+  assert.equal(typeof result.nvErrNoMemory, "number");
+  assert.equal(result.nvErrNoMemory, 43);
+});
+
+test("nvErrNoMemory: defaults to 0 when the remote SSH journal call throws", async () => {
+  failSsh = true;
+
+  const c = new SystemCollector({ id: "gx11", isLocal: false, lanIp: "10.200.0.2" });
+  const result = await c._getRemoteUnifiedMemory();
+
+  failSsh = false;
+  assert.equal(result.nvErrNoMemory, 0);
+});

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -175,6 +175,8 @@ export interface UnifiedMemoryMetrics {
   used: number;
   available: number;
   percentage: number;
+  /** Cumulative count of NV_ERR_NO_MEMORY kernel driver errors. */
+  nvErrNoMemory: number;
   oomRisk: "low" | "medium" | "high";
   bandwidth: {
     current: number;

--- a/src/components/SparkPage/CpuPanel.tsx
+++ b/src/components/SparkPage/CpuPanel.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import type { CpuMetrics, RamMetrics, UnifiedMemoryMetrics } from "../../api/types";
 import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
@@ -15,6 +16,25 @@ interface CpuPanelProps {
 function formatMb(mb: number): string {
   if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
   return `${Math.round(mb)} MB`;
+}
+
+const NV_ERR_STORAGE_KEY = "nvErrBaseline";
+
+function getNvErrBaseline(sparkId: string): number {
+  try {
+    const raw = localStorage.getItem(`${NV_ERR_STORAGE_KEY}.${sparkId}`);
+    return raw ? parseInt(raw, 10) || 0 : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function setNvErrBaseline(sparkId: string, value: number) {
+  try {
+    localStorage.setItem(`${NV_ERR_STORAGE_KEY}.${sparkId}`, String(value));
+  } catch {
+    /* localStorage unavailable */
+  }
 }
 
 function MetricRow({
@@ -50,6 +70,22 @@ export function CpuPanel({ cpu, ram, sparkId, unifiedMemory }: CpuPanelProps) {
   const ramTotal = ram?.total ?? 0;
   const ramPct = ram?.percentage ?? 0;
   const ramAvail = ramTotal > 0 ? ramTotal - ramUsed : 0;
+
+  const nvErrRaw = unifiedMemory?.nvErrNoMemory ?? 0;
+  const [nvErrBaseline, setNvErrBaselineState] = useState<number>(() =>
+    getNvErrBaseline(sparkId)
+  );
+  const [nvErrSinceReset, setNvErrSinceReset] = useState<number>(0);
+
+  useEffect(() => {
+    setNvErrSinceReset(Math.max(0, nvErrRaw - nvErrBaseline));
+  }, [nvErrRaw, nvErrBaseline]);
+
+  const handleResetNvErr = () => {
+    setNvErrBaseline(sparkId, nvErrRaw);
+    setNvErrBaselineState(nvErrRaw);
+    setNvErrSinceReset(0);
+  };
 
   return (
     <Panel title="CPU" icon={<CpuIcon />} className="panel-cpu" bodyClassName="space-y-3" accent>
@@ -94,6 +130,28 @@ export function CpuPanel({ cpu, ram, sparkId, unifiedMemory }: CpuPanelProps) {
               >
                 {unifiedMemory.oomRisk}
               </span>
+            </div>
+          )}
+          {unifiedMemory !== null && (
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted">NV_ERR_NO_MEMORY</span>
+              <div className="flex items-center gap-1.5">
+                <span
+                  className={`font-tabular ${
+                    nvErrSinceReset > 0 ? "text-danger font-semibold" : "text-text"
+                  }`}
+                >
+                  {nvErrSinceReset}
+                </span>
+                <button
+                  type="button"
+                  className="cursor-pointer rounded border border-border bg-surface px-1.5 py-0.5 text-xs text-muted hover:border-accent hover:text-accent transition-colors"
+                  onClick={handleResetNvErr}
+                  title="Reset error counter — set a new baseline so only future errors are counted"
+                >
+                  ↺ reset
+                </button>
+              </div>
             </div>
           )}
         </div>

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -96,7 +96,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
       <SparkHeader spark={spark} onEdit={onEdit} />
       <div className="spark-page grid md:grid-cols-2" style={{ gap: "var(--density-page-gap)" }}>
         <GpuPanel gpu={metrics.gpu} sparkId={spark.id} temperatureUnit={temperatureUnit} />
-        <CpuPanel cpu={metrics.cpu} ram={metrics.ram} sparkId={spark.id} unifiedMemory={metrics.unifiedMemory} />
+        <CpuPanel key={spark.id} cpu={metrics.cpu} ram={metrics.ram} sparkId={spark.id} unifiedMemory={metrics.unifiedMemory} />
         <StoragePanel
           storage={metrics.storage}
           sparkId={spark.id}


### PR DESCRIPTION
## Summary

Adds a read-only **NV_ERR_NO_MEMORY** counter to the CPU/unified-memory panel, showing the number of NVRM kernel-driver `NV_ERR_NO_MEMORY` errors since a manual reset (per-Spark baseline). This is an optional monitoring enhancement for users running NVIDIA driver + DGX-class SPARKS.

## Motivation

The NVRM driver logs `NV_ERR_NO_MEMORY` (`mem_desc.c:1359`) under GPU memory pressure, but sparkDash doesn't surface it — you have to grep the kernel journal by hand. This gives operators a live, resettable counter in the existing metrics UI.

## Changes

- **Server** (`server/collectors/SystemCollector.js`): collect cumulative `nvErrNoMemory` from the kernel journal (`journalctl -k | grep -c NV_ERR_NO_MEMORY`, `dmesg` fallback), host-namespace aware for the Docker local path, and over SSH for remote Sparks. Defaults to 0 and never throws.
- **Types** (`src/api/types.ts`): add `nvErrNoMemory: number` on `UnifiedMemoryMetrics`.
- **UI** (`src/components/SparkPage/CpuPanel.tsx`): render raw-minus-baseline (clamped `>= 0`) with a `reset` button backed by a per-Spark `localStorage` baseline; key CpuPanel by Spark so the baseline re-initializes on page switch.
- **Tests**: `server/collectors/__tests__/SystemCollector.nvErr.test.js` covering local, remote, and failure-to-0 paths.

## Testing

- `npm test`: 84/84 pass (includes the new nvErr tests). Note: the tests use Node's experimental module-mocks (`--experimental-test-module-mocks`) because the repo's ESM namespace exports aren't `mock.method`-able.
- `npm run typecheck` and `npm run build`: clean.

Happy to adjust scope, placement, or gate it behind a config flag if you'd prefer it opt-in.
