### PR TITLE
fix(llm): reject unconfigured decode-bench ports

### DIFF
--- a/server/collectors/__tests__/LlmStreaming.auth.test.js
+++ b/server/collectors/__tests__/LlmStreaming.auth.test.js
@@ -1,0 +1,101 @@
+/**
+ * Streaming and /metrics helpers must send the same Bearer key LlmProbe uses.
+ * Authenticated LiteLLM/OpenAI-compatible gateways return HTTP 401 without it.
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  readServerGenerationTokens,
+  runStreamingRequest,
+} from "../LlmStreaming.js";
+
+function sseOkResponse() {
+  return new Response("data: [DONE]\n\n", {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+test("runStreamingRequest sends Authorization Bearer when apiKey is set", async () => {
+  const seen = [];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (_url, opts) => {
+    seen.push(opts?.headers || {});
+    return sseOkResponse();
+  };
+  try {
+    await runStreamingRequest(
+      "http://example.invalid/v1/chat/completions",
+      { model: "qwen3.6:35b-a3b", messages: [{ role: "user", content: "hi" }] },
+      AbortSignal.timeout(2000),
+      { apiKey: "test-kalliope-key" }
+    );
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].Authorization, "Bearer test-kalliope-key");
+    assert.equal(seen[0]["Content-Type"], "application/json");
+  } finally {
+    globalThis.fetch = orig;
+  }
+});
+
+test("runStreamingRequest omits Authorization when apiKey is absent", async () => {
+  const seen = [];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (_url, opts) => {
+    seen.push(opts?.headers || {});
+    return sseOkResponse();
+  };
+  try {
+    await runStreamingRequest(
+      "http://example.invalid/v1/chat/completions",
+      { model: "dspark", messages: [{ role: "user", content: "hi" }] },
+      AbortSignal.timeout(2000),
+      {}
+    );
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].Authorization, undefined);
+  } finally {
+    globalThis.fetch = orig;
+  }
+});
+
+test("readServerGenerationTokens sends Authorization Bearer when apiKey is set", async () => {
+  const seen = [];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (_url, opts) => {
+    seen.push(opts?.headers || {});
+    return new Response("vllm:generation_tokens_total 12\n", {
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+    });
+  };
+  try {
+    const tokens = await readServerGenerationTokens("http://example.invalid", {
+      apiKey: "test-kalliope-key",
+    });
+    assert.equal(tokens, 12);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].Authorization, "Bearer test-kalliope-key");
+  } finally {
+    globalThis.fetch = orig;
+  }
+});
+
+test("readServerGenerationTokens omits Authorization when apiKey is absent", async () => {
+  const seen = [];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (_url, opts) => {
+    seen.push(opts?.headers || {});
+    return new Response("vllm:generation_tokens_total 3\n", {
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+    });
+  };
+  try {
+    await readServerGenerationTokens("http://example.invalid");
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].Authorization, undefined);
+  } finally {
+    globalThis.fetch = orig;
+  }
+});

--- a/server/collectors/__tests__/llmAuth.wiring.test.js
+++ b/server/collectors/__tests__/llmAuth.wiring.test.js
@@ -1,0 +1,101 @@
+/**
+ * DecodeBench / Showcase must forward start({ apiKey }) into fetch.
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import os from "node:os";
+import path from "node:path";
+import { DecodeBenchManager } from "../DecodeBench.js";
+import { ShowcaseManager } from "../ShowcaseManager.js";
+
+function sseOkResponse() {
+  return new Response("data: [DONE]\n\n", {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+async function waitFor(pred, timeoutMs = 2000) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeoutMs) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error("timed out waiting for fetch");
+}
+
+test("DecodeBenchManager.start sends Bearer on chat completions", async () => {
+  const seen = [];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    seen.push({ url: String(url), headers: opts?.headers || {} });
+    return sseOkResponse();
+  };
+  const tmp = os.tmpdir();
+  const stamp = Date.now();
+  const mgr = new DecodeBenchManager(
+    path.join(tmp, `sparkdash-bench-auth-${stamp}.json`),
+    path.join(tmp, `sparkdash-bench-active-${stamp}.json`)
+  );
+  try {
+    const job = mgr.start({
+      sparkId: "wiring-bench",
+      lanIp: "127.0.0.1",
+      port: 4000,
+      modelId: "qwen3.6:35b-a3b",
+      concurrencies: [1],
+      maxTokens: 64,
+      apiKey: "test-kalliope-key",
+    });
+    assert.equal(job.apiKey, undefined);
+    await waitFor(() =>
+      seen.some((s) => String(s.url).includes("/v1/chat/completions"))
+    );
+    const chat = seen.find((s) => String(s.url).includes("/v1/chat/completions"));
+    assert.equal(chat.headers.Authorization, "Bearer test-kalliope-key");
+    mgr.cancel("wiring-bench", job.benchId);
+  } finally {
+    globalThis.fetch = orig;
+  }
+});
+
+test("ShowcaseManager.start sends Bearer on completions and /metrics", async () => {
+  const seen = [];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    seen.push({ url: String(url), headers: opts?.headers || {} });
+    if (String(url).endsWith("/metrics")) {
+      return new Response("vllm:generation_tokens_total 1\n", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+    return sseOkResponse();
+  };
+  const mgr = new ShowcaseManager(
+    path.join(os.tmpdir(), `sparkdash-showcase-auth-${Date.now()}.json`)
+  );
+  try {
+    const started = mgr.start({
+      sparkId: "wiring-showcase",
+      lanIp: "127.0.0.1",
+      port: 4000,
+      modelId: "qwen3.6:35b-a3b",
+      prompts: ["hi"],
+      maxTokens: 64,
+      apiKey: "test-kalliope-key",
+    });
+    await waitFor(() =>
+      seen.some((s) => String(s.url).includes("/v1/chat/completions"))
+    );
+    const chat = seen.find((s) => String(s.url).includes("/v1/chat/completions"));
+    assert.equal(chat.headers.Authorization, "Bearer test-kalliope-key");
+    const metrics = seen.find((s) => String(s.url).endsWith("/metrics"));
+    if (metrics) {
+      assert.equal(metrics.headers.Authorization, "Bearer test-kalliope-key");
+    }
+    mgr.cancel("wiring-showcase", started.sessionId);
+  } finally {
+    globalThis.fetch = orig;
+  }
+});

--- a/server/index.js
+++ b/server/index.js
@@ -778,6 +778,9 @@ app.post("/api/sparks/:id/llm/bench", (req, res) => {
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     return res.status(400).json({ error: "Invalid port" });
   }
+  if (!ports.includes(port)) {
+    return res.status(400).json({ error: "port is not configured for this Spark" });
+  }
 
   // Resolve model id for this port from live snapshot when possible
   let modelId = req.body?.modelId || null;


### PR DESCRIPTION
Related: MiaAI-Lab/sparkDash#25

## TL;DR

Showcase already rejects LLM ports that are not in the Spark's configured list. Decode bench did not, so `POST /llm/bench` could start a stream against any port on the host and attach a per-port API key when one exists. This uses the same allowlist as showcase and adds tests that the Bearer header actually goes out.

## What Problem This Solves

A dashboard caller can pick any integer port for a decode bench. Showcase returns 400 if that port is not configured. Bench only checked 1-65535, then forwarded `resolveLlmApiKey(spark, port)` to the stream. The missing Bearer header on keyed proxies is already fixed on main in #25. The leftover hole is the port allowlist.

## Why This Change Was Made

Same check and same error string as showcase. No new key lookup path.

## User Impact

Unconfigured bench ports now return 400. Configured ports behave as before.

## Risk and Rollout

Low. Three-line guard. No migration.

## Evidence

- `node --test server/collectors/__tests__/LlmStreaming.auth.test.js server/collectors/__tests__/llmAuth.wiring.test.js` → 6 passed
- Full `npm test` on this checkout: 108 passed, 1 failed (`ComfyProbe.test.js` missing `ws`; pre-existing, this tree was not `npm install`ed for Comfy)
- No HTTP-level test for the Express 400. Showcase is the existing pattern.