### PR TITLE
feat(tailscale): opt-in tailnet monitoring per Spark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format: version sections are listed newest first.
 
 ---
 
+## [1.7.0] — 2026-08-10
+
+### Added
+- **Tailnet monitoring** — opt-in per Spark (`tailscaleMonitoring`, default **off**); runs `tailscale status --json` on the host and shows a **Tailnet** card beside Network. Closes a blind spot shared by every LAN-based check: when `tailscaled` loses its coordination-server session, SSH/GPU/LLM all keep reporting healthy while the Spark is unreachable from off-LAN.
+- **Off-tailnet verdict from the node itself** — reads `Self.Online` on each host rather than a peer's (possibly stale) view of it.
+- **Failure reason, not just state** — surfaces Tailscale's own `Health` messages (e.g. *"hasn't received a network map from the coordination server in 2m7s"*), `BackendState`, tailnet IP, DERP relay region, version, and an expired-node-key warning.
+- **Edit Spark** — `Tailnet monitoring` checkbox.
+- Env: `POLL_INTERVAL_TAILSCALE` (default `30000`), `TAILSCALE_PROBE_TIMEOUT_MS` (default `8000`).
+
+---
+
 ## [1.6.0] — 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ sparkDash is a real-time web dashboard for one or more **NVIDIA DGX Spark (GB10)
 - [Latest version changelog](#latest-version-changelog)
 - [Features](#features)
 - [ComfyUI monitoring](#comfyui-monitoring)
+- [Tailnet monitoring](#tailnet-monitoring)
 - [Full changelog](./CHANGELOG.md)
 - [Quick start](#quick-start)
 - [Architecture](#architecture)
@@ -46,6 +47,10 @@ sparkDash is a real-time web dashboard for one or more **NVIDIA DGX Spark (GB10)
 ---
 
 ## Latest version changelog
+
+### Version 1.7.0 — Tailnet monitoring
+- **Tailnet** — opt-in per Spark (`tailscaleMonitoring`): flags a Spark that is healthy on the LAN but has fallen off its tailnet, which no LAN-based check can see
+- **Reason shown, not just state** — surfaces Tailscale's own `Health` messages plus backend state, tailnet IP, DERP relay, version, and expired-key warning
 
 ### Version 1.6.0 — ComfyUI monitoring & compact default
 - **ComfyUI** — opt-in per Spark (port 8188): live jobs, progress, last run, cancel, queue ETA, Open on LAN IP, model inventory
@@ -66,6 +71,7 @@ Full history: [CHANGELOG.md](./CHANGELOG.md)
 | **Local + remote** | Host metrics via sysfs/proc/`nvidia-smi`; remotes over SSH (key or password) |
 | **LLM probe** | Auto-detects llama.cpp, vLLM, sglang, or ds4-server; live tok/s per server |
 | **ComfyUI** | Opt-in probe: queue/jobs, progress, cancel, Open link, inventory, overview chip |
+| **Tailnet** | Opt-in probe: flags a Spark that is healthy on the LAN but off its tailnet |
 | **Decode benchmark** | Multi-concurrency streaming decode tok/s (server + per-stream), persisted last run |
 | **Prompt Showcase** | Full-page multi-terminal LLM streaming demo (up to 32 prompts) with live tok/s and copy-out |
 | **vLLM health** | KV cache %, run/wait queue, TTFT/E2E/ITL p95, preemptions, prefix cache, MTP accept from Prometheus `/metrics` |
@@ -137,6 +143,61 @@ The Spark page **Services** section shows the ComfyUI card. On Overview, a small
 | POST | `/api/sparks/:id/comfy/cancel` | Cancel a job (`{ "promptId": "<uuid>" }`) — interrupt running and/or remove from queue |
 
 Env (optional): `COMFY_PORT` (default `8188`), `COMFY_PROBE_TIMEOUT_MS`, `POLL_INTERVAL_COMFY`.
+
+---
+
+## Tailnet monitoring
+
+Opt-in per Spark. Runs `tailscale status --json` on the host and shows a **Tailnet** card
+beside Network.
+
+This closes a blind spot that every LAN-based check shares, including sparkDash's own SSH
+liveness. When `tailscaled` loses its session with the coordination server, short connections
+keep retrying and succeeding — SSH answers, the GPU reports, the LLM serves, and the dashboard
+says **up**, correctly. But the Spark is unreachable from anywhere *off* the LAN: your phone on
+cellular, the admin console, another tailnet node. The box looks perfectly healthy and is
+invisible. This card is the difference.
+
+### What is supported
+
+| Capability | Details |
+|------------|---------|
+| **Opt-in per Spark** | `tailscaleMonitoring` (default **off**) |
+| **Off-tailnet detection** | `Self.Online` — the node's *own* view of the coordination server |
+| **Reason, not just state** | Tailscale's `Health` messages, e.g. *"hasn't received a network map from the coordination server in 2m7s"* |
+| **Backend state** | `Running` / `Stopped` / `NeedsLogin` / `NoState` |
+| **Identity** | Tailnet IP, hostname, DERP relay region, tailscale version |
+| **Key expiry** | Flags an expired node key (which a restart will not fix — it needs re-auth) |
+
+Asked of **each node about itself**, deliberately: one node's view of a *peer* can be stale, so
+peer state is never used as the verdict.
+
+Not claimed: this does not manage Tailscale. It never runs `tailscale up`, `down`, or `login` —
+the probe is read-only.
+
+### How to enable (per Spark)
+
+1. Open **Edit Spark**.
+2. Tick **Tailnet monitoring**.
+3. Save. The Tailnet card appears under Resources, next to Network.
+
+### Host requirements
+
+- The `tailscale` CLI on the monitored host, and `tailscaled` running.
+- Remote Sparks: reached over the existing SSH connection — no extra setup.
+- Local Spark in Docker: tailscaled's socket lives on the *host*, so the probe enters the host
+  mount namespace via `nsenter` (the same approach used for `nvidia-smi`). This needs
+  `/host/proc` bind-mounted, which the shipped compose file already does.
+- A node with key expiry disabled reports no expiry — that is normal, not an error.
+
+### Config fields (persisted on the Spark)
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `tailscaleMonitoring` | `false` | Run `tailscale status --json` and show the Tailnet card |
+
+Env (optional): `POLL_INTERVAL_TAILSCALE` (default `30000` — tailnet state changes slowly and
+each poll is an SSH round-trip), `TAILSCALE_PROBE_TIMEOUT_MS` (default `8000`).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkdash",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "sparkDash — Multi-DGX Spark Monitoring Dashboard",
   "type": "module",
   "scripts": {

--- a/server/collectors/TailscaleProbe.js
+++ b/server/collectors/TailscaleProbe.js
@@ -1,0 +1,185 @@
+/**
+ * TailscaleProbe — reports whether a Spark is actually present on its tailnet.
+ *
+ * Why this exists: a Spark can be perfectly healthy — SSH answering, GPU idle,
+ * LLM serving — while `tailscaled` has lost its session with the coordination
+ * server. Short connections retry and survive, so every LAN-based check
+ * (including sparkDash's own SSH liveness) still reports "up", but the box is
+ * unreachable from anywhere off the LAN: phone on cellular, the admin console,
+ * another tailnet node. The dashboard and the tailnet disagree and the dashboard
+ * looks right.
+ *
+ * `tailscale status --json` is the authoritative answer, and it must be asked of
+ * the node itself — one node's view of a *peer* can be stale, so peer state is
+ * deliberately not used here.
+ *
+ * Command: `tailscale status --json` (read-only; no state is changed)
+ */
+import { TAILSCALE_PROBE_TIMEOUT_MS, HOST_PATHS } from "../config.js";
+import { sshExec } from "./ssh.js";
+import fs from "fs";
+import path from "path";
+
+/**
+ * @param {unknown} v
+ * @returns {string | null}
+ */
+function str(v) {
+  if (typeof v !== "string") return null;
+  const s = v.trim();
+  return s.length > 0 ? s : null;
+}
+
+/**
+ * Normalize `tailscale status --json` into the fields the UI needs.
+ *
+ * Exported for unit testing — keep it pure (no I/O, no clock).
+ *
+ * @param {object} raw - parsed output of `tailscale status --json`
+ * @returns {object} normalized fields (without `error`)
+ */
+export function parseTailscaleStatus(raw) {
+  const self = raw && typeof raw === "object" && raw.Self && typeof raw.Self === "object"
+    ? raw.Self
+    : null;
+
+  // Health is the payload that actually explains a failure, e.g.
+  // "Tailscale hasn't received a network map from the coordination server in 2m7s."
+  const health = Array.isArray(raw?.Health)
+    ? raw.Health.filter((m) => typeof m === "string" && m.trim().length > 0)
+    : [];
+
+  const ips = Array.isArray(self?.TailscaleIPs)
+    ? self.TailscaleIPs.filter((ip) => typeof ip === "string")
+    : [];
+
+  return {
+    available: self != null,
+    /**
+     * Self.Online is the node's OWN view of whether it is talking to the
+     * coordination server. This is the signal a LAN-only check cannot see.
+     * null when tailscale did not report it.
+     */
+    online: typeof self?.Online === "boolean" ? self.Online : null,
+    /** "Running" | "Stopped" | "NeedsLogin" | "NoState" — tailscaled's own state. */
+    backendState: str(raw?.BackendState),
+    hostName: str(self?.HostName),
+    dnsName: str(self?.DNSName),
+    tailscaleIp: ips[0] ?? null,
+    /** DERP relay region, or null when the node has a direct path. */
+    relay: str(self?.Relay),
+    /** ISO timestamp; null when key expiry is disabled for this node. */
+    keyExpiry: str(self?.KeyExpiry),
+    keyExpired: self?.Expired === true,
+    version: str(raw?.Version),
+    /** Human-readable reasons tailscale itself considers itself unhealthy. */
+    health,
+  };
+}
+
+export class TailscaleProbe {
+  /**
+   * @param {object} spark
+   */
+  constructor(spark) {
+    this.spark = spark;
+    this.error = null;
+  }
+
+  /** @param {object} spark */
+  setTarget(spark) {
+    this.spark = spark ?? this.spark;
+    this.error = null;
+  }
+
+  /** Symmetry with the other probes; nothing persistent to release. */
+  dispose() {}
+
+  /**
+   * Host PID 1 mount namespace, present when running as the bind-mounted
+   * container. Mirrors SystemCollector._hasHostProc.
+   */
+  _hasHostProc() {
+    return fs.existsSync(path.join(HOST_PATHS.PROC, "1", "ns", "mnt"));
+  }
+
+  /**
+   * Run the status command for an `isLocal` Spark.
+   *
+   * In the container the `tailscale` CLI and, more importantly, tailscaled's
+   * unix socket live on the *host*, so a plain `sh -c` finds neither. Enter the
+   * host mount namespace when it is available (same approach SystemCollector
+   * uses for nvidia-smi).
+   *
+   * @param {string} cmd
+   * @returns {Promise<string>}
+   */
+  async _execLocal(cmd) {
+    const { execFile } = await import("child_process");
+    const useHostNs = this._hasHostProc();
+    const file = useHostNs ? "nsenter" : "sh";
+    const args = useHostNs
+      ? ["--mount=" + path.join(HOST_PATHS.PROC, "1", "ns", "mnt"), "--", "sh", "-c", cmd]
+      : ["-c", cmd];
+    return new Promise((resolve, reject) => {
+      execFile(file, args, { timeout: TAILSCALE_PROBE_TIMEOUT_MS }, (err, stdout, stderr) => {
+        if (err) return reject(new Error(stderr?.trim() || err.message));
+        resolve(String(stdout).trim());
+      });
+    });
+  }
+
+  /**
+   * Never throws — on failure returns `_default()` with `error` set, matching
+   * the other probes.
+   *
+   * @returns {Promise<object>}
+   */
+  async probe() {
+    const cmd = "tailscale status --json";
+    let out;
+    try {
+      out = this.spark?.isLocal
+        ? await this._execLocal(cmd)
+        : await sshExec(this.spark, cmd, { timeoutMs: TAILSCALE_PROBE_TIMEOUT_MS });
+    } catch (err) {
+      // Most common causes: tailscale not installed, or tailscaled not running
+      // (the CLI exits non-zero). Both are legitimately "not on the tailnet".
+      this.error = err.message || "tailscale status failed";
+      return this._default();
+    }
+
+    let raw;
+    try {
+      raw = JSON.parse(out);
+    } catch {
+      this.error = "Unparseable `tailscale status --json` output";
+      return this._default();
+    }
+
+    const parsed = parseTailscaleStatus(raw);
+    if (!parsed.available) {
+      this.error = "No Self in `tailscale status --json`";
+      return this._default();
+    }
+    this.error = null;
+    return { ...parsed, error: null };
+  }
+
+  _default() {
+    return {
+      available: false,
+      online: null,
+      backendState: null,
+      hostName: null,
+      dnsName: null,
+      tailscaleIp: null,
+      relay: null,
+      keyExpiry: null,
+      keyExpired: false,
+      version: null,
+      health: [],
+      error: this.error,
+    };
+  }
+}

--- a/server/collectors/__tests__/TailscaleProbe.test.js
+++ b/server/collectors/__tests__/TailscaleProbe.test.js
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { TailscaleProbe, parseTailscaleStatus } from "../TailscaleProbe.js";
+
+/** Shape of a healthy `tailscale status --json`, trimmed to the fields we read. */
+const HEALTHY = {
+  BackendState: "Running",
+  Version: "1.102.2-t6cac91817",
+  Self: {
+    HostName: "spark-1",
+    DNSName: "spark-1.example.ts.net.",
+    Online: true,
+    TailscaleIPs: ["100.64.0.1", "fd7a:115c:a1e0::1"],
+    Relay: "nyc",
+    KeyExpiry: "2026-09-06T20:02:31Z",
+    Expired: false,
+  },
+  Health: [],
+};
+
+test("parseTailscaleStatus reads a healthy node", () => {
+  const p = parseTailscaleStatus(HEALTHY);
+  assert.equal(p.available, true);
+  assert.equal(p.online, true);
+  assert.equal(p.backendState, "Running");
+  assert.equal(p.hostName, "spark-1");
+  // First IP only — the v4 address is what operators recognize.
+  assert.equal(p.tailscaleIp, "100.64.0.1");
+  assert.equal(p.relay, "nyc");
+  assert.equal(p.keyExpired, false);
+  assert.deepEqual(p.health, []);
+});
+
+test("parseTailscaleStatus surfaces the wedged-netmap case (healthy box, off tailnet)", () => {
+  // The failure this probe exists for: tailscaled running, SSH fine, but no
+  // session with the coordination server — invisible from off-LAN.
+  const p = parseTailscaleStatus({
+    ...HEALTHY,
+    Self: { ...HEALTHY.Self, Online: false },
+    Health: ["Tailscale hasn't received a network map from the coordination server in 2m7s."],
+  });
+  assert.equal(p.available, true);
+  assert.equal(p.online, false);
+  assert.equal(p.backendState, "Running");
+  assert.equal(p.health.length, 1);
+  assert.match(p.health[0], /coordination server/);
+});
+
+test("parseTailscaleStatus flags an expired key", () => {
+  const p = parseTailscaleStatus({
+    ...HEALTHY,
+    Self: { ...HEALTHY.Self, Online: false, Expired: true },
+  });
+  assert.equal(p.keyExpired, true);
+  assert.equal(p.online, false);
+});
+
+test("parseTailscaleStatus tolerates missing and malformed fields", () => {
+  const p = parseTailscaleStatus({ Self: {} });
+  assert.equal(p.available, true); // Self exists, just empty
+  assert.equal(p.online, null); // absent boolean stays unknown, not false
+  assert.equal(p.tailscaleIp, null);
+  assert.equal(p.relay, null);
+  assert.equal(p.keyExpiry, null);
+  assert.equal(p.keyExpired, false);
+  assert.deepEqual(p.health, []);
+
+  const empty = parseTailscaleStatus({});
+  assert.equal(empty.available, false);
+  assert.equal(empty.online, null);
+
+  // Non-string junk in Health must not reach the UI.
+  const junk = parseTailscaleStatus({ Self: {}, Health: ["ok", "", 42, null] });
+  assert.deepEqual(junk.health, ["ok"]);
+});
+
+test("parseTailscaleStatus blanks whitespace-only strings", () => {
+  const p = parseTailscaleStatus({
+    BackendState: "   ",
+    Self: { HostName: "", Relay: "  ", Online: true },
+  });
+  assert.equal(p.backendState, null);
+  assert.equal(p.hostName, null);
+  assert.equal(p.relay, null);
+});
+
+test("TailscaleProbe returns default shape with error when the command fails", async () => {
+  // isLocal avoids SSH; `false` exits non-zero, standing in for a missing
+  // tailscale binary or a stopped tailscaled.
+  const probe = new TailscaleProbe({ isLocal: true });
+  probe._execLocal = async () => {
+    throw new Error("tailscale: command not found");
+  };
+  const snap = await probe.probe();
+  assert.equal(snap.available, false);
+  assert.equal(snap.online, null);
+  assert.equal(snap.keyExpired, false);
+  assert.deepEqual(snap.health, []);
+  assert.match(snap.error, /command not found/);
+  probe.dispose();
+});
+
+test("TailscaleProbe reports an error on unparseable output rather than throwing", async () => {
+  const probe = new TailscaleProbe({ isLocal: true });
+  probe._execLocal = async () => "not json at all";
+  const snap = await probe.probe();
+  assert.equal(snap.available, false);
+  assert.match(snap.error, /Unparseable/);
+});
+
+test("TailscaleProbe clears a stale error after recovery", async () => {
+  const probe = new TailscaleProbe({ isLocal: true });
+  probe._execLocal = async () => {
+    throw new Error("boom");
+  };
+  assert.ok((await probe.probe()).error);
+
+  probe._execLocal = async () => JSON.stringify(HEALTHY);
+  const ok = await probe.probe();
+  assert.equal(ok.error, null);
+  assert.equal(ok.online, true);
+});

--- a/server/config.js
+++ b/server/config.js
@@ -19,6 +19,8 @@ const SECRETS_KEY_PATH =
 // ─── LLM / Comfy probe timeouts ──────────────────────────
 const LLM_PROBE_TIMEOUT_MS = 3000;
 const COMFY_PROBE_TIMEOUT_MS = parseInt(process.env.COMFY_PROBE_TIMEOUT_MS || "3000", 10);
+// `tailscale status --json` runs over SSH, so it needs more headroom than an HTTP probe.
+const TAILSCALE_PROBE_TIMEOUT_MS = parseInt(process.env.TAILSCALE_PROBE_TIMEOUT_MS || "8000", 10);
 const SSH_CONNECT_TIMEOUT = 5; // seconds
 
 // ─── Poll intervals (milliseconds) ───────────────────────
@@ -28,6 +30,9 @@ const POLL_INTERVAL_NETWORK = parseInt(process.env.POLL_INTERVAL_NETWORK || "200
 const POLL_INTERVAL_STORAGE = parseInt(process.env.POLL_INTERVAL_STORAGE || "5000", 10);
 const POLL_INTERVAL_LLM = parseInt(process.env.POLL_INTERVAL_LLM || "2000", 10);
 const POLL_INTERVAL_COMFY = parseInt(process.env.POLL_INTERVAL_COMFY || "2000", 10);
+// Tailnet membership changes on the order of minutes, and each poll is an SSH
+// round-trip — a slow cadence keeps this cheap.
+const POLL_INTERVAL_TAILSCALE = parseInt(process.env.POLL_INTERVAL_TAILSCALE || "30000", 10);
 // dmon -c 1 -d 1 blocks ~1s; default 2s avoids stacking with in-flight guards
 const POLL_INTERVAL_BANDWIDTH = parseInt(process.env.POLL_INTERVAL_BANDWIDTH || "2000", 10);
 // Dedicated liveness (sshTest / local ping) cadence — not a metric domain.
@@ -82,6 +87,7 @@ export {
   SECRETS_KEY_PATH,
   LLM_PROBE_TIMEOUT_MS,
   COMFY_PROBE_TIMEOUT_MS,
+  TAILSCALE_PROBE_TIMEOUT_MS,
   SSH_CONNECT_TIMEOUT,
   POLL_INTERVAL_GPU,
   POLL_INTERVAL_CPU,
@@ -89,6 +95,7 @@ export {
   POLL_INTERVAL_STORAGE,
   POLL_INTERVAL_LLM,
   POLL_INTERVAL_COMFY,
+  POLL_INTERVAL_TAILSCALE,
   POLL_INTERVAL_BANDWIDTH,
   POLL_INTERVAL_LIVENESS,
   PORT,

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -3,6 +3,7 @@ import path from "path";
 import { SystemCollector } from "../collectors/SystemCollector.js";
 import { LlmProbe } from "../collectors/LlmProbe.js";
 import { ComfyProbe } from "../collectors/ComfyProbe.js";
+import { TailscaleProbe } from "../collectors/TailscaleProbe.js";
 import { sshTest, sshExec } from "../collectors/ssh.js";
 import {
   POLL_INTERVAL_GPU,
@@ -11,6 +12,7 @@ import {
   POLL_INTERVAL_STORAGE,
   POLL_INTERVAL_LLM,
   POLL_INTERVAL_COMFY,
+  POLL_INTERVAL_TAILSCALE,
   POLL_INTERVAL_BANDWIDTH,
   POLL_INTERVAL_LIVENESS,
   LLM_PORT,
@@ -47,6 +49,11 @@ export class SparkMonitor {
       ? new ComfyProbe(spark, this._comfyPort(spark))
       : null;
 
+    /** @type {TailscaleProbe | null} */
+    this.tailscaleProbe = this._tailscaleMonitoringEnabled(spark)
+      ? new TailscaleProbe(spark)
+      : null;
+
     // Online status from dedicated liveness checks (not metric poll success)
     this.online = false;
     this.lastOnlineOk = 0;
@@ -64,6 +71,7 @@ export class SparkMonitor {
       unifiedMemory: this.collector._defaultUnifiedMemory(),
       llm: [],
       comfy: null,
+      tailscale: null,
     };
     this._lastUpdate = {};
 
@@ -73,6 +81,8 @@ export class SparkMonitor {
     this._llmIntervalId = null;
     /** @type {ReturnType<typeof setInterval> | null} */
     this._comfyIntervalId = null;
+    /** @type {ReturnType<typeof setInterval> | null} */
+    this._tailscaleIntervalId = null;
     this._running = false;
     /** @type {Record<string, boolean>} in-flight domain guards */
     this._inflight = {};
@@ -82,6 +92,7 @@ export class SparkMonitor {
   updateConfig(spark) {
     const wasLlm = this._llmMonitoringEnabled(this.spark);
     const wasComfy = this._comfyMonitoringEnabled(this.spark);
+    const wasTailscale = this._tailscaleMonitoringEnabled(this.spark);
     const prevComfyPort = this._comfyPort(this.spark);
     this.spark = spark;
     this.collector.spark = spark;
@@ -123,6 +134,18 @@ export class SparkMonitor {
       this._metrics.comfy = null;
     }
 
+    // Tailscale probe — create / update / clear
+    if (this._tailscaleMonitoringEnabled()) {
+      if (this.tailscaleProbe) {
+        this.tailscaleProbe.setTarget(spark);
+      } else {
+        this.tailscaleProbe = new TailscaleProbe(spark);
+      }
+    } else {
+      this.tailscaleProbe = null;
+      this._metrics.tailscale = null;
+    }
+
     // Toggle LLM poll interval when monitoring enablement flips
     if (this._running && wasLlm !== this._llmMonitoringEnabled()) {
       this._restartLlmPollInterval();
@@ -131,6 +154,9 @@ export class SparkMonitor {
     const comfyPortChanged = comfyOn && prevComfyPort !== this._comfyPort();
     if (this._running && (wasComfy !== comfyOn || comfyPortChanged)) {
       this._restartComfyPollInterval();
+    }
+    if (this._running && wasTailscale !== this._tailscaleMonitoringEnabled()) {
+      this._restartTailscalePollInterval();
     }
   }
 
@@ -188,6 +214,31 @@ export class SparkMonitor {
     }
   }
 
+  /**
+   * Opt-in tailnet monitoring (all roles; default off).
+   * @param {object} [spark]
+   */
+  _tailscaleMonitoringEnabled(spark = this.spark) {
+    return Boolean(spark?.tailscaleMonitoring);
+  }
+
+  /** Start or clear the tailnet poll timer based on monitoring flag. */
+  _restartTailscalePollInterval() {
+    if (this._tailscaleIntervalId != null) {
+      clearInterval(this._tailscaleIntervalId);
+      this._intervals = this._intervals.filter((id) => id !== this._tailscaleIntervalId);
+      this._tailscaleIntervalId = null;
+    }
+    if (this._tailscaleMonitoringEnabled() && this._running) {
+      this._tailscaleIntervalId = setInterval(
+        () => this._pollDomain("tailscale"),
+        POLL_INTERVAL_TAILSCALE
+      );
+      this._intervals.push(this._tailscaleIntervalId);
+      void this._pollDomain("tailscale");
+    }
+  }
+
   /** Returns array of LLM ports from spark config. */
   _llmPorts() {
     const raw = this.spark?.llmPorts;
@@ -216,6 +267,7 @@ export class SparkMonitor {
     this._intervals.push(setInterval(() => this._pollDomain("memory"), POLL_INTERVAL_BANDWIDTH));
     this._restartLlmPollInterval();
     this._restartComfyPollInterval();
+    this._restartTailscalePollInterval();
     // Liveness on a slightly slower cadence
     this._intervals.push(setInterval(() => this._checkOnline(), POLL_INTERVAL_LIVENESS));
     console.log(`[SparkMonitor] ${this.spark.id} started`);
@@ -228,6 +280,7 @@ export class SparkMonitor {
     this._intervals = [];
     this._llmIntervalId = null;
     this._comfyIntervalId = null;
+    this._tailscaleIntervalId = null;
     this._inflight = {};
     if (this.comfyProbe) {
       try {
@@ -243,6 +296,7 @@ export class SparkMonitor {
   snapshot() {
     const ports = this._llmMonitoringEnabled() ? this._llmPorts() : [];
     const comfyOn = this._comfyMonitoringEnabled();
+    const tailscaleOn = this._tailscaleMonitoringEnabled();
     return {
       id: this.spark.id,
       name: this.spark.name,
@@ -267,6 +321,7 @@ export class SparkMonitor {
             .filter((n) => Number.isInteger(n)),
       comfyMonitoring: comfyOn,
       comfyPort: this._comfyPort(),
+      tailscaleMonitoring: tailscaleOn,
       hardware: this._getHardwareSummary(),
       metrics: {
         // NOTE: no `timestamp` here on purpose. The broadcast path skips
@@ -284,6 +339,7 @@ export class SparkMonitor {
         unifiedMemory: this._metrics.unifiedMemory,
         llm: this._metrics.llm,
         comfy: comfyOn ? this._metrics.comfy : null,
+        tailscale: tailscaleOn ? this._metrics.tailscale : null,
       },
     };
   }
@@ -352,6 +408,7 @@ export class SparkMonitor {
       this._pollDomain("memory"),
       this._pollDomain("llm"),
       this._pollDomain("comfy"),
+      this._pollDomain("tailscale"),
     ]);
   }
 
@@ -362,6 +419,7 @@ export class SparkMonitor {
     // Worker nodes: no local LLM API
     if (domain === "llm" && !this._llmMonitoringEnabled()) return;
     if (domain === "comfy" && !this._comfyMonitoringEnabled()) return;
+    if (domain === "tailscale" && !this._tailscaleMonitoringEnabled()) return;
     this._inflight[domain] = true;
     try {
       let result;
@@ -392,6 +450,9 @@ export class SparkMonitor {
           break;
         case "comfy":
           result = this.comfyProbe ? await this.comfyProbe.probe() : null;
+          break;
+        case "tailscale":
+          result = this.tailscaleProbe ? await this.tailscaleProbe.probe() : null;
           break;
       }
       // Re-check after the await — `stop()`/`updateSpark()` may have torn
@@ -431,6 +492,9 @@ export class SparkMonitor {
           break;
         case "comfy":
           this._metrics.comfy = result;
+          break;
+        case "tailscale":
+          this._metrics.tailscale = result;
           break;
       }
       this._lastUpdate[domain] = Date.now();

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -511,6 +511,12 @@ export class SparkRegistry {
       comfyMonitoring: Boolean(config.comfyMonitoring),
       /** ComfyUI HTTP port (default 8188). */
       comfyPort: this._normalizeComfyPort(config.comfyPort),
+      /**
+       * Report tailnet presence via `tailscale status --json` (default false;
+       * all roles). Catches a Spark that is healthy on the LAN but has fallen
+       * off its tailnet, which no LAN-based check can see.
+       */
+      tailscaleMonitoring: Boolean(config.tailscaleMonitoring),
       disabledDevices: Array.isArray(config.disabledDevices) ? config.disabledDevices : [],
       disabledInterfaces: Array.isArray(config.disabledInterfaces) ? config.disabledInterfaces : [],
       storagePollDisabled: Boolean(config.storagePollDisabled),

--- a/server/sparks/__tests__/role-normalize.test.js
+++ b/server/sparks/__tests__/role-normalize.test.js
@@ -27,6 +27,17 @@ test("comfyMonitoring is opt-in for all roles; comfyPort defaults to 8188", () =
   assert.equal(n({ comfyPort: "8190" }).comfyPort, 8190);
 });
 
+test("tailscaleMonitoring is opt-in for all roles", () => {
+  assert.equal(n({ role: "head" }).tailscaleMonitoring, false);
+  assert.equal(n({ role: "worker" }).tailscaleMonitoring, false);
+  assert.equal(n({ role: "standalone" }).tailscaleMonitoring, false);
+  assert.equal(n({ role: "standalone", tailscaleMonitoring: true }).tailscaleMonitoring, true);
+  assert.equal(n({ role: "worker", tailscaleMonitoring: true }).tailscaleMonitoring, true);
+  // Non-boolean input is coerced, never persisted raw.
+  assert.equal(n({ tailscaleMonitoring: "yes" }).tailscaleMonitoring, true);
+  assert.equal(n({ tailscaleMonitoring: 0 }).tailscaleMonitoring, false);
+});
+
 test("legacy workerNode-only becomes worker", () => {
   const out = n({ workerNode: true, workerLabel: "  DS  ", workerHeadId: "s5" });
   assert.equal(out.role, "worker");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ function placeholderSnapshot(
     workerHeadId?: string | null;
     llmMonitoring?: boolean;
     comfyMonitoring?: boolean;
+    tailscaleMonitoring?: boolean;
     comfyPort?: number;
   }
 ): SparkSnapshot {
@@ -59,6 +60,7 @@ function placeholderSnapshot(
           ? true
           : roleFields?.llmMonitoring !== false,
     comfyMonitoring: Boolean(roleFields?.comfyMonitoring),
+    tailscaleMonitoring: Boolean(roleFields?.tailscaleMonitoring),
     comfyPort: roleFields?.comfyPort ?? 8188,
     hardware: {
       device: "NVIDIA DGX Spark",
@@ -164,6 +166,7 @@ function DashboardApp() {
               workerHeadId: c.workerHeadId ?? existing.workerHeadId,
               llmMonitoring: c.llmMonitoring ?? existing.llmMonitoring,
               comfyMonitoring: c.comfyMonitoring ?? existing.comfyMonitoring,
+              tailscaleMonitoring: c.tailscaleMonitoring ?? existing.tailscaleMonitoring,
               comfyPort: c.comfyPort ?? existing.comfyPort,
               disabledDevices: c.disabledDevices || existing.disabledDevices,
               disabledInterfaces: c.disabledInterfaces || existing.disabledInterfaces,
@@ -184,6 +187,7 @@ function DashboardApp() {
               workerHeadId: c.workerHeadId,
               llmMonitoring: c.llmMonitoring,
               comfyMonitoring: c.comfyMonitoring,
+              tailscaleMonitoring: c.tailscaleMonitoring,
               comfyPort: c.comfyPort,
             }
           );

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -65,6 +65,10 @@ export interface SparkConfig {
   comfyMonitoring?: boolean;
   /** ComfyUI HTTP port (default 8188). */
   comfyPort?: number;
+  /**
+   * Report tailnet presence via `tailscale status --json` (default false; all roles).
+   */
+  tailscaleMonitoring?: boolean;
   /** When true, storage is only updated on manual refresh, not auto-polled. */
   storagePollDisabled?: boolean;
 }
@@ -310,6 +314,31 @@ export interface ComfyMetrics {
   error: string | null;
 }
 
+export interface TailscaleMetrics {
+  /** True when `tailscale status --json` was read and had a Self entry. */
+  available: boolean;
+  /**
+   * The node's OWN view of whether it is talking to the coordination server.
+   * A Spark can be healthy on the LAN with this false — that is the whole point
+   * of this probe. null when tailscale did not report it.
+   */
+  online: boolean | null;
+  /** tailscaled's own state: Running | Stopped | NeedsLogin | NoState. */
+  backendState: string | null;
+  hostName: string | null;
+  dnsName: string | null;
+  tailscaleIp: string | null;
+  /** DERP relay region, or null when the node has a direct path. */
+  relay: string | null;
+  /** ISO timestamp; null when key expiry is disabled for this node. */
+  keyExpiry: string | null;
+  keyExpired: boolean;
+  version: string | null;
+  /** Tailscale's own health warnings — these explain a false `online`. */
+  health: string[];
+  error: string | null;
+}
+
 // ─── Full metrics snapshot ────────────────────────────────
 export interface SparkMetrics {
   gpu: GpuMetrics | null;
@@ -322,6 +351,8 @@ export interface SparkMetrics {
   llm: LlmMetrics[];
   /** ComfyUI probe result when monitoring is enabled; null when off or not yet polled. */
   comfy?: ComfyMetrics | null;
+  /** Tailnet probe result when monitoring is enabled; null when off or not yet polled. */
+  tailscale?: TailscaleMetrics | null;
 }
 
 // ─── Spark snapshot (server pushes this) ──────────────────
@@ -357,6 +388,8 @@ export interface SparkSnapshot {
   comfyMonitoring?: boolean;
   /** ComfyUI HTTP port (default 8188) */
   comfyPort?: number;
+  /** Whether tailnet presence is probed (opt-in; all roles) */
+  tailscaleMonitoring?: boolean;
   hardware: HardwareInfo;
   metrics: SparkMetrics;
 }

--- a/src/components/EditSparkDialog.tsx
+++ b/src/components/EditSparkDialog.tsx
@@ -180,6 +180,7 @@ export function EditSparkDialog({
         config.ssh?.user !== savedConfig.ssh?.user ||
         config.ssh?.auth !== savedConfig.ssh?.auth ||
         Boolean(config.comfyMonitoring) !== Boolean(savedConfig.comfyMonitoring) ||
+        Boolean(config.tailscaleMonitoring) !== Boolean(savedConfig.tailscaleMonitoring) ||
         (config.comfyPort ?? 8188) !== (savedConfig.comfyPort ?? 8188);
 
       const result = formDirty
@@ -249,6 +250,7 @@ export function EditSparkDialog({
           const n = Number(config.comfyPort);
           return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : 8188;
         })(),
+        tailscaleMonitoring: Boolean(config.tailscaleMonitoring),
         ssh: {
           host: config.ssh.host || config.lanIp,
           user: config.ssh.user,
@@ -461,6 +463,25 @@ export function EditSparkDialog({
                     className="w-14 border-0 bg-transparent px-0.5 py-0.5 text-center font-tabular text-xs text-inherit outline-none focus:rounded focus:bg-surface-elevated focus:ring-1 focus:ring-accent disabled:cursor-not-allowed"
                   />
                 </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted">
+                <label className="flex min-w-0 items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(config.tailscaleMonitoring)}
+                    onChange={(e) => update({ tailscaleMonitoring: e.target.checked })}
+                    className="rounded border-border"
+                  />
+                  <span>Tailnet monitoring</span>
+                  <span
+                    className="inline-flex shrink-0 cursor-help text-muted hover:text-text"
+                    title="When enabled, run `tailscale status --json` on this host and show a Tailnet card. Catches a Spark that is healthy on the LAN but has fallen off its tailnet — which no LAN-based check can see. Requires the tailscale CLI on the host."
+                    aria-label="Enable reporting this Spark's tailnet presence."
+                  >
+                    <InfoIcon className="h-3.5 w-3.5" />
+                  </span>
+                </label>
               </div>
 
               {role === "worker" && (

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -7,6 +7,7 @@ import { GpuPanel } from "./GpuPanel";
 import { CpuPanel } from "./CpuPanel";
 import { StoragePanel } from "./StoragePanel";
 import { NetworkPanel } from "./NetworkPanel";
+import { TailscalePanel } from "./TailscalePanel";
 import { LlmPanel } from "./LlmPanel";
 import { ComfyPanel } from "./ComfyPanel";
 import { ChevronDownIcon } from "../ui/icons";
@@ -174,6 +175,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
 
   const llmOn = isLlmMonitoringEnabled(spark);
   const comfyOn = Boolean(spark.comfyMonitoring);
+  const tailscaleOn = Boolean(spark.tailscaleMonitoring);
   /** First LLM + Comfy share a row when both are on. */
   const primarySideBySide = llmOn && comfyOn;
   const showServices = llmOn || comfyOn;
@@ -241,6 +243,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
               disabledInterfaces={disabledInterfaces}
               onDisabledChange={setDisabledInterfaces}
             />
+            {tailscaleOn && <TailscalePanel tailscale={metrics.tailscale ?? null} />}
           </>
         )}
         {/*

--- a/src/components/SparkPage/TailscalePanel.tsx
+++ b/src/components/SparkPage/TailscalePanel.tsx
@@ -1,0 +1,102 @@
+import type { TailscaleMetrics } from "../../api/types";
+import { Panel } from "../ui/Panel";
+import { NetworkIcon } from "../ui/icons";
+
+interface TailscalePanelProps {
+  tailscale: TailscaleMetrics | null;
+}
+
+/**
+ * Tailnet presence for one Spark.
+ *
+ * The state worth shouting about is "reachable on the LAN but NOT on the
+ * tailnet" — every other panel here is fed over the LAN, so they all look
+ * healthy while the box is invisible from anywhere else.
+ */
+export function TailscalePanel({ tailscale }: TailscalePanelProps) {
+  const online = tailscale?.online ?? null;
+  const health = tailscale?.health ?? [];
+  const available = Boolean(tailscale?.available);
+
+  // Unknown (null) is deliberately not treated as a failure — the first poll
+  // may not have landed, and tailscale may omit the field.
+  const offTailnet = available && online === false;
+
+  const status = !available
+    ? { label: "unknown", cls: "text-muted" }
+    : online === true
+      ? { label: "online", cls: "text-accent" }
+      : online === false
+        ? { label: "OFF TAILNET", cls: "text-danger" }
+        : { label: "unknown", cls: "text-muted" };
+
+  return (
+    <Panel title="Tailnet" accent={offTailnet} icon={<NetworkIcon />}>
+      <div className="mb-3 flex items-center gap-2 text-xs">
+        <span className="text-muted">Status</span>
+        <span className={`font-tabular font-medium ${status.cls}`}>{status.label}</span>
+        {tailscale?.backendState && (
+          <span className="ml-auto chip py-0.5">{tailscale.backendState}</span>
+        )}
+      </div>
+
+      {/* Tailscale's own explanation of a bad state — the actionable part. */}
+      {health.length > 0 && (
+        <div className="mb-2 space-y-1">
+          {health.map((msg) => (
+            <p
+              key={msg}
+              className="rounded-md border border-danger/40 bg-danger-soft px-3 py-2 text-[11px] text-text"
+            >
+              {msg}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {tailscale?.error && (
+        <p className="mb-2 rounded-md border border-border bg-surface-elevated px-3 py-2 text-[11px] text-muted">
+          {tailscale.error}
+        </p>
+      )}
+
+      <div className="space-y-2">
+        {tailscale?.tailscaleIp && (
+          <Row label="IP" value={tailscale.tailscaleIp} tabular />
+        )}
+        {tailscale?.hostName && <Row label="Host" value={tailscale.hostName} />}
+        {tailscale?.relay && <Row label="Relay" value={tailscale.relay} />}
+        {tailscale?.keyExpired && <Row label="Key" value="EXPIRED — needs re-auth" danger />}
+        {tailscale?.version && <Row label="Version" value={tailscale.version} tabular />}
+        {!available && !tailscale?.error && (
+          <p className="text-xs text-muted">Waiting for first poll…</p>
+        )}
+      </div>
+    </Panel>
+  );
+}
+
+function Row({
+  label,
+  value,
+  tabular,
+  danger,
+}: {
+  label: string;
+  value: string;
+  tabular?: boolean;
+  danger?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between rounded-md border border-border bg-surface-elevated px-3 py-2">
+      <span className="text-xs text-muted">{label}</span>
+      <span
+        className={`truncate text-xs ${tabular ? "font-tabular" : ""} ${
+          danger ? "text-danger" : "text-text"
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## The problem

A Spark can be entirely healthy — SSH answering, GPU reporting, LLM serving — while `tailscaled` has lost its session with the coordination server. Short connections retry and survive, so every LAN-based check keeps reporting **up** and is *correct*. But the box is unreachable from anywhere off the LAN: phone on cellular, the admin console, another tailnet node.

This bit me this morning on a 7-Spark fleet. sparkDash said all 7 up. Three of them (`aria`, `nova`, `lynx`) had been invisible on the tailnet for ~15 hours, logging this every ~2 minutes since 43 minutes after boot:

```
control: map response long-poll timed out!
Received error: PollNetMap: Post ".../machine/map": context canceled
```

540 occurrences on one node. Node keys were fine, DNS fine, MTU fine, routes fine, clocks fine. Just no control-plane session. `systemctl restart tailscaled` fixed all three. The dashboard never had a reason to say anything, because nothing it measures was wrong.

## What this adds

Opt-in `tailscaleMonitoring` per Spark (**default off**), a `TailscaleProbe` reading `tailscale status --json`, and a **Tailnet** card next to Network.

The card, rendered on a live Spark (dark theme, native styling):

```
TAILNET                          [Running]
Status  online
IP       100.x.x.x
Host     lynx
Relay    nyc
Version  1.98.10-t0ee734d30
```

When the node reports itself off the tailnet the card goes red with **OFF TAILNET** and prints Tailscale's own `Health` strings — so it explains the failure rather than just flagging it:

> Tailscale hasn't received a network map from the coordination server in 2m7s.

Also surfaced: `BackendState` (`Running`/`Stopped`/`NeedsLogin`), tailnet IP, DERP relay, version, and an expired-node-key warning (worth distinguishing, because a restart will *not* fix that one — it needs re-auth).

## Design notes

- **Asks each node about itself.** Reads `Self.Online`, never a peer's view. During the incident my Mac's `tailscale status` claimed `nova` was online while nova's own `tailscaled` said `Online: false` — one node's view of a peer can be stale, so peer state is never the verdict.
- **Default off**, so nothing changes for users who don't run Tailscale.
- **30s poll** (`POLL_INTERVAL_TAILSCALE`). Each poll is an SSH round-trip and tailnet state moves slowly; 2s like the Comfy probe would be wasteful.
- **Read-only.** Never runs `tailscale up`/`down`/`login`.
- **Local Sparks under Docker:** tailscaled's socket lives on the *host*, so a plain `sh -c` in the container finds neither the CLI nor the socket. The probe enters the host mount namespace via `nsenter`, mirroring `SystemCollector._execOnHost` for `nvidia-smi`, and falls back to plain exec when `/host/proc` isn't mounted.
- **No timestamps in the snapshot payload**, preserving the byte-identical broadcast dedupe noted in `SparkMonitor.snapshot()`.
- **Parsing is a pure exported function** (`parseTailscaleStatus`) so it unit-tests without I/O, matching how `summarizeComfyPrompt` / `estimateQueueEtaMs` are tested. There's no existing DI seam for `sshExec`, so the two probe-level tests stub the instance's exec method; happy to switch to a constructor-injected `exec` if you'd prefer a consistent pattern.

Followed the `comfyMonitoring` precedent throughout: `Boolean()` coercion in `_normalizeConfig`, flag-gated probe + interval in `SparkMonitor`, mirrored flag in `snapshot()`, Edit Spark checkbox, `validate.js` untouched (nothing host/user-shaped).

## Testing

- **97/97 tests pass**, 9 new: parser on healthy / wedged-netmap / expired-key / missing-and-malformed / whitespace-only input, plus probe default-shape on command failure, unparseable output, and stale-error clearing on recovery.
- `tsc --noEmit` clean; `vite build` clean.
- **Live on a 7-Spark fleet** for the four boxes I enabled: correct IP / relay / version / key-expiry on each.
  - Includes the **local Spark inside the Docker container** — the `nsenter` path works.
  - Stopped `tailscaled` on one node and watched the card degrade to an error and then clear on recovery.

One honest gap: I did not capture the red **OFF TAILNET** state live. Reproducing it needs a wedged control session (not a stopped daemon), and I wasn't willing to wedge a production node to stage a screenshot. That state is covered by unit tests against captured real-world output.

## Version

Bumped to 1.7.0 with README + CHANGELOG entries, since a new opt-in monitoring feature matched the 1.6.0 precedent. Happy to drop the bump if you'd rather own versioning — just say and I'll amend.
