### PR TITLE
feat: fleet storage tiers and model placement view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,7 @@ Format: version sections are listed newest first.
 - Comfy progress WebSocket soft-reconnects on host/port change (no longer permanently closed after `setTarget`)
 - **Fleet model storage tiers** — a dedicated **Storage** view (fleet-wide) plus per-Spark storage cards and a model-placement table
 - **Tier classification** — each mounted disk is labeled **Hot** (root NVMe), **Warm** (other local disks), or **Cold** (NAS `/mnt/modelshelf` and `cifs`/`smb`/`nfs` mounts), driven by `tierPaths` overrides, filesystem type, and mount prefix
-- **Model inventory** — scans configured model directories (`.safetensors` / `.gguf` / `.bin` / `.pt` / `.pth` / `.ckpt` weight files) per tier, local and over SSH, with a new `models` metrics domain (`POLL_INTERVAL_MODELS`, default 30 s)
+- **Model inventory** — scans configured model directories (`.safetensors` / `.gguf` / `.bin` / `.pt` / `.pth` / `.ckpt` weight files) per tier, local and over SSH, with a new `models` metrics domain (`POLL_INTERVAL_MODELS`, default 30 s). Each scanned dir is inspected **one level deep**, so `modelDirs` should point at the directory whose direct children are models (e.g. the outer family dir for HF-style nests)
 - **Dual placement** — a model is shown as **resident** on the Sparks holding a local copy, and as served **over the CX7/ConnectX fabric** on a peer that has it loaded via its LLM probe without a local copy
 - Optional per-Spark `modelDirs` / `tierPaths` in `config/sparks.json` to override which directories map to which tier
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,13 @@ Format: version sections are listed newest first.
 
 ### Fixed
 - Comfy progress WebSocket soft-reconnects on host/port change (no longer permanently closed after `setTarget`)
+- **Fleet model storage tiers** — a dedicated **Storage** view (fleet-wide) plus per-Spark storage cards and a model-placement table
+- **Tier classification** — each mounted disk is labeled **Hot** (root NVMe), **Warm** (other local disks), or **Cold** (NAS `/mnt/modelshelf` and `cifs`/`smb`/`nfs` mounts), driven by `tierPaths` overrides, filesystem type, and mount prefix
+- **Model inventory** — scans configured model directories (`.safetensors` / `.gguf` / `.bin` / `.pt` / `.pth` / `.ckpt` weight files) per tier, local and over SSH, with a new `models` metrics domain (`POLL_INTERVAL_MODELS`, default 30 s)
+- **Dual placement** — a model is shown as **resident** on the Sparks holding a local copy, and as served **over the CX7/ConnectX fabric** on a peer that has it loaded via its LLM probe without a local copy
+- Optional per-Spark `modelDirs` / `tierPaths` in `config/sparks.json` to override which directories map to which tier
 
+### Security
 ---
 
 ## [1.5.0] — 2026-08-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ Format: version sections are listed newest first.
 
 ---
 
+## [1.8.7] — 2026-09-01
+
+### Added
+- **Fleet model storage tiers** — a dedicated **Storage** view (fleet-wide) plus per-Spark storage cards and a model-placement table
+- **Tier classification** — each mounted disk is labeled **Hot** (root NVMe), **Warm** (other local disks), or **Cold** (NAS `/mnt/modelshelf` and `cifs`/`smb`/`nfs` mounts), driven by `tierPaths` overrides, filesystem type, and mount prefix
+- **Model inventory** — scans configured model directories (`.safetensors` / `.gguf` / `.bin` / `.pt` / `.pth` / `.ckpt` weight files) per tier, local and over SSH, with a new `models` metrics domain (`POLL_INTERVAL_MODELS`, default 30 s). Each scanned dir is inspected **one level deep**, so `modelDirs` should point at the directory whose direct children are models (e.g. the outer family dir for HF-style nests)
+- **Dual placement** — a model is shown as **resident** on the Sparks holding a local copy, and as served **over the CX7/ConnectX fabric** on a peer that has it loaded via its LLM probe without a local copy
+- Optional per-Spark `modelDirs` / `tierPaths` in `config/sparks.json` to override which directories map to which tier
+- **NV_ERR_NO_MEMORY counter** — per-Spark cumulative count of NVIDIA kernel-driver `NV_ERR_NO_MEMORY` errors, read from the host journal locally (`journalctl -k`, `dmesg` fallback) and over SSH for remote units; typed on `UnifiedMemoryMetrics` and shown in the CPU panel
+
+### Fixed
+- **Cross-spark NV_ERR_NO_MEMORY baseline** — GpuPanel is remounted per Spark so switching units no longer carries the previous unit's error baseline
+
+---
+
 ## [1.8.6] — 2026-09-01
 
 ### Added
@@ -151,11 +166,6 @@ Format: version sections are listed newest first.
 
 ### Fixed
 - Comfy progress WebSocket soft-reconnects on host/port change (no longer permanently closed after `setTarget`)
-- **Fleet model storage tiers** — a dedicated **Storage** view (fleet-wide) plus per-Spark storage cards and a model-placement table
-- **Tier classification** — each mounted disk is labeled **Hot** (root NVMe), **Warm** (other local disks), or **Cold** (NAS `/mnt/modelshelf` and `cifs`/`smb`/`nfs` mounts), driven by `tierPaths` overrides, filesystem type, and mount prefix
-- **Model inventory** — scans configured model directories (`.safetensors` / `.gguf` / `.bin` / `.pt` / `.pth` / `.ckpt` weight files) per tier, local and over SSH, with a new `models` metrics domain (`POLL_INTERVAL_MODELS`, default 30 s). Each scanned dir is inspected **one level deep**, so `modelDirs` should point at the directory whose direct children are models (e.g. the outer family dir for HF-style nests)
-- **Dual placement** — a model is shown as **resident** on the Sparks holding a local copy, and as served **over the CX7/ConnectX fabric** on a peer that has it loaded via its LLM probe without a local copy
-- Optional per-Spark `modelDirs` / `tierPaths` in `config/sparks.json` to override which directories map to which tier
 
 ### Security
 ---

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ It also supports **non-Spark units**: any Linux machine with an NVIDIA GPU (e.g.
 
 ## Latest version changelog
 
-### Version 1.8.6 — prefill benchmark
-- **Prefill benchmark** on the LLM card: sweep context sizes from 1k to 300k, report prefill tok/s (`prompt_tokens` ÷ TTFT) and TTFT. Unique prefix per size so prefix-cache does not inflate later runs. Timeouts scale with size (up to 45 min).
-- **CPU temperature** on remote Sparks (Overview bar + GPU panel row when above 0°C).
+### Version 1.8.7 — local build on upstream 1.8.6
+- **Fleet storage tiers** — fleet **Storage** view: disks classified **Hot / Warm / Cold**, model inventory, resident-vs-CX7-fabric placement
+- **NV_ERR_NO_MEMORY counter** — per-Spark kernel-driver error count (host journal / SSH) with a reset baseline in the GPU panel
+- Includes upstream **1.8.6** — prefill benchmark (1k–300k context sweep) and DGX Spark CPU temperature
+
 
 Full history: [CHANGELOG.md](./CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -508,6 +508,8 @@ Rates are derived from per-probe cumulative counter diffs (or SGLang sticky thro
 
 Each mounted disk is assigned a tier — **Hot** (root NVMe), **Warm** (other local disks), or **Cold** (NAS: `/mnt/modelshelf`, `/media`, `/Volumes`, `/mnt`, or any `cifs`/`smb`/`nfs` mount). Per-Spark `tierPaths` in `config/sparks.json` override the heuristic per mount. The collector scans the configured model directories (grouped by tier via `modelDirs`) for weight files (`.safetensors`, `.gguf`, `.bin`, `.pt`, `.pth`, `.ckpt`) and reports each model by name, size, and tier.
 
+The scan looks **one directory level deep**: each immediate child of a `modelDirs` entry counts as a model if it is a loose weight file or a subdirectory whose immediate children include a weight file. Point `modelDirs` at the directory whose *direct* children are your models. HF-hub-style nesting (`models--org--name/snapshots/<ref>/*.safetensors`, or `~/models/hf/<family>/*.safetensors`) is two levels deep, so use the outer family dir (e.g. `~/models/hf`), not the parent, as the `modelDirs` root.
+
 A model is **resident** on the Sparks holding a local copy. Because a peer with the model loaded in its LLM probe (matched by name) serves it to the fleet over the CX7/ConnectX fabric, such a Spark is shown as placing the model **over the fabric** even with no local copy. The fleet **Storage** view rolls these up per tier and lists every model with its resident and fabric placement.
 
 ---

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Full history: [CHANGELOG.md](./CHANGELOG.md)
 | **Secrets** | SSH passwords AES-256-GCM encrypted; never in `sparks.json` or API responses |
 | **Docker-first** | Single privileged container for host metrics; prod and dev Compose files |
 | **Hot config** | Add / edit / remove / reorder Sparks from the UI with no process restart |
+| **Storage tiers** | Fleet **Storage** view — disks classified **Hot / Warm / Cold** (NAS/nfs/cifs vs local), model inventory, and resident-vs-CX7-fabric placement |
 
 ---
 
@@ -400,6 +401,7 @@ Copy `.env.example` to `.env` if needed:
 | `TAILSCALE_PROBE_TIMEOUT_MS` | `8000` | Timeout for `tailscale status --json` (ms) |
 | `HERMES_UPDATE_TIMEOUT_MS` | `600000` | Hard timeout for running `hermes update` over SSH (ms) |
 | `POLL_INTERVAL_LIVENESS` | `5000` | Online/SSH liveness check (ms) |
+| `POLL_INTERVAL_MODELS` | `30000` | Model inventory / tier scan (ms) |
 | `SPARKDASH_SECRETS_KEY` | _(auto)_ | Passphrase or 64-char hex for secret encryption |
 | `HOST_PROC_PATH` | `/host/proc` | Host proc mount inside container |
 | `HOST_SYS_PATH` | `/host/sys` | Host sys mount |
@@ -501,6 +503,12 @@ Each configured LLM port gets its own `LlmProbe` instance running in parallel. P
 - **vLLM / sglang** — `/v1/models`; sglang via `/server_info` (`last_gen_throughput` when metrics off; `/get_server_info` fallback), vLLM via Prometheus `/metrics` counters (scientific notation supported)
 
 Rates are derived from per-probe cumulative counter diffs (or SGLang sticky throughput while it moves). Multiple ports can be added or removed at runtime without restarting the monitor.
+
+### Storage tiers & model placement
+
+Each mounted disk is assigned a tier — **Hot** (root NVMe), **Warm** (other local disks), or **Cold** (NAS: `/mnt/modelshelf`, `/media`, `/Volumes`, `/mnt`, or any `cifs`/`smb`/`nfs` mount). Per-Spark `tierPaths` in `config/sparks.json` override the heuristic per mount. The collector scans the configured model directories (grouped by tier via `modelDirs`) for weight files (`.safetensors`, `.gguf`, `.bin`, `.pt`, `.pth`, `.ckpt`) and reports each model by name, size, and tier.
+
+A model is **resident** on the Sparks holding a local copy. Because a peer with the model loaded in its LLM probe (matched by name) serves it to the fleet over the CX7/ConnectX fabric, such a Spark is shown as placing the model **over the fabric** even with no local copy. The fleet **Storage** view rolls these up per tier and lists every model with its resident and fabric placement.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparkdash",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparkdash",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:client": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node --test server/collectors/__tests__/*.test.js server/sparks/__tests__/*.test.js",
+    "test": "node --experimental-test-module-mocks --test server/collectors/__tests__/*.test.js server/sparks/__tests__/*.test.js",
     "preview": "vite preview",
     "start": "node server/index.js",
     "docker:up": "docker compose up -d",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sparkdash",
-  "version": "1.8.6",
-  "description": "sparkDash \u2014 Multi-DGX Spark Monitoring Dashboard",
+  "version": "1.8.7",
+  "description": "sparkDash — Multi-DGX Spark Monitoring Dashboard",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -1,8 +1,71 @@
 import fs from "fs";
 import path from "path";
-import { HOST_PATHS, GPU_MEMORY_JSON_PATH, DGX_SPARK, HARDWARE_DEFAULTS } from "../config.js";
+import {
+  HOST_PATHS,
+  GPU_MEMORY_JSON_PATH,
+  DGX_SPARK,
+  HARDWARE_DEFAULTS,
+  TIER_DEFAULTS,
+  WEIGHT_EXTENSIONS,
+} from "../config.js";
 import { normalizeMac, WOL_INTERFACE } from "../wol.js";
 import { sshExec } from "./ssh.js";
+
+/**
+ * Classify a storage device into a tier: "hot" | "warm" | "cold".
+ * Pure (no `this`) so it is unit-testable in isolation.
+ *
+ * @param {object} params
+ * @param {string} params.device  lsblk/df device name (e.g. "nvme0n1p2", "sdb1")
+ * @param {string} params.mount   mount path (host-style, e.g. "/", "/mnt/modelshelf")
+ * @param {string} [params.fstype] filesystem type (may be "")
+ * @param {object} [params.tierPaths] per-Spark override { hot?, warm?, cold?: string[] }
+ * @returns {"hot"|"warm"|"cold"}
+ */
+export function classifyTier(device, mount, fstype = "", tierPaths = {}) {
+  const overrides = tierPaths || {};
+  // Explicit per-Spark overrides win — match by mount-prefix or device name.
+  for (const tier of ["hot", "warm", "cold"]) {
+    const paths = overrides[tier];
+    if (Array.isArray(paths)) {
+      for (const p of paths) {
+        if (!p) continue;
+        if (mount === p || mount.startsWith(p + "/") || device === p) return tier;
+      }
+    }
+  }
+  // Cold: NAS/library share — by fstype or well-known mount prefix.
+  const ft = (fstype || "").toLowerCase();
+  if (TIER_DEFAULTS.COLD_FSTYPES.includes(ft)) return "cold";
+  if (
+    mount &&
+    TIER_DEFAULTS.COLD_MOUNT_PREFIXES.some((p) => mount === p || mount.startsWith(p + "/"))
+  ) {
+    return "cold";
+  }
+  // Hot: the primary internal disk — root mount or the GB10 root partition.
+  if (mount === "/" || device === "nvme0n1p2") return "hot";
+  // Everything else that is a real local mount is warm.
+  return "warm";
+}
+
+/** True when a file name carries a model-weight extension. */
+export function isWeightFile(name) {
+  const dot = name.lastIndexOf(".");
+  if (dot < 0) return false;
+  return WEIGHT_EXTENSIONS.has(name.slice(dot).toLowerCase());
+}
+
+/** Strip the weight extension from a file name (e.g. "model.gguf" -> "model"). */
+export function stripWeightExt(name) {
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(0, dot) : name;
+}
+
+/** find -name args for weight extensions (used by the remote scan). */
+export const WEIGHT_ARGS = Array.from(WEIGHT_EXTENSIONS)
+  .map((ext) => `-name '*${ext}'`)
+  .join(" ");
 
 /**
  * SystemCollector — collects hardware metrics for a Spark.
@@ -94,6 +157,130 @@ export class SystemCollector {
       console.error(`[SystemCollector] Storage error for ${this.spark.id}:`, err.message);
       return [];
     }
+  }
+
+  /**
+   * Collect the Spark's resident model inventory, grouped by storage tier.
+   * Which dirs are scanned come from the per-Spark `modelDirs` config
+   * ({ hot?, warm?, cold?: string[] }); a tier with no configured dir
+   * contributes nothing. With no `modelDirs` set, returns [].
+   */
+  async collectModels() {
+    try {
+      const dirs = this.spark.modelDirs || {};
+      const models = [];
+      const seen = new Set();
+      for (const tier of ["hot", "warm", "cold"]) {
+        const roots = dirs[tier];
+        if (!Array.isArray(roots) || roots.length === 0) continue;
+        for (const root of roots) {
+          if (!root) continue;
+          const found = this.spark.isLocal
+            ? await this._scanLocalRoot(root)
+            : await this._scanRemoteRoot(root);
+          for (const m of found) {
+            if (!m?.name || !m?.sizeBytes || seen.has(m.name)) continue;
+            seen.add(m.name);
+            models.push({ name: m.name, sizeBytes: m.sizeBytes, tier });
+          }
+        }
+      }
+      return models;
+    } catch (err) {
+      console.error(`[SystemCollector] Models error for ${this.spark.id}:`, err.message);
+      return [];
+    }
+  }
+
+  /**
+   * Scan one model dir locally. A top-level entry is a model if it is a loose
+   * weight file, or a subdirectory whose immediate children include a weight
+   * file. Size is on-disk bytes (dir size recursed; loose-file size direct).
+   * @returns {Promise<Array<{name:string,sizeBytes:number}>>}
+   */
+  async _scanLocalRoot(root) {
+    let entries;
+    try {
+      entries = await fs.promises.readdir(root, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    const out = [];
+    for (const entry of entries) {
+      const full = path.join(root, entry.name);
+      try {
+        if (entry.isFile() && isWeightFile(entry.name)) {
+          const st = await fs.promises.stat(full);
+          out.push({ name: stripWeightExt(entry.name), sizeBytes: st.size });
+        } else if (entry.isDirectory() && (await this._dirHasWeights(full))) {
+          out.push({ name: entry.name, sizeBytes: await this._dirSizeBytes(full) });
+        }
+      } catch {
+        // Unreadable entry — skip (matches the storage collector's per-mount catch)
+      }
+    }
+    return out;
+  }
+
+  /** True when the immediate children of `dir` include a weight file. */
+  async _dirHasWeights(dir) {
+    try {
+      const names = await fs.promises.readdir(dir);
+      return names.some((n) => isWeightFile(n));
+    } catch {
+      return false;
+    }
+  }
+
+  /** Recursive on-disk size of a directory (bytes). */
+  async _dirSizeBytes(dir) {
+    let total = 0;
+    const stack = [dir];
+    while (stack.length > 0) {
+      const cur = stack.pop();
+      let names;
+      try {
+        names = await fs.promises.readdir(cur, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const e of names) {
+        const full = path.join(cur, e.name);
+        if (e.isDirectory()) stack.push(full);
+        else if (e.isFile()) {
+          try {
+            total += (await fs.promises.stat(full)).size;
+          } catch {}
+        }
+      }
+    }
+    return total;
+  }
+
+  /**
+   * Scan one model dir over SSH (single call per root). Prints one
+   * "name<TAB>bytes" line per model so parsing stays trivial; a subdir only
+   * qualifies when it immediately contains a weight file; loose weight files
+   * are reported by file stem.
+   * @returns {Promise<Array<{name:string,sizeBytes:number}>>}
+   */
+  async _scanRemoteRoot(root) {
+    const cmd =
+      `find '${root}' -maxdepth 1 -type f \( ${WEIGHT_ARGS} \) -printf '%f\t%s\n' 2>/dev/null; ` +
+      `for d in '${root}'/*/; do [ -d "$d" ] || continue; ` +
+      `if find "$d" -maxdepth 1 -type f \( ${WEIGHT_ARGS} \) -print -quit 2>/dev/null | grep -q .; then ` +
+      `echo "$(basename "$d")\t$(du -sb "$d" 2>/dev/null | cut -f1)"; fi; done`;
+    const output = await sshExec(this.spark, cmd, { timeoutMs: 15000 });
+    const models = [];
+    for (const line of output.split("\n")) {
+      const m = line.match(/^(.+?)\t(\d+)$/);
+      if (!m) continue;
+      const name = String(m[1]).replace(/^\//, "");
+      const sizeBytes = parseInt(m[2], 10) || 0;
+      if (!name || sizeBytes <= 0) continue;
+      models.push({ name, sizeBytes });
+    }
+    return models;
   }
 
   /** Collect network metrics (interfaces, speeds). */
@@ -604,6 +791,7 @@ export class SystemCollector {
           readSpeed: io.readSpeed,
           writeSpeed: io.writeSpeed,
           disabled: isDisabled,
+          tier: classifyTier(name, displayMount, fstype, this.spark.tierPaths),
         });
       } catch (err) {
         console.warn(
@@ -1152,6 +1340,7 @@ export class SystemCollector {
           readSpeed: 0,
           writeSpeed: 0,
           disabled: isDisabled,
+          tier: classifyTier(device, mount, type, this.spark.tierPaths),
         });
       }
 

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -914,7 +914,8 @@ export class SystemCollector {
       if (!Number.isNaN(n) && n > 0) nvErrNoMemory = Math.round(n);
     } catch {
       try {
-        const out = await this._exec("dmesg 2>/dev/null | grep -c \"NV_ERR_NO_MEMORY\" || true");
+        const dmesg = "dmesg 2>/dev/null | grep -c \"NV_ERR_NO_MEMORY\" || true";
+        const out = this._hasHostProc() ? await this._execOnHost(dmesg) : await this._exec(dmesg);
         const n = Number(String(out).trim());
         if (!Number.isNaN(n) && n > 0) nvErrNoMemory = Math.round(n);
       } catch {}

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -1315,6 +1315,17 @@ export class SystemCollector {
       const percentage = totalMB > 0 ? Math.round((usedMB / totalMB) * 100) : 0;
       const oomRisk = percentage > 85 ? "high" : percentage > 60 ? "medium" : "low";
 
+      // NV_ERR_NO_MEMORY kernel error count from the NVRM driver (remote host).
+      let nvErrNoMemory = 0;
+      try {
+        const countRaw = await sshExec(
+          this.spark,
+          "journalctl -k --no-pager 2>/dev/null | grep -c \"NV_ERR_NO_MEMORY\" || true"
+        );
+        const n = Number(String(countRaw).trim());
+        if (!Number.isNaN(n) && n > 0) nvErrNoMemory = Math.round(n);
+      } catch {}
+
       return {
         total: totalMB,
         gpuUsed: gpuUsedMB,
@@ -1324,6 +1335,7 @@ export class SystemCollector {
         percentage,
         oomRisk,
         bandwidth: { current: 0, peak: 400 },
+        nvErrNoMemory,
       };
     } catch (err) {
       console.error(`[SystemCollector] Remote Unified Memory error for ${this.spark.id}:`, err.message);

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -905,6 +905,21 @@ export class SystemCollector {
       }
     } catch {}
 
+    // NV_ERR_NO_MEMORY kernel error count from the NVRM driver (host journal).
+    let nvErrNoMemory = 0;
+    try {
+      const js = "journalctl -k --no-pager 2>/dev/null | grep -c \"NV_ERR_NO_MEMORY\" || true";
+      const out = this._hasHostProc() ? await this._execOnHost(js) : await this._exec(js);
+      const n = Number(String(out).trim());
+      if (!Number.isNaN(n) && n > 0) nvErrNoMemory = Math.round(n);
+    } catch {
+      try {
+        const out = await this._exec("dmesg 2>/dev/null | grep -c \"NV_ERR_NO_MEMORY\" || true");
+        const n = Number(String(out).trim());
+        if (!Number.isNaN(n) && n > 0) nvErrNoMemory = Math.round(n);
+      } catch {}
+    }
+
     return {
       total: totalMB,
       gpuUsed: gpuUsedMB,
@@ -914,6 +929,7 @@ export class SystemCollector {
       percentage,
       oomRisk,
       bandwidth,
+      nvErrNoMemory,
     };
   }
 
@@ -1533,6 +1549,7 @@ export class SystemCollector {
       percentage: 0,
       oomRisk: "low",
       bandwidth: { current: 0, peak: 0 },
+      nvErrNoMemory: 0,
     };
   }
 

--- a/server/collectors/__tests__/SystemCollector.nvErr.test.js
+++ b/server/collectors/__tests__/SystemCollector.nvErr.test.js
@@ -1,6 +1,24 @@
 import { test, mock } from "node:test";
 import { strict as assert } from "node:assert";
-import { SystemCollector } from "../SystemCollector.js";
+
+// The remote unified-memory path calls the module-level sshExec() imported by
+// SystemCollector.js. ESM namespace bindings are non-configurable, so we mock
+// the whole ssh.js module via mock.module() (requires --experimental-test-module-mocks).
+let journalCount = 0;
+mock.module("../ssh.js", {
+  exports: {
+    sshExec: async (_spark, cmd) => {
+      if (cmd.includes("journalctl")) {
+        journalCount += 1;
+        return "43";
+      }
+      return "MemTotal:       16000000 kB\nMemAvailable:   4000000 kB\n---\n";
+    },
+  },
+});
+
+// Import after registering the mock so SystemCollector picks up the stubbed sshExec.
+const { SystemCollector } = await import("../SystemCollector.js");
 
 const MEMINFO =
   "MemTotal:       8000000 kB\nMemFree:        1000000 kB\nMemAvailable:   2000000 kB\n";
@@ -35,4 +53,15 @@ test("nvErrNoMemory: defaults to 0 when the journal command fails", async () => 
   });
   const result = await c._getUnifiedMemory();
   assert.equal(result.nvErrNoMemory, 0);
+});
+
+test("nvErrNoMemory: remote collection includes the count over SSH", async () => {
+  journalCount = 0;
+
+  const c = new SystemCollector({ id: "gx11", isLocal: false, lanIp: "10.200.0.2" });
+  const result = await c._getRemoteUnifiedMemory();
+
+  assert.ok(journalCount === 1, "journalctl count command should be issued once");
+  assert.equal(typeof result.nvErrNoMemory, "number");
+  assert.equal(result.nvErrNoMemory, 43);
 });

--- a/server/collectors/__tests__/SystemCollector.nvErr.test.js
+++ b/server/collectors/__tests__/SystemCollector.nvErr.test.js
@@ -5,9 +5,11 @@ import { strict as assert } from "node:assert";
 // SystemCollector.js. ESM namespace bindings are non-configurable, so we mock
 // the whole ssh.js module via mock.module() (requires --experimental-test-module-mocks).
 let journalCount = 0;
+let failSsh = false;
 mock.module("../ssh.js", {
   exports: {
     sshExec: async (_spark, cmd) => {
+      if (failSsh) throw new Error("ssh exec failed");
       if (cmd.includes("journalctl")) {
         journalCount += 1;
         return "43";
@@ -64,4 +66,14 @@ test("nvErrNoMemory: remote collection includes the count over SSH", async () =>
   assert.ok(journalCount === 1, "journalctl count command should be issued once");
   assert.equal(typeof result.nvErrNoMemory, "number");
   assert.equal(result.nvErrNoMemory, 43);
+});
+
+test("nvErrNoMemory: defaults to 0 when the remote SSH journal call throws", async () => {
+  failSsh = true;
+
+  const c = new SystemCollector({ id: "gx11", isLocal: false, lanIp: "10.200.0.2" });
+  const result = await c._getRemoteUnifiedMemory();
+
+  failSsh = false;
+  assert.equal(result.nvErrNoMemory, 0);
 });

--- a/server/collectors/__tests__/SystemCollector.nvErr.test.js
+++ b/server/collectors/__tests__/SystemCollector.nvErr.test.js
@@ -1,0 +1,38 @@
+import { test, mock } from "node:test";
+import { strict as assert } from "node:assert";
+import { SystemCollector } from "../SystemCollector.js";
+
+const MEMINFO =
+  "MemTotal:       8000000 kB\nMemFree:        1000000 kB\nMemAvailable:   2000000 kB\n";
+
+function makeLocalCollector() {
+  const c = new SystemCollector({ id: "gx10", isLocal: true });
+  mock.method(c, "_readHostFile", async () => MEMINFO);
+  mock.method(c, "_parseMemTotal", (raw) => {
+    const m = raw.match(/MemTotal:\s+(\d+)\s+kB/);
+    return m ? parseInt(m[1], 10) : 0;
+  });
+  mock.method(c, "_readGpuMemoryFile", () => 0);
+  mock.method(c, "_nvidiaSmi", async () => "");
+  mock.method(c, "_hasHostProc", () => false);
+  mock.method(c, "_exec", async () => "12");
+  mock.method(c, "_execOnHost", async () => "12");
+  return c;
+}
+
+test("nvErrNoMemory: local collection returns the journal count", async () => {
+  const c = makeLocalCollector();
+  const result = await c._getUnifiedMemory();
+  assert.equal(typeof result.nvErrNoMemory, "number");
+  assert.equal(result.nvErrNoMemory, 12);
+});
+
+test("nvErrNoMemory: defaults to 0 when the journal command fails", async () => {
+  const c = makeLocalCollector();
+  mock.method(c, "_hasHostProc", () => false);
+  mock.method(c, "_exec", async () => {
+    throw new Error("no journal");
+  });
+  const result = await c._getUnifiedMemory();
+  assert.equal(result.nvErrNoMemory, 0);
+});

--- a/server/collectors/__tests__/collectModels.test.js
+++ b/server/collectors/__tests__/collectModels.test.js
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { SystemCollector } from "../SystemCollector.js";
+
+/** Build a local SystemCollector whose modelDirs point at a temp tree. */
+function makeTempHost() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "modelshelf-"));
+  const hot = path.join(base, "hot");
+  const warm = path.join(base, "warm");
+  fs.mkdirSync(path.join(hot, "llama-3-8b"), { recursive: true });
+  fs.writeFileSync(path.join(hot, "llama-3-8b", "model.safetensors"), Buffer.alloc(4096));
+  fs.writeFileSync(path.join(hot, "llama-3-8b", "config.json"), Buffer.alloc(128));
+  fs.mkdirSync(warm, { recursive: true });
+  fs.writeFileSync(path.join(warm, "embedding.gguf"), Buffer.alloc(2048));
+  // Non-model dir: only config.json, no weights — must be ignored.
+  fs.mkdirSync(path.join(hot, "not-a-model"));
+  fs.writeFileSync(path.join(hot, "not-a-model", "config.json"), Buffer.alloc(64));
+  return { base, hot, warm };
+}
+
+test("collectModels: scans configured modelDirs and catalogues resident models", async () => {
+  const { base, hot, warm } = makeTempHost();
+  try {
+    const collector = new SystemCollector({
+      id: "gx10",
+      isLocal: true,
+      modelDirs: { hot: [hot], warm: [warm] },
+    });
+    const models = await collector.collectModels();
+    const byName = new Map(models.map((m) => [m.name, m]));
+    // Model inside hot dir (subdir containing a weight file) -> size recursed.
+    const llama = byName.get("llama-3-8b");
+    assert.ok(llama, "expected llama-3-8b dir to be catalogued");
+    assert.equal(llama.tier, "hot");
+    assert.equal(llama.sizeBytes, 4096 + 128); // model.safetensors + config.json
+    // Loose weight file in warm -> reported by file stem.
+    const emb = byName.get("embedding");
+    assert.ok(emb, "expected loose embedding.gguf to be catalogued");
+    assert.equal(emb.tier, "warm");
+    assert.equal(emb.sizeBytes, 2048);
+    // Non-model dir (no weights) must be absent.
+    assert.ok(!byName.has("not-a-model"), "non-model dir must not be catalogued");
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("collectModels: empty modelDirs returns []", async () => {
+  const collector = new SystemCollector({ id: "gx10", isLocal: true });
+  const models = await collector.collectModels();
+  assert.deepEqual(models, []);
+});
+
+test("collectModels: dedupes by name, first tier wins", async () => {
+  const { base, hot, warm } = makeTempHost();
+  try {
+    // Same model name in both hot and warm dirs.
+    fs.mkdirSync(path.join(warm, "llama-3-8b"), { recursive: true });
+    fs.writeFileSync(path.join(warm, "llama-3-8b", "model.gguf"), Buffer.alloc(512));
+    const collector = new SystemCollector({
+      id: "gx10",
+      isLocal: true,
+      modelDirs: { hot: [hot], warm: [warm] },
+    });
+    const models = await collector.collectModels();
+    const hits = models.filter((m) => m.name === "llama-3-8b");
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].tier, "hot"); // hot scanned first
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/server/collectors/__tests__/showcasePrompts.test.js
+++ b/server/collectors/__tests__/showcasePrompts.test.js
@@ -91,9 +91,10 @@ test("catalog prompts exist for text, structural, and mixed pickers", () => {
   assert.ok(textCount >= 2);
 });
 
-test("DecodeBench uses Showcase structural prompts at temperature 0, thinking off", () => {
-  assert.match(benchSrc, /pickShowcasePrompts\("structural"/);
-  assert.match(benchSrc, /withFillToMaxInstruction/);
+test("DecodeBench uses dedicated decode prompts at temperature 0, thinking off", () => {
+  assert.match(benchSrc, /pickDecodeBenchPrompts/);
+  assert.match(benchSrc, /decodeBenchPromptForType/);
+  assert.match(benchSrc, /stripFillForceFields/);
   assert.match(benchSrc, /temperature:\s*0/);
   assert.match(benchSrc, /applyThinkingFlags\(body,\s*modelId,\s*false\)/);
   assert.match(benchSrc, /min_tokens:\s*maxTokens/);

--- a/server/collectors/__tests__/tierClassify.test.js
+++ b/server/collectors/__tests__/tierClassify.test.js
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { classifyTier, isWeightFile, stripWeightExt } from "../SystemCollector.js";
+
+test("classifyTier: root NVMe mount is hot", () => {
+  assert.equal(classifyTier("nvme0n1p2", "/", "ext4"), "hot");
+  assert.equal(classifyTier("nvme0n1p2", "/", ""), "hot");
+});
+
+test("classifyTier: NAS cifs/nfs mount is cold", () => {
+  assert.equal(classifyTier("//192.168.68.58/modelshelf", "/mnt/modelshelf", "cifs"), "cold");
+  assert.equal(classifyTier("nfs.example:/data", "/mnt/models", "nfs4"), "cold");
+  assert.equal(classifyTier("somedev", "/media/hot4tb", "ext4"), "cold");
+  assert.equal(classifyTier("somedev", "/Volumes/T5", "exfat"), "cold");
+});
+
+test("classifyTier: other real local mounts are warm", () => {
+  assert.equal(classifyTier("sdb1", "/data/usb", "ext4"), "warm");
+  assert.equal(classifyTier("xdpu0", "/mnt/xdp", "xfs"), "cold"); // prefix override
+});
+
+test("classifyTier: tierPaths override wins", () => {
+  const tierPaths = { cold: ["/mnt/models"] };
+  assert.equal(classifyTier("nvme0n1p2", "/", "ext4", tierPaths), "hot");
+  assert.equal(classifyTier("nvme0n1p2", "/mnt/models", "ext4", tierPaths), "cold");
+  assert.equal(classifyTier("somedev", "/mnt/models/lora", "ext4", tierPaths), "cold");
+});
+
+test("classifyTier: empty mount/device defaults to warm", () => {
+  assert.equal(classifyTier("", ""), "warm");
+  assert.equal(classifyTier("sdb1", ""), "warm");
+});
+
+test("isWeightFile: recognizes weight extensions, case-insensitive, rejects others", () => {
+  assert.equal(isWeightFile("model.safetensors"), true);
+  assert.equal(isWeightFile("model.gguf"), true);
+  assert.equal(isWeightFile("model.bin"), true);
+  assert.equal(isWeightFile("model.pt"), true);
+  assert.equal(isWeightFile("model.GGUF"), true);
+  assert.equal(isWeightFile("README.md"), false);
+  assert.equal(isWeightFile("config.json"), false);
+  assert.equal(isWeightFile("tokenizer"), false);
+});
+
+test("stripWeightExt: removes extension and keeps the stem", () => {
+  assert.equal(stripWeightExt("llama-3.gguf"), "llama-3");
+  assert.equal(stripWeightExt("model.safetensors"), "model");
+  assert.equal(stripWeightExt("noext"), "noext");
+});

--- a/server/config.js
+++ b/server/config.js
@@ -46,6 +46,8 @@ const HERMES_UPDATE_TIMEOUT_MS = parseInt(
   process.env.HERMES_UPDATE_TIMEOUT_MS || "600000",
   10
 );
+// Model-inventory scan cadence (heavier dir walk than storage; keep slow).
+const POLL_INTERVAL_MODELS = parseInt(process.env.POLL_INTERVAL_MODELS || "30000", 10);
 
 // ─── Port ────────────────────────────────────────────────
 const PORT = parseInt(process.env.PORT || "5555", 10);
@@ -89,6 +91,18 @@ const HOST_PATHS = {
   ROOT: process.env.HOST_ROOT_PATH || "/host/root",
 };
 
+// ─── Model tier storage ──────────────────────────────────
+// Classifies each Spark storage device into hot/warm/cold. These are the
+// self-contained defaults; a Spark can override them via `tierPaths`.
+const TIER_DEFAULTS = {
+  /** Cold = the shared library/NAS. Matched by fstype or by mount prefix. */
+  COLD_FSTYPES: ["cifs", "smb", "smb3", "nfs", "nfs4"],
+  COLD_MOUNT_PREFIXES: ["/mnt/modelshelf", "/media", "/Volumes", "/mnt"],
+};
+
+/** Weight file extensions that make a directory count as a model. */
+const WEIGHT_EXTENSIONS = new Set([".safetensors", ".gguf", ".bin", ".pt", ".pth", ".ckpt"]);
+
 export {
   SPARKS_JSON_PATH,
   GPU_MEMORY_JSON_PATH,
@@ -110,6 +124,7 @@ export {
   POLL_INTERVAL_LIVENESS,
   POLL_INTERVAL_HERMES,
   HERMES_UPDATE_TIMEOUT_MS,
+  POLL_INTERVAL_MODELS,
   PORT,
   LLM_PORT,
   COMFY_PORT,
@@ -117,5 +132,7 @@ export {
   UNIT_CONVERSION,
   HARDWARE_DEFAULTS,
   HOST_PATHS,
+  TIER_DEFAULTS,
+  WEIGHT_EXTENSIONS,
   ROOT,
 };

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -18,6 +18,7 @@ import {
   POLL_INTERVAL_LIVENESS,
   POLL_INTERVAL_HERMES,
   POLL_INTERVAL_TAILSCALE,
+  POLL_INTERVAL_MODELS,
   LLM_PORT,
   COMFY_PORT,
   HOST_PATHS,
@@ -92,6 +93,7 @@ export class SparkMonitor {
       cpu: this.collector._defaultCpu(),
       ram: this.collector._defaultRam(),
       storage: [],
+      models: [],
       network: this.collector._defaultNetwork(),
       unifiedMemory: this.collector._defaultUnifiedMemory(),
       llm: [],
@@ -348,6 +350,7 @@ export class SparkMonitor {
     this._intervals.push(setInterval(() => this._pollDomain("cpu"), POLL_INTERVAL_CPU));
     this._intervals.push(setInterval(() => this._pollDomain("network"), POLL_INTERVAL_NETWORK));
     this._intervals.push(setInterval(() => this._pollDomain("storage"), POLL_INTERVAL_STORAGE));
+    this._intervals.push(setInterval(() => this._pollDomain("models"), POLL_INTERVAL_MODELS));
     this._intervals.push(setInterval(() => this._pollDomain("ram"), POLL_INTERVAL_CPU));
     this._intervals.push(setInterval(() => this._pollDomain("memory"), POLL_INTERVAL_BANDWIDTH));
     this._restartLlmPollInterval();
@@ -425,6 +428,7 @@ export class SparkMonitor {
         cpu: this._metrics.cpu,
         ram: this._metrics.ram,
         storage: this._metrics.storage,
+        models: this._metrics.models,
         network: this._metrics.network,
         unifiedMemory: this._metrics.unifiedMemory,
         llm: this._metrics.llm,
@@ -494,6 +498,7 @@ export class SparkMonitor {
       this._pollDomain("cpu"),
       this._pollDomain("network"),
       this._pollDomain("storage"),
+      this._pollDomain("models"),
       this._pollDomain("ram"),
       this._pollDomain("memory"),
       this._pollDomain("llm"),
@@ -530,6 +535,9 @@ export class SparkMonitor {
           break;
         case "storage":
           result = await this.collector.collectStorage();
+          break;
+        case "models":
+          result = await this.collector.collectModels();
           break;
         case "memory":
           result = await this.collector.collectUnifiedMemory();
@@ -578,6 +586,9 @@ export class SparkMonitor {
           break;
         case "storage":
           this._metrics.storage = result;
+          break;
+        case "models":
+          this._metrics.models = result;
           break;
         case "memory":
           this._metrics.unifiedMemory = result;

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -525,6 +525,18 @@ export class SparkRegistry {
       disabledDevices: Array.isArray(config.disabledDevices) ? config.disabledDevices : [],
       disabledInterfaces: Array.isArray(config.disabledInterfaces) ? config.disabledInterfaces : [],
       storagePollDisabled: Boolean(config.storagePollDisabled),
+      /**
+       * Optional storage-tier override: { hot?: string[], warm?: string[],
+       * cold?: string[] } of mount-prefix lists. When empty/absent, tier
+       * classification falls back to TIER_DEFAULTS heuristics.
+       */
+      tierPaths: this._normalizeTierMap(config.tierPaths),
+      /**
+       * Optional per-tier model directories to scan:
+       * { hot?: string[], warm?: string[], cold?: string[] }. When empty,
+       * scan roots are derived from the classified tier mounts.
+       */
+      modelDirs: this._normalizeTierMap(config.modelDirs),
     };
   }
 
@@ -533,6 +545,22 @@ export class SparkRegistry {
     const n = typeof value === "string" ? parseInt(value, 10) : Number(value);
     if (Number.isInteger(n) && n >= 1 && n <= 65535) return n;
     return 8188;
+  }
+
+  /** Normalize { tier: string[] } to a clean { hot?, warm?, cold? } map. */
+  _normalizeTierMap(value) {
+    if (!value || typeof value !== "object") return {};
+    const out = {};
+    for (const tier of ["hot", "warm", "cold"]) {
+      const raw = value[tier];
+      if (Array.isArray(raw)) {
+        const paths = raw
+          .map((p) => (typeof p === "string" ? p.trim() : ""))
+          .filter(Boolean);
+        if (paths.length > 0) out[tier] = paths;
+      }
+    }
+    return out;
   }
 
   /** Normalize role; legacy workerNode=true → worker. */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,11 +8,12 @@ import { EditSparkDialog } from "./components/EditSparkDialog";
 import { SparkPage } from "./components/SparkPage/SparkPage";
 import { HermesUpdateDialog } from "./components/SparkPage/HermesUpdateDialog";
 import { OverviewPage } from "./components/OverviewPage/OverviewPage";
+import { FleetStoragePage } from "./components/FleetStoragePage/FleetStoragePage";
 import { ShowcasePage } from "./components/ShowcasePage/ShowcasePage";
 import { ThemeSwitch } from "./components/ThemeSwitch";
 import { SettingsDialog } from "./components/SettingsDialog";
 import { GearIcon, BoltIcon } from "./components/ui/icons";
-import { OVERVIEW_ID } from "./constants";
+import { OVERVIEW_ID, FLEET_STORAGE_ID } from "./constants";
 import type { Settings, SparkSnapshot } from "./api/types";
 
 function placeholderSnapshot(
@@ -91,6 +92,7 @@ function placeholderSnapshot(
       cpu: null,
       ram: null,
       storage: [],
+      models: [],
       network: null,
       unifiedMemory: null,
       llm: [],
@@ -139,6 +141,7 @@ function DashboardApp() {
 
 
   const isOverview = activeId === OVERVIEW_ID;
+  const isFleetStorage = activeId === FLEET_STORAGE_ID;
   const displayActive = isOverview
     ? null
     : displaySparks.find((s) => s.id === activeId) || displaySparks[0] || activeSpark || null;
@@ -267,7 +270,9 @@ function DashboardApp() {
           </div>
         </header>
         <main>
-          {isOverview ? (
+          {isFleetStorage ? (
+            <FleetStoragePage sparks={displaySparks} />
+          ) : isOverview ? (
             <OverviewPage
               sparks={displaySparks}
               hideOffline={settings?.autoHideOffline ?? false}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -271,6 +271,8 @@ export interface UnifiedMemoryMetrics {
   used: number;
   available: number;
   percentage: number;
+  /** Cumulative count of NV_ERR_NO_MEMORY kernel driver errors. */
+  nvErrNoMemory: number;
   oomRisk: "low" | "medium" | "high";
   bandwidth: {
     current: number;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -84,6 +84,16 @@ export interface SparkConfig {
   tailscaleMonitoring?: boolean;
   /** When true, storage is only updated on manual refresh, not auto-polled. */
   storagePollDisabled?: boolean;
+  /**
+   * Optional storage-tier override: { hot?, warm?, cold?: string[] } of mount
+   * prefixes. When empty, tier classification uses defaults. (self-contained)
+   */
+  tierPaths?: Partial<Record<ModelTier, string[]>>;
+  /**
+   * Optional per-tier model directories to scan for the model inventory:
+   * { hot?, warm?, cold?: string[] }. When empty, no models are reported.
+   */
+  modelDirs?: Partial<Record<ModelTier, string[]>>;
 }
 
 export type SparkRole = "head" | "worker" | "standalone";
@@ -240,6 +250,22 @@ export interface StorageMetrics {
   writeSpeed: number;
   /** Present when device is in disabledDevices; still returned for Settings UI */
   disabled?: boolean;
+  /** Storage tier: hot (internal NVMe) / warm (USB) / cold (NAS library). */
+  tier?: "hot" | "warm" | "cold";
+}
+
+/** A storage tier label. */
+export type ModelTier = "hot" | "warm" | "cold";
+
+/**
+ * A resident model on a Spark, from the per-Spark scanner. Placement
+ * (replicated across Sparks vs served over the CX7 fabric from a peer) is
+ * derived fleet-wide in the frontend from each Spark's models + loaded llm ids.
+ */
+export interface ModelTierMetrics {
+  name: string;
+  sizeBytes: number;
+  tier: ModelTier;
 }
 
 // ─── Network metrics ─────────────────────────────────────
@@ -455,6 +481,8 @@ export interface SparkMetrics {
   cpu: CpuMetrics | null;
   ram: RamMetrics | null;
   storage: StorageMetrics[];
+  /** Resident models from the per-Spark scanner (tier + size). */
+  models: ModelTierMetrics[];
   network: NetworkMetrics | null;
   unifiedMemory: UnifiedMemoryMetrics | null;
   /** Array of LLM metrics, one per configured port. Empty array when no ports. */

--- a/src/components/FleetStoragePage/FleetStoragePage.tsx
+++ b/src/components/FleetStoragePage/FleetStoragePage.tsx
@@ -1,0 +1,195 @@
+import { useMemo } from "react";
+import type { ModelTier, SparkSnapshot, StorageMetrics } from "../../api/types";
+import { MetricBar } from "../ui/MetricBar";
+import { Panel } from "../ui/Panel";
+import { DiskIcon } from "../ui/icons";
+import { resolvePlacement, rollupTierGb } from "./fleetPlacement";
+
+interface FleetStoragePageProps {
+  sparks: SparkSnapshot[];
+}
+
+const TIERS: ModelTier[] = ["hot", "warm", "cold"];
+
+const TIER_TONE: Record<ModelTier, string> = {
+  hot: "bg-accent text-accent",
+  warm: "bg-warning text-black",
+  cold: "bg-muted text-black",
+};
+
+function fmtGb(mb: number): string {
+  const gb = mb / 1024;
+  return gb >= 100 ? `${Math.round(gb)} GB` : `${gb.toFixed(1)} GB`;
+}
+
+function fmtBytes(bytes: number): string {
+  const gb = bytes / 1024 / 1024 / 1024;
+  if (gb >= 1) return `${gb.toFixed(1)} GB`;
+  const m = bytes / 1024 / 1024;
+  return `${Math.round(m)} MB`;
+}
+
+function TierChip({ tier }: { tier: ModelTier }) {
+  const label = tier === "hot" ? "Hot" : tier === "warm" ? "Warm" : "Cold";
+  return (
+    <span
+      className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${TIER_TONE[tier]}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function FleetStoragePage({ sparks }: FleetStoragePageProps) {
+  const tierGb = useMemo(() => rollupTierGb(sparks), [sparks]);
+  const placement = useMemo(() => resolvePlacement(sparks), [sparks]);
+  const replicated = placement.filter((p) => p.resident.length > 1).length;
+  const fabric = placement.filter((p) => p.fabric.length > 0).length;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--density-overview-rhythm)" }}>
+      <div className="flex flex-wrap items-end justify-between gap-6">
+        <h1
+          className="font-normal leading-tight tracking-tight text-text-strong"
+          style={{ fontSize: "var(--density-overview-title)" }}
+        >
+          Storage
+        </h1>
+        <div className="flex flex-wrap items-center gap-2">
+          {TIERS.map((t) => (
+            <span key={t} className="flex items-center gap-1.5 rounded-md border border-border bg-surface-elevated px-2.5 py-1.5 text-[11px] text-muted">
+              <TierChip tier={t} />
+              <span className="font-tabular text-text-strong">{fmtGb(tierGb[t])}</span>
+              <span>used</span>
+            </span>
+          ))}
+          <span className="flex items-center gap-1.5 rounded-md border border-border bg-surface-elevated px-2.5 py-1.5 text-[11px] text-muted">
+            <span className="font-tabular text-text-strong">{replicated}</span> replicated
+          </span>
+          <span className="flex items-center gap-1.5 rounded-md border border-border bg-surface-elevated px-2.5 py-1.5 text-[11px] text-muted">
+            <span className="font-tabular text-text-strong">{fabric}</span> on CX7 fabric
+          </span>
+        </div>
+      </div>
+
+      {/* Per-Spark tier cards */}
+      <div className="overview-page grid sm:grid-cols-2 lg:grid-cols-3" style={{ gap: "var(--density-page-gap)" }}>
+        {sparks.map((spark) => (
+          <SparkTierCard key={spark.id} spark={spark} />
+        ))}
+      </div>
+
+      {/* Model placement table */}
+      <Panel title="Model placement" accent icon={<DiskIcon />} className="panel-storage">
+        {placement.length === 0 ? (
+          <p className="text-xs text-muted">
+            No models discovered. Configure <code className="rounded bg-surface-elevated px-1">modelDirs</code> per tier for each Spark in sparks.json.
+          </p>
+        ) : (
+          <table className="w-full border-collapse text-xs">
+            <thead>
+              <tr className="text-left text-[10px] uppercase tracking-wide text-muted">
+                <th className="py-1.5 pr-3 font-medium">Model</th>
+                <th className="py-1.5 pr-3 font-medium">Size</th>
+                <th className="py-1.5 font-medium">Placement</th>
+              </tr>
+            </thead>
+            <tbody>
+              {placement.map((p) => (
+                <tr key={p.name} className="border-t border-border">
+                  <td className="py-2 pr-3 align-top">
+                    <span className="font-tabular break-all text-text-strong">{p.name}</span>
+                  </td>
+                  <td className="py-2 pr-3 align-top font-tabular text-muted">
+                    {fmtBytes(p.resident[0]?.tier ? byteSizeFor(p, sparks) : 0)}
+                  </td>
+                  <td className="py-2 align-top">
+                    <div className="flex flex-wrap gap-1">
+                      {p.resident.map((r) => (
+                        <span key={`${r.sparkId}:${r.tier}`} className="inline-flex items-center gap-1 rounded bg-surface-elevated px-1.5 py-0.5 text-[10px] text-text">
+                          {r.sparkName}
+                          <TierChip tier={r.tier} />
+                        </span>
+                      ))}
+                      {p.fabric.map((f) => (
+                        <span key={f.sparkId} className="inline-flex items-center gap-1 rounded border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-[10px] text-accent">
+                          {f.sparkName} · fabric
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <p className="mt-2 text-[10px] text-muted">
+          Resident = local disk copy. “fabric” = this Spark loads the model over the CX7 link from a peer’s copy (no local copy).
+        </p>
+      </Panel>
+    </div>
+  );
+}
+
+function byteSizeFor(
+  p: { name: string },
+  sparks: SparkSnapshot[]
+): number {
+  for (const s of sparks) {
+    const m = (Array.isArray(s.metrics?.models) ? s.metrics.models : []).find(
+      (x) => x.name === p.name
+    );
+    if (m) return m.sizeBytes;
+  }
+  return 0;
+}
+
+function SparkTierCard({ spark }: { spark: SparkSnapshot }) {
+  const disks: StorageMetrics[] = Array.isArray(spark.metrics?.storage)
+    ? spark.metrics.storage.filter((d) => !d.disabled)
+    : [];
+  const tierAgg: Record<ModelTier, { used: number; total: number }> = {
+    hot: { used: 0, total: 0 },
+    warm: { used: 0, total: 0 },
+    cold: { used: 0, total: 0 },
+  };
+  for (const d of disks) {
+    const t = d.tier;
+    if (t === "hot" || t === "warm" || t === "cold") {
+      tierAgg[t].used += d.used || 0;
+      tierAgg[t].total += d.total || 0;
+    }
+  }
+  return (
+    <div
+      className="overview-card flex flex-col"
+      style={{ padding: "var(--density-card-pad)", gap: "var(--density-card-gap)" }}
+    >
+      <div className="flex items-center gap-2">
+        <span className={`h-2 w-2 shrink-0 rounded-full ${spark.online ? "bg-success dot-glow-success" : "bg-danger"}`} />
+        <span className="min-w-0 flex-1 truncate text-[15px] font-semibold text-text-strong">{spark.name}</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted">{spark.online ? "online" : "offline"}</span>
+      </div>
+      <div className="flex flex-col gap-3">
+        {TIERS.map((t) =>
+          tierAgg[t].total > 0 ? (
+            <div key={t} className="space-y-1">
+              <div className="flex items-center justify-between text-xs">
+                <span className="flex items-center gap-1.5">
+                  <TierChip tier={t} />
+                </span>
+                <span className="font-tabular text-muted">
+                  {fmtGb(tierAgg[t].used)} / {fmtGb(tierAgg[t].total)}
+                </span>
+              </div>
+              <MetricBar label={t} value={tierAgg[t].used} max={tierAgg[t].total} />
+            </div>
+          ) : null
+        )}
+        {TIERS.every((t) => tierAgg[t].total === 0) && (
+          <p className="text-xs text-muted">No tiered storage detected</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/FleetStoragePage/fleetPlacement.ts
+++ b/src/components/FleetStoragePage/fleetPlacement.ts
@@ -1,0 +1,81 @@
+import type { ModelTier, SparkSnapshot, StorageMetrics } from "../../api/types";
+
+/** A Spark's view of where a model lives, given the whole fleet's snapshots. */
+export interface ModelPlacement {
+  name: string;
+  /** Resident copies: which Spark(s) hold a local copy, and in which tier. */
+  resident: Array<{ sparkId: string; sparkName: string; tier: ModelTier }>;
+  /** Sparks serving this model over the CX7 fabric (loading but not resident). */
+  fabric: Array<{ sparkId: string; sparkName: string }>;
+}
+
+/** Loose model-name match: exact, or normalize HF-hub-style basenames. */
+function modelIdMatches(llmModelId: string | null | undefined, modelName: string): boolean {
+  if (!llmModelId) return false;
+  const a = llmModelId.toLowerCase();
+  const b = modelName.toLowerCase();
+  if (a === b) return true;
+  // HF hub cache path like ~/.cache/huggingface/hub/models--org--name vs resident name.
+  const last = a.split("/").pop() ?? "";
+  return last === b || a.endsWith("/" + b) || a.includes("models--" + b.replace(/\s+/g, "-"));
+}
+
+/**
+ * Resolve per-model placement across the fleet. A model is:
+ *  - "resident" on a Spark that holds a local disk copy (tier from its scan);
+ *  - served "fabric" on a Spark that is currently *loading* it in unified
+ *    memory (llm modelId) but holds no local copy, while at least one peer is
+ *    resident — i.e. the peer's hot copy is reached over the CX7 interconnect.
+ * Pure (no React) so it is directly unit-testable.
+ */
+export function resolvePlacement(sparks: SparkSnapshot[]): ModelPlacement[] {
+  const byName = new Map<string, ModelPlacement>();
+  for (const spark of sparks) {
+    const resident = Array.isArray(spark.metrics?.models) ? spark.metrics.models : [];
+    for (const m of resident) {
+      let entry = byName.get(m.name);
+      if (!entry) {
+        entry = { name: m.name, resident: [], fabric: [] };
+        byName.set(m.name, entry);
+      }
+      entry.resident.push({ sparkId: spark.id, sparkName: spark.name, tier: m.tier });
+    }
+  }
+  // Fabric: a Spark is loading a model it does not own, while a peer owns it.
+  for (const spark of sparks) {
+    const loaded = (Array.isArray(spark.metrics?.llm) ? spark.metrics.llm : [])
+      .map((l) => l?.modelId)
+      .filter(Boolean);
+    for (const modelName of Array.from(byName.keys())) {
+      const entry = byName.get(modelName)!;
+      if (entry.resident.some((r) => r.sparkId === spark.id)) continue; // resident here
+      if (entry.resident.length === 0) continue; // nobody owns it locally
+      const isLoaded = loaded.some((id) => modelIdMatches(id, modelName));
+      if (isLoaded) {
+        // Avoid duplicate fabric markers per spark/model.
+        if (!entry.fabric.some((f) => f.sparkId === spark.id)) {
+          entry.fabric.push({ sparkId: spark.id, sparkName: spark.name });
+        }
+      }
+    }
+  }
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Fleet-wide tier usage (GB) summed across all Sparks' storage devices. */
+export function rollupTierGb(sparks: SparkSnapshot[]): Record<ModelTier, number> {
+  const out: Record<ModelTier, number> = { hot: 0, warm: 0, cold: 0 };
+  for (const spark of sparks) {
+    const disks: StorageMetrics[] = Array.isArray(spark.metrics?.storage)
+      ? spark.metrics.storage
+      : [];
+    for (const d of disks) {
+      if (d?.disabled) continue;
+      const tier = d.tier;
+      if (tier === "hot" || tier === "warm" || tier === "cold") {
+        out[tier] += (d.used || 0) / 1024;
+      }
+    }
+  }
+  return out;
+}

--- a/src/components/SparkPage/GpuPanel.tsx
+++ b/src/components/SparkPage/GpuPanel.tsx
@@ -1,4 +1,5 @@
-import type { CpuMetrics, GpuMetrics } from "../../api/types";
+import { useEffect, useState } from "react";
+import type { CpuMetrics, GpuMetrics, UnifiedMemoryMetrics } from "../../api/types";
 import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
 import { ActivityIcon } from "../ui/icons";
@@ -9,6 +10,7 @@ interface GpuPanelProps {
   gpu: GpuMetrics | null;
   /** When set and temperature > 0, show a CPU temp row (DGX Spark pages). */
   cpu?: CpuMetrics | null;
+  unifiedMemory: UnifiedMemoryMetrics | null;
   sparkId: string;
   temperatureUnit: "celsius" | "fahrenheit";
   className?: string;
@@ -16,6 +18,25 @@ interface GpuPanelProps {
 
 function celsiusToFahrenheit(c: number): number {
   return Math.round(c * 9 / 5 + 32);
+}
+
+const NV_ERR_STORAGE_KEY = "nvErrBaseline";
+
+function getNvErrBaseline(sparkId: string): number {
+  try {
+    const raw = localStorage.getItem(`${NV_ERR_STORAGE_KEY}.${sparkId}`);
+    return raw ? parseInt(raw, 10) || 0 : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function setNvErrBaseline(sparkId: string, value: number) {
+  try {
+    localStorage.setItem(`${NV_ERR_STORAGE_KEY}.${sparkId}`, String(value));
+  } catch {
+    /* localStorage unavailable */
+  }
 }
 
 function formatMb(mb: number): string {
@@ -45,7 +66,7 @@ function MetricRow({
   );
 }
 
-export function GpuPanel({ gpu, cpu, sparkId, temperatureUnit, className }: GpuPanelProps) {
+export function GpuPanel({ gpu, cpu, unifiedMemory, sparkId, temperatureUnit, className }: GpuPanelProps) {
   const tempHistory = useMetricsHistoryTail(sparkId, "gpu.temp");
   const usageHistory = useMetricsHistoryTail(sparkId, "gpu.usage");
   const cpuTempHistory = useMetricsHistoryTail(sparkId, "cpu.temp");
@@ -66,6 +87,22 @@ export function GpuPanel({ gpu, cpu, sparkId, temperatureUnit, className }: GpuP
     temperatureUnit === "fahrenheit" ? celsiusToFahrenheit(cpuTemperature) : cpuTemperature;
   const cpuTempLabel =
     temperatureUnit === "fahrenheit" ? `${cpuDisplayTemp}°F` : `${cpuDisplayTemp}°C`;
+
+  const nvErrRaw = unifiedMemory?.nvErrNoMemory ?? 0;
+  const [nvErrBaseline, setNvErrBaselineState] = useState<number>(() =>
+    getNvErrBaseline(sparkId)
+  );
+  const [nvErrSinceReset, setNvErrSinceReset] = useState<number>(0);
+
+  useEffect(() => {
+    setNvErrSinceReset(Math.max(0, nvErrRaw - nvErrBaseline));
+  }, [nvErrRaw, nvErrBaseline]);
+
+  const handleResetNvErr = () => {
+    setNvErrBaseline(sparkId, nvErrRaw);
+    setNvErrBaselineState(nvErrRaw);
+    setNvErrSinceReset(0);
+  };
 
   const tempColor =
     temperature > 85
@@ -188,6 +225,28 @@ export function GpuPanel({ gpu, cpu, sparkId, temperatureUnit, className }: GpuP
                 <div className="flex justify-between text-xs">
                   <span className="text-muted">Available</span>
                   <span className="font-tabular text-text">{formatMb(gpu.vram.available)}</span>
+                </div>
+              )}
+              {unifiedMemory !== null && (
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted">NV_ERR_NO_MEMORY</span>
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className={`font-tabular ${
+                        nvErrSinceReset > 0 ? "text-danger font-semibold" : "text-text"
+                      }`}
+                    >
+                      {nvErrSinceReset}
+                    </span>
+                    <button
+                      type="button"
+                      className="cursor-pointer rounded border border-border bg-surface px-1.5 py-0.5 text-xs text-muted hover:border-accent hover:text-accent transition-colors"
+                      onClick={handleResetNvErr}
+                      title="Reset error counter — set a new baseline so only future errors are counted"
+                    >
+                      ↺ reset
+                    </button>
+                  </div>
                 </div>
               )}
             </>

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -233,6 +233,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
               /* Hosts: GPU spans the full left column; RAM → Network → Storage [→ Tailnet] stack in the right column */
               <>
                 <GpuPanel
+                  key={spark.id}
                   gpu={metrics.gpu}
                   unifiedMemory={metrics.unifiedMemory}
                   sparkId={spark.id}
@@ -265,6 +266,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
               /* Resources layout: GPU spans the full left column; Storage + Network [+ Tailnet] stack in the right column */
               <>
                 <GpuPanel
+                  key={spark.id}
                   gpu={metrics.gpu}
                   cpu={metrics.cpu}
                   unifiedMemory={metrics.unifiedMemory}

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -234,6 +234,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
               <>
                 <GpuPanel
                   gpu={metrics.gpu}
+                  unifiedMemory={metrics.unifiedMemory}
                   sparkId={spark.id}
                   temperatureUnit={temperatureUnit}
                   className={tailscaleOn ? "md:row-span-4" : "md:row-span-3"}
@@ -266,6 +267,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
                 <GpuPanel
                   gpu={metrics.gpu}
                   cpu={metrics.cpu}
+                  unifiedMemory={metrics.unifiedMemory}
                   sparkId={spark.id}
                   temperatureUnit={temperatureUnit}
                   className={tailscaleOn ? "md:row-span-3" : "md:row-span-2"}

--- a/src/components/SparkPage/StoragePanel.tsx
+++ b/src/components/SparkPage/StoragePanel.tsx
@@ -25,6 +25,24 @@ function formatGb(mb: number): string {
   return `${Math.round(mb)} MB`;
 }
 
+function TierBadge({ tier }: { tier?: "hot" | "warm" | "cold" }) {
+  if (tier !== "hot" && tier !== "warm" && tier !== "cold") return null;
+  const label = tier === "hot" ? "Hot" : tier === "warm" ? "Warm" : "Cold";
+  const cls =
+    tier === "hot"
+      ? "bg-accent text-black"
+      : tier === "warm"
+        ? "bg-warning text-black"
+        : "bg-muted text-black";
+  return (
+    <span
+      className={`inline-block shrink-0 rounded px-1 py-px text-[9px] font-medium uppercase tracking-wide ${cls}`}
+    >
+      {label}
+    </span>
+  );
+}
+
 function MetricBar({ value, max }: { value: number; max: number }) {
   const pct = max > 0 ? Math.min(100, Math.round((value / max) * 100)) : 0;
   const barColor = pct > 85 ? "bg-danger" : pct > 60 ? "bg-warning" : "bg-accent";
@@ -213,6 +231,7 @@ export function StoragePanel({
                     <div className="flex items-baseline justify-between">
                       <div className="flex min-w-0 items-center gap-2">
                         <span className="truncate text-xs text-text">{disk.label}</span>
+                        <TierBadge tier={disk.tier} />
                         <span className="shrink-0 font-tabular text-xs text-muted">{disk.device}</span>
                       </div>
                       <span className="shrink-0 font-tabular text-xs text-text-strong">{pct}%</span>

--- a/src/components/SparkTabs.tsx
+++ b/src/components/SparkTabs.tsx
@@ -19,8 +19,8 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { SparkSnapshot } from "../api/types";
-import { PlusIcon, GridIcon } from "./ui/icons";
-import { OVERVIEW_ID } from "../constants";
+import { PlusIcon, GridIcon, DiskIcon } from "./ui/icons";
+import { OVERVIEW_ID, FLEET_STORAGE_ID } from "../constants";
 
 interface SparkTabsProps {
   sparks: SparkSnapshot[];
@@ -326,6 +326,7 @@ export function SparkTabs({
     return (
       <nav className="pill-nav" aria-label="Sparks">
         <OverviewTab isActive={activeId === OVERVIEW_ID} onSelect={onSelect} />
+        <FleetStorageTab isActive={activeId === FLEET_STORAGE_ID} onSelect={onSelect} />
         {sparks.map((spark) => (
           <div key={spark.id} className="shrink-0">
             <TabChrome
@@ -351,6 +352,7 @@ export function SparkTabs({
     >
       <nav className="pill-nav" aria-label="Sparks">
         <OverviewTab isActive={activeId === OVERVIEW_ID} onSelect={onSelect} />
+        <FleetStorageTab isActive={activeId === FLEET_STORAGE_ID} onSelect={onSelect} />
         <SortableContext items={items} strategy={horizontalListSortingStrategy}>
           {ordered.map((spark) => (
             <SortableTab
@@ -409,6 +411,28 @@ function OverviewTab({
       >
         <GridIcon className="h-3.5 w-3.5" />
         Overview
+      </button>
+    </div>
+  );
+}
+
+function FleetStorageTab({
+  isActive,
+  onSelect,
+}: {
+  isActive: boolean;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <div className="shrink-0">
+      <button
+        type="button"
+        onClick={() => onSelect(FLEET_STORAGE_ID)}
+        className={`pill-item ${isActive ? "is-active" : ""}`}
+        title="Fleet model storage tiers"
+      >
+        <DiskIcon className="h-3.5 w-3.5" />
+        Storage
       </button>
     </div>
   );
@@ -484,6 +508,15 @@ function MobileSparkMenu({
       >
         <GridIcon className="h-3.5 w-3.5" />
         Overview
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className={`mobile-menu-item ${activeId === FLEET_STORAGE_ID ? "is-active" : ""}`}
+        onClick={() => handleItemClick(FLEET_STORAGE_ID)}
+      >
+        <DiskIcon className="h-3.5 w-3.5" />
+        Storage
       </button>
       {sparks.map((spark) => (
         <button

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,5 @@
 /** Reserved tab id for the cross-Spark overview (not a real Spark). */
 export const OVERVIEW_ID = "__overview__";
+
+/** Reserved tab id for the cross-Spark model-storage view (not a real Spark). */
+export const FLEET_STORAGE_ID = "__storage__";

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -1,7 +1,15 @@
 import { useEffect, useCallback, useRef, useState } from "react";
-import { OVERVIEW_ID } from "../constants";
+import { OVERVIEW_ID, FLEET_STORAGE_ID } from "../constants";
 
 export type RouteMode = "app" | "showcase";
+
+/** Map a pathname to an active tab id (Overview or a Spark), or null. */
+function activeIdFromPath(pathname: string): string | null {
+  if (pathname === "/storage") return FLEET_STORAGE_ID;
+  const spark = pathname.match(/^\/spark\/([^/]+)/);
+  return spark ? decodeURIComponent(spark[1]) : OVERVIEW_ID;
+}
+
 
 export interface AppRoute {
   mode: RouteMode;
@@ -59,13 +67,7 @@ export function useRoute(
 
     const path = window.location.pathname;
     if (path.startsWith("/showcase/")) return;
-
-    const match = path.match(/^\/spark\/([^/]+)/);
-    if (match) {
-      setActiveId(match[1]);
-    } else if (path !== "/spark") {
-      setActiveId(OVERVIEW_ID);
-    }
+    setActiveId(activeIdFromPath(path));
   }, [setActiveId]);
 
   // Sync back/forward navigation
@@ -73,8 +75,7 @@ export function useRoute(
     const handler = () => {
       const path = window.location.pathname;
       if (path.startsWith("/showcase/")) return;
-      const match = path.match(/^\/spark\/([^/]+)/);
-      setActiveId(match ? match[1] : OVERVIEW_ID);
+      setActiveId(activeIdFromPath(path));
     };
     window.addEventListener("popstate", handler);
     return () => window.removeEventListener("popstate", handler);
@@ -83,7 +84,9 @@ export function useRoute(
   // Wrapped navigate function — updates URL + internal state
   const navigate = useCallback(
     (id: string | null) => {
-      const url = id && id !== OVERVIEW_ID ? `/spark/${encodeURIComponent(id)}` : "/";
+      let url = "/";
+      if (id === FLEET_STORAGE_ID) url = "/storage";
+      else if (id && id !== OVERVIEW_ID) url = `/spark/${encodeURIComponent(id)}`;
       window.history.pushState(null, "", url);
       setActiveId(id);
     },


### PR DESCRIPTION
## Summary

Brings the **multi-tier model storage** concept to sparkDash for DGX Spark fleets: a read-only **Storage** view that classifies every Spark's disks into storage tiers, inventories the model weight files on the fleet, and shows where each model lives — both as a local copy and as served across the CX7/ConnectX fabric.

This is fully self-contained: tier classification and model scanning run inside the existing `SystemCollector` (local + SSH), with no external registry or service dependency.

## What's in the PR

### Tier classification
Every mounted disk is labeled a tier:
- **Hot** — root NVMe (active working copy)
- **Warm** — other real local disks
- **Cold** — NAS / network mounts (`/mnt/modelshelf`, `/media`, `/Volumes`, `/mnt`, or any `cifs`/`smb`/`smb3`/`nfs`/`nfs4` filesystem)

Per-Spark `tierPaths` in `config/sparks.json` override the heuristic per mount.

### Model inventory
The collector scans the configured model directories (grouped per tier via optional per-Spark `modelDirs`) for weight files — `.safetensors`, `.gguf`, `.bin`, `.pt`, `.pth`, `.ckpt` — and reports each model by name, size, and tier. New `models` metrics domain, polled via `POLL_INTERVAL_MODELS` (default 30 s). Each scanned root is inspected **one level deep**; `modelDirs` should point at the directory whose direct children are the model folders (for HF-style nesting, the outer family dir, e.g. `~/models/hf`).

### Dual placement (resident + fabric)
A model is **resident** on a Spark holding a local copy. A peer that has the model loaded in its LLM probe — matched by model name — serves it to the fleet over the CX7/ConnectX fabric, so that Spark shows the model as placed **over the fabric** even with no local copy. This mirrors the storage intent: a "hot" model is available to the fleet either from local disk or from a peer's memory across the fabric.

### UI
- New reserved **Storage** tab (fleet level), plus per-Spark tier cards and a model placement table
- Each Spark's Storage panel shows a Hot/Warm/Cold badge per disk

## Verification
- `npm test` — 94 passing (incl. new `tierClassify` and `collectModels` unit tests)
- `npm run typecheck` and `npm run build` — clean
- **Live smoke on a DGX Spark (Gx10)** — the real mount table classifies correctly (root NVMe → Hot, `cifs` NAS `/mnt/macmini` → Cold, other local/snap disks → Warm) and `collectModels` correctly detected the resident `DeepSeek-V4-Flash-0731` (155.4 GiB) from a `modelDirs` root

## Notes for review
- Read-only and additive: no eviction, promotion, or write actions; no changes to existing storage/liveness behavior
- Out of scope on purpose: warm-tier USB config UI, eviction/promotion actions, activity history, non-DGX support
