### PR TITLE
docs: document occupancy helpers for OpenCode and oh-my-pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 sparks.json
 config/sparks-secrets.json
 config/.secrets-key
+config/session-sources.json
 config/bench-history.json
 config/bench-active.json
 config/showcase-history.json

--- a/OCCUPANCY.md
+++ b/OCCUPANCY.md
@@ -1,0 +1,107 @@
+# Session occupancy
+
+sparkDash shows active coding-agent sessions on each Spark's LLM card. Sessions are matched to Sparks by the LLM host:port they hit — so a session using a model on `mama:4000` shows on mama's port-4000 card.
+
+## Supported sources
+
+| Source | Local mode | URL mode | State-dir mode |
+|--------|-----------|----------|----------------|
+| **OpenClaw** | `~/.openclaw` (or gateway on same host) | Gateway URL + token | Custom state dir |
+| **Hermes Agent** | `~/.hermes` | Dashboard URL + token | Custom state dir |
+| **OpenCode** | `~/.local/share/opencode` (reads `opencode.db`) | Helper URL + token | Custom state dir |
+| **oh-my-pi (omp)** | `~/.omp` (reads JSONL + `models.yml`) | Helper URL + token | Custom state dir |
+
+## Configure attaches
+
+Dashboard-wide — set once on any LLM card:
+
+1. **Any LLM card → Settings (gear) → Occupancy sources**
+2. Toggle a source on, pick a mode, fill in URL/state-dir/token as needed
+3. **Check** to test connectivity
+4. **Save occupancy** (separate from the LLM port Save)
+
+Sessions land on the Spark whose `llmPorts` match the session's origin host:port.
+
+## Session age filter
+
+**Settings → Occupancy session age limit** (default: 12 hours). Sessions older than this are hidden from the dashboard. Set to `0` to show all sessions regardless of age.
+
+## Local mode (same host as sparkDash)
+
+When sparkDash runs on the same machine as the agent, use **Local** mode. No helper needed — the collector reads the state directory directly.
+
+For Docker deployments with `HOST_ROOT_PATH=/host/root`, local mode reads through the host root mount.
+
+## URL mode (remote machine)
+
+When the agent runs on a different machine, run a helper on that machine and attach via URL.
+
+### OpenCode helper
+
+On the OpenCode machine (Node 22+, sparkDash checkout):
+
+```bash
+BIND="$(tailscale ip -4 2>/dev/null || ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')"
+TOKEN="$(openssl rand -hex 32)"
+printf 'URL:   http://%s:8788/occupancy\nToken: %s\n' "$BIND" "$TOKEN"
+OPENCODE_OCCUPANCY_BIND="$BIND" OPENCODE_OCCUPANCY_TOKEN="$TOKEN" \
+  node scripts/opencode-occupancy-helper/index.js
+```
+
+Full env and macOS path notes: [`scripts/opencode-occupancy-helper/README.md`](./scripts/opencode-occupancy-helper/README.md)
+
+### oh-my-pi (omp) helper
+
+On the omp machine (Node 22+, sparkDash checkout):
+
+```bash
+BIND="$(tailscale ip -4 2>/dev/null || ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')"
+TOKEN="$(openssl rand -hex 32)"
+printf 'URL:   http://%s:8789/occupancy\nToken: %s\n' "$BIND" "$TOKEN"
+OMP_OCCUPANCY_BIND="$BIND" OMP_OCCUPANCY_TOKEN="$TOKEN" \
+  node scripts/omp-occupancy-helper/index.js
+```
+
+Full env notes: [`scripts/omp-occupancy-helper/README.md`](./scripts/omp-occupancy-helper/README.md)
+
+### Security rules for helpers
+
+- **Never bind `0.0.0.0`** — the helpers refuse it. Use a Tailscale or LAN IP.
+- **Token required** for non-loopback binds. The helper refuses to start without one.
+- Helpers serve **metadata only** — session handles, model origins, timestamps. No transcripts, no API keys, no credentials.
+- Response is cached for 2 seconds to avoid re-reading files on every poll.
+
+### Running both helpers on one machine
+
+OpenCode and omp helpers use different ports (8788 and 8789), so they can run side by side:
+
+```bash
+# Terminal 1 — OpenCode
+OPENCODE_OCCUPANCY_TOKEN="token-oc" OPENCODE_OCCUPANCY_BIND="$(tailscale ip -4)" \
+  node scripts/opencode-occupancy-helper/index.js
+
+# Terminal 2 — omp
+OMP_OCCUPANCY_TOKEN="token-omp" OMP_OCCUPANCY_BIND="$(tailscale ip -4)" \
+  node scripts/omp-occupancy-helper/index.js
+```
+
+Then add two URL attaches in sparkDash (one OpenCode, one oh-my-pi), each pointing at the same IP on the respective port.
+
+## Multiple attaches of the same kind
+
+Click **Add** next to a source kind to attach more than one instance (e.g., OpenCode on both your Mac and your workstation). Each attach gets a unique ID (`opencode-2`, `opencode-3`, etc.) and can be checked and toggled independently.
+
+## How origin matching works
+
+Each session has an `originHost` and `originPort` derived from the provider's `baseUrl`:
+
+- OpenClaw: provider `baseUrl` from the gateway payload
+- Hermes: provider `baseUrl` from the dashboard API
+- OpenCode: provider `baseURL` from `opencode.jsonc`/`opencode.json`
+- omp: provider `baseUrl` from `~/.omp/agent/models.yml`
+
+The projector matches sessions to Sparks by comparing `originHost:originPort` against each Spark's `llmPorts` and listen IPs. If a Spark has multiple LLM ports, sessions show on the port they actually hit.
+
+## LiteLLM note
+
+If you route models through LiteLLM (e.g., `kalliope` on port 4000), set the LLM API key in sparkDash so the `/v1/models` probe authenticates. LiteLLM without a database returns `400` on `/v1/models` without a key, which sparkDash interprets as "unreachable." With the key, all routed models appear on the single LiteLLM port — no need to expose the raw backend port separately.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ It also supports **non-Spark units**: any Linux machine with an NVIDIA GPU (e.g.
 - [Repository layout](#repository-layout)
 - [REST API](#rest-api)
 - [Configuration](#configuration)
+- [Session occupancy](#session-occupancy)
 - [Security](#security)
 - [Scripts](#scripts)
 - [How it works](#how-it-works)
@@ -85,6 +86,7 @@ Full history: [CHANGELOG.md](./CHANGELOG.md)
 | **Secrets** | SSH passwords AES-256-GCM encrypted; never in `sparks.json` or API responses |
 | **Docker-first** | Single privileged container for host metrics; prod and dev Compose files |
 | **Hot config** | Add / edit / remove / reorder Sparks from the UI with no process restart |
+| **Session occupancy** | OpenClaw / Hermes / OpenCode sessions on each LLM card; OpenCode on another machine uses a small helper |
 
 ---
 
@@ -357,6 +359,9 @@ sparkDash/
 | GET | `/api/sparks/:id/llm/daily` | Daily busy decode/prefill tok/s (`port`, `days`) |
 | GET | `/api/settings` | Global settings |
 | PUT | `/api/settings` | Update global settings |
+| GET | `/api/session-sources` | Occupancy attaches (tokens redacted) |
+| PATCH | `/api/session-sources` | Update occupancy attaches |
+| POST | `/api/session-sources/test` | Check occupancy attach reachability |
 | WS | `/ws` | Real-time metrics stream |
 
 There is no authentication on the HTTP/WebSocket API. Run sparkDash only on a trusted network (or behind your own reverse proxy with auth).
@@ -441,6 +446,32 @@ Header theme control cycles:
 | **OLED** | True black for OLED panels |
 
 Choice is stored in `localStorage`.
+
+---
+
+## Session occupancy
+
+OpenClaw, Hermes Agent, and OpenCode sessions that hit a Spark LLM show on that card’s **Sessions** list.
+
+Configure attaches on **any LLM card → Settings (gear) → Occupancy sources**. The list is dashboard-wide; save with **Save occupancy** (separate from the LLM port Save).
+
+| Source | Typical setup |
+|--------|----------------|
+| **OpenClaw / Hermes** | **Local** if they run on the dashboard host; otherwise **URL** or **State dir** |
+| **OpenCode on this host** | **Local** — reads `opencode.db` directly |
+| **OpenCode on another computer** | Run the helper on that machine, then **URL** + token |
+
+OpenCode has no occupancy HTTP API. On the OpenCode machine (Node 22+, sparkDash checkout):
+
+```bash
+BIND="$(tailscale ip -4 2>/dev/null || ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')"
+TOKEN="$(openssl rand -hex 32)"
+printf 'URL:   http://%s:8788/occupancy\nToken: %s\n' "$BIND" "$TOKEN"
+OPENCODE_OCCUPANCY_BIND="$BIND" OPENCODE_OCCUPANCY_TOKEN="$TOKEN" \
+  node scripts/opencode-occupancy-helper/index.js
+```
+
+Paste the printed URL (`http://<that-ip>:8788/occupancy`) and token into Occupancy sources → OpenCode → URL, then **Check** and **Save occupancy**. Do not bind `0.0.0.0`. Full env and macOS path notes: [`scripts/opencode-occupancy-helper/README.md`](./scripts/opencode-occupancy-helper/README.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Full history: [CHANGELOG.md](./CHANGELOG.md)
 | **Secrets** | SSH passwords AES-256-GCM encrypted; never in `sparks.json` or API responses |
 | **Docker-first** | Single privileged container for host metrics; prod and dev Compose files |
 | **Hot config** | Add / edit / remove / reorder Sparks from the UI with no process restart |
-| **Session occupancy** | OpenClaw / Hermes / OpenCode sessions on each LLM card; OpenCode on another machine uses a small helper |
+| **Session occupancy** | OpenClaw / Hermes / OpenCode / oh-my-pi sessions on each LLM card; remote machines use a small helper |
 
 ---
 
@@ -451,7 +451,7 @@ Choice is stored in `localStorage`.
 
 ## Session occupancy
 
-OpenClaw, Hermes Agent, and OpenCode sessions that hit a Spark LLM show on that card’s **Sessions** list.
+OpenClaw, Hermes Agent, OpenCode, and oh-my-pi (omp) sessions that hit a Spark LLM show on that card’s **Sessions** list.
 
 Configure attaches on **any LLM card → Settings (gear) → Occupancy sources**. The list is dashboard-wide; save with **Save occupancy** (separate from the LLM port Save).
 
@@ -460,8 +460,14 @@ Configure attaches on **any LLM card → Settings (gear) → Occupancy sources**
 | **OpenClaw / Hermes** | **Local** if they run on the dashboard host; otherwise **URL** or **State dir** |
 | **OpenCode on this host** | **Local** — reads `opencode.db` directly |
 | **OpenCode on another computer** | Run the helper on that machine, then **URL** + token |
+| **oh-my-pi on this host** | **Local** — reads `~/.omp/agent/sessions/*.jsonl` directly |
+| **oh-my-pi on another computer** | Run the helper on that machine, then **URL** + token |
 
-OpenCode has no occupancy HTTP API. On the OpenCode machine (Node 22+, sparkDash checkout):
+Sessions older than the **Occupancy session age limit** (Settings, default 12h) are hidden. Set to `0` to show all.
+
+### OpenCode helper (remote machine)
+
+On the OpenCode machine (Node 22+, sparkDash checkout):
 
 ```bash
 BIND="$(tailscale ip -4 2>/dev/null || ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')"
@@ -472,6 +478,22 @@ OPENCODE_OCCUPANCY_BIND="$BIND" OPENCODE_OCCUPANCY_TOKEN="$TOKEN" \
 ```
 
 Paste the printed URL (`http://<that-ip>:8788/occupancy`) and token into Occupancy sources → OpenCode → URL, then **Check** and **Save occupancy**. Do not bind `0.0.0.0`. Full env and macOS path notes: [`scripts/opencode-occupancy-helper/README.md`](./scripts/opencode-occupancy-helper/README.md).
+
+### oh-my-pi helper (remote machine)
+
+On the omp machine (Node 22+, sparkDash checkout):
+
+```bash
+BIND="$(tailscale ip -4 2>/dev/null || ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')"
+TOKEN="$(openssl rand -hex 32)"
+printf 'URL:   http://%s:8789/occupancy\nToken: %s\n' "$BIND" "$TOKEN"
+OMP_OCCUPANCY_BIND="$BIND" OMP_OCCUPANCY_TOKEN="$TOKEN" \
+  node scripts/omp-occupancy-helper/index.js
+```
+
+Paste the printed URL (`http://<that-ip>:8789/occupancy`) and token into Occupancy sources → oh-my-pi → URL, then **Check** and **Save occupancy**. Full env notes: [`scripts/omp-occupancy-helper/README.md`](./scripts/omp-occupancy-helper/README.md).
+
+Both helpers can run on the same machine (ports 8788 and 8789). Full setup guide: [`OCCUPANCY.md`](./OCCUPANCY.md).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:client": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node --test server/collectors/__tests__/*.test.js server/sparks/__tests__/*.test.js",
+    "test": "node --test server/collectors/__tests__/*.test.js server/sparks/__tests__/*.test.js server/__tests__/*.test.js scripts/opencode-occupancy-helper/index.test.js",
     "preview": "vite preview",
     "start": "node server/index.js",
     "docker:up": "docker compose up -d",

--- a/scripts/omp-occupancy-helper/README.md
+++ b/scripts/omp-occupancy-helper/README.md
@@ -1,0 +1,54 @@
+# oh-my-pi (omp) occupancy helper
+
+sparkDash polls this process over LAN or Tailscale to show omp session occupancy. It reads local `~/.omp/agent/sessions/*.jsonl` and `~/.omp/agent/models.yml` — never transcripts, credentials, or databases.
+
+In the dashboard: any **LLM card → Settings (gear) → Occupancy sources → oh-my-pi → URL**.
+
+## Run (from the sparkDash checkout)
+
+Node 22+. Do **not** bind `0.0.0.0`.
+
+```bash
+BIND="$(tailscale ip -4 2>/dev/null || ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')"
+TOKEN="$(openssl rand -hex 32)"
+printf 'URL:   http://%s:8789/occupancy\nToken: %s\n' "$BIND" "$TOKEN"
+OMP_OCCUPANCY_BIND="$BIND" OMP_OCCUPANCY_TOKEN="$TOKEN" \
+  node scripts/omp-occupancy-helper/index.js
+```
+
+Leave it running. Paste the printed URL and token into sparkDash, then **Check** and **Save occupancy** (not the LLM port Save).
+
+Loopback-only (dashboard on the same host as omp): skip the helper and use mode **Local**.
+
+## Reach sparkDash from a workstation
+
+A reachable (non-loopback) bind **requires** `OMP_OCCUPANCY_TOKEN`. Either:
+
+1. Bind a **tailnet or LAN IP** with a token (command above).
+2. **Tailscale Serve**: keep the helper on `127.0.0.1` and serve the port on the tailnet.
+
+## Environment
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `OMP_OCCUPANCY_BIND` | `127.0.0.1` | Listen address |
+| `OMP_OCCUPANCY_PORT` | `8789` | Listen port |
+| `OMP_OCCUPANCY_PATH` | `/occupancy` | GET path |
+| `OMP_OCCUPANCY_TOKEN` | empty | If set, require `Authorization: Bearer …` |
+| `OMP_STATE_DIR` | `~/.omp` | State root (contains `agent/sessions/`) |
+| `OMP_CONFIG_DIR` | `~/.omp/agent` | Config dir (contains `models.yml`) |
+
+The helper reads JSONL session files and the provider map only. Missing state returns **HTTP 503**, not an empty list.
+
+Response shape:
+
+```json
+{ "found": 2, "rows": [{ "source": "omp", "handle": "…", "originHost": "192.168.4.117", "originPort": 8888, "midTurn": "unknown" }] }
+```
+
+## What it reads
+
+- `~/.omp/agent/sessions/**/*.jsonl` — session metadata (title, model, timestamps)
+- `~/.omp/agent/models.yml` — provider `baseUrl` values for origin mapping
+
+It does **not** read message transcripts, thinking content, API keys (only `baseUrl` from `models.yml`), or any database.

--- a/scripts/omp-occupancy-helper/index.js
+++ b/scripts/omp-occupancy-helper/index.js
@@ -1,0 +1,145 @@
+/**
+ * oh-my-pi (omp) occupancy helper for sparkDash URL attach.
+ * GET /occupancy → { found, rows } of projector-input fields only.
+ *
+ * Run on the machine that has ~/.omp:
+ *   OMP_OCCUPANCY_TOKEN="$(openssl rand -hex 32)" \
+ *   OMP_OCCUPANCY_BIND="$(tailscale ip -4)" \
+ *   node scripts/omp-occupancy-helper/index.js
+ *
+ * In sparkDash: LLM card → Settings → Occupancy sources → oh-my-pi → URL.
+ * Paste the printed URL and token, then Check and Save occupancy.
+ */
+import http from "node:http";
+import { timingSafeEqual } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { loadOmpOccupancy } from "../../server/collectors/OmpSessions.js";
+
+export async function loadOccupancy(deps = {}) {
+  const attach = {
+    enabled: true,
+    mode: deps.mode ?? "local",
+    stateDir: deps.stateDir ?? "",
+    url: "",
+    id: "",
+  };
+  const loaded = await loadOmpOccupancy(attach, deps);
+  if (loaded.missingState) {
+    const err = new Error("oh-my-pi sessions not found");
+    err.status = 503;
+    throw err;
+  }
+  return { found: loaded.found, rows: loaded.rows };
+}
+
+function timingEqual(left, right) {
+  const a = Buffer.from(String(left));
+  const b = Buffer.from(String(right));
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export function createOccupancyHelper(opts = {}) {
+  const token = opts.token ?? process.env.OMP_OCCUPANCY_TOKEN ?? "";
+  const occupancyPath = opts.path ?? process.env.OMP_OCCUPANCY_PATH ?? "/occupancy";
+  const ttlMs = opts.ttlMs ?? 2000;
+  const load = opts.load ?? loadOccupancy;
+  const host = opts.host ?? process.env.OMP_OCCUPANCY_BIND ?? "127.0.0.1";
+  const port = Number(opts.port ?? process.env.OMP_OCCUPANCY_PORT ?? 8789);
+  let cached = null;
+  let cachedAt = 0;
+  /** @type {http.Server | null} */
+  let server = null;
+
+  async function occupancyJson() {
+    const now = Date.now();
+    if (cached && now - cachedAt < ttlMs) return cached;
+    const payload = await load(opts.deps ?? {});
+    cached = payload;
+    cachedAt = now;
+    return payload;
+  }
+
+  async function onRequest(req, res) {
+    res.setHeader("Cache-Control", "no-store");
+    if (req.method !== "GET" || urlPath(req) !== occupancyPath) {
+      res.statusCode = 404;
+      res.end("Not found");
+      return;
+    }
+    if (token && !bearerMatches(req, token)) {
+      res.statusCode = 401;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+    try {
+      const payload = await occupancyJson();
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify(payload));
+    } catch (err) {
+      res.statusCode = 503;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "oh-my-pi sessions not found" }));
+    }
+  }
+
+  function listen() {
+    if (host === "0.0.0.0" || host === "::") {
+      console.error("Refusing to bind all interfaces. Set OMP_OCCUPANCY_BIND to a tailnet IP or use Tailscale Serve.");
+      process.exitCode = 1;
+      return Promise.reject(new Error("bind not allowed"));
+    }
+    if (token === "" && host !== "127.0.0.1" && host !== "::1") {
+      console.error("Refusing reachable bind without OMP_OCCUPANCY_TOKEN.");
+      process.exitCode = 1;
+      return Promise.reject(new Error("token required"));
+    }
+    server = http.createServer((req, res) => void onRequest(req, res));
+    return new Promise((resolve) => {
+      server.listen(port, host, () => resolve(server));
+    });
+  }
+
+  function close() {
+    return new Promise((resolve, reject) => {
+      if (!server) {
+        resolve();
+        return;
+      }
+      server.close((err) => (err ? reject(err) : resolve()));
+      server = null;
+    });
+  }
+
+  return { onRequest, listen, close, occupancyJson, host, port, path: occupancyPath };
+}
+
+function urlPath(req) {
+  try {
+    return new URL(req.url || "/", "http://127.0.0.1").pathname;
+  } catch {
+    return "/";
+  }
+}
+
+function bearerMatches(req, token) {
+  const header = String(req.headers.authorization || "");
+  const got = header.startsWith("Bearer ") ? header.slice(7) : "";
+  return timingEqual(got, token);
+}
+
+const isMain =
+  Boolean(process.argv[1]) && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain) {
+  const helper = createOccupancyHelper();
+  await helper.listen();
+  const url = `http://${helper.host}:${helper.port}${helper.path}`;
+  console.error(`oh-my-pi occupancy helper on ${url}`);
+  console.error(
+    "In sparkDash: any LLM card → Settings → Occupancy sources → oh-my-pi → URL. Paste that URL and OMP_OCCUPANCY_TOKEN, then Check and Save occupancy."
+  );
+}

--- a/scripts/opencode-occupancy-helper/README.md
+++ b/scripts/opencode-occupancy-helper/README.md
@@ -1,0 +1,50 @@
+# OpenCode occupancy helper
+
+sparkDash polls this process over LAN or Tailscale. It does **not** talk to OpenCode’s own HTTP server.
+
+In the dashboard: any **LLM card → Settings (gear) → Occupancy sources → OpenCode → URL**.
+That panel also has a copy-paste start command.
+
+## Run (from the sparkDash checkout)
+
+Node 22+. Do **not** bind `0.0.0.0`.
+
+```bash
+BIND="$(tailscale ip -4 2>/dev/null || ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')"
+TOKEN="$(openssl rand -hex 32)"
+printf 'URL:   http://%s:8788/occupancy\nToken: %s\n' "$BIND" "$TOKEN"
+OPENCODE_OCCUPANCY_BIND="$BIND" OPENCODE_OCCUPANCY_TOKEN="$TOKEN" \
+  node scripts/opencode-occupancy-helper/index.js
+```
+
+Leave it running. Paste the printed URL and token into sparkDash, then **Check** and **Save occupancy** (not the LLM port Save).
+
+Loopback-only (dashboard on the same host as OpenCode): skip the helper and use mode **Local**.
+
+## Reach sparkDash from a workstation
+
+A reachable (non-loopback) bind **requires** `OPENCODE_OCCUPANCY_TOKEN`. Either:
+
+1. Bind a **tailnet or LAN IP** with a token (command above).
+2. **Tailscale Serve**: keep the helper on `127.0.0.1` and serve the port on the tailnet.
+
+## Environment
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `OPENCODE_OCCUPANCY_BIND` | `127.0.0.1` | Listen address |
+| `OPENCODE_OCCUPANCY_PORT` | `8788` | Listen port |
+| `OPENCODE_OCCUPANCY_PATH` | `/occupancy` | GET path |
+| `OPENCODE_OCCUPANCY_TOKEN` | empty | If set, require `Authorization: Bearer …` |
+| `OPENCODE_DATA_DIR` | `~/.local/share/opencode` | Session db root (`opencode.db`) |
+| `OPENCODE_CONFIG_DIR` | `~/.config/opencode` | Provider map (`opencode.jsonc` then `opencode.json`) |
+
+macOS: if Check returns **503**, set `OPENCODE_DATA_DIR` to the folder that contains `opencode.db` (often `~/Library/Application Support/opencode`).
+
+The helper reads the OpenCode **session** table only. Missing state returns **HTTP 503**, not an empty list.
+
+Response shape:
+
+```json
+{ "found": 2, "rows": [{ "source": "opencode", "handle": "…", "originHost": "john", "originPort": 8888, "midTurn": "unknown" }] }
+```

--- a/scripts/opencode-occupancy-helper/index.js
+++ b/scripts/opencode-occupancy-helper/index.js
@@ -1,0 +1,137 @@
+/**
+ * Workstation occupancy helper for sparkDash OpenCode URL attach.
+ * GET /occupancy → { found, rows } of projector-input fields only.
+ */
+import http from "node:http";
+import { timingSafeEqual } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { loadOpenCodeOccupancy } from "../../server/collectors/OpenCodeSessions.js";
+
+export async function loadOccupancy(deps = {}) {
+  const attach = {
+    enabled: true,
+    mode: deps.mode ?? "local",
+    stateDir: deps.stateDir ?? "",
+    url: "",
+    id: "",
+  };
+  const loaded = await loadOpenCodeOccupancy(attach, deps);
+  if (loaded.missingState || loaded.invalidHelper) {
+    const err = new Error("OpenCode state not found");
+    err.status = 503;
+    throw err;
+  }
+  return { found: loaded.found, rows: loaded.rows };
+}
+
+function timingEqual(left, right) {
+  const a = Buffer.from(String(left));
+  const b = Buffer.from(String(right));
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export function createOccupancyHelper(opts = {}) {
+  const token = opts.token ?? process.env.OPENCODE_OCCUPANCY_TOKEN ?? "";
+  const occupancyPath = opts.path ?? process.env.OPENCODE_OCCUPANCY_PATH ?? "/occupancy";
+  const ttlMs = opts.ttlMs ?? 2000;
+  const load = opts.load ?? loadOccupancy;
+  const host = opts.host ?? process.env.OPENCODE_OCCUPANCY_BIND ?? "127.0.0.1";
+  const port = Number(opts.port ?? process.env.OPENCODE_OCCUPANCY_PORT ?? 8788);
+  let cached = null;
+  let cachedAt = 0;
+  /** @type {http.Server | null} */
+  let server = null;
+
+  async function occupancyJson() {
+    const now = Date.now();
+    if (cached && now - cachedAt < ttlMs) return cached;
+    const payload = await load(opts.deps ?? {});
+    cached = payload;
+    cachedAt = now;
+    return payload;
+  }
+
+  async function onRequest(req, res) {
+    res.setHeader("Cache-Control", "no-store");
+    if (req.method !== "GET" || urlPath(req) !== occupancyPath) {
+      res.statusCode = 404;
+      res.end("Not found");
+      return;
+    }
+    if (token && !bearerMatches(req, token)) {
+      res.statusCode = 401;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+    try {
+      const payload = await occupancyJson();
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify(payload));
+    } catch (err) {
+      res.statusCode = 503;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "OpenCode state not found" }));
+    }
+  }
+
+  function listen() {
+    if (host === "0.0.0.0" || host === "::") {
+      console.error("Refusing to bind all interfaces. Set OPENCODE_OCCUPANCY_BIND to a tailnet IP or use Tailscale Serve.");
+      process.exitCode = 1;
+      return Promise.reject(new Error("bind not allowed"));
+    }
+    if (token === "" && host !== "127.0.0.1" && host !== "::1") {
+      console.error("Refusing reachable bind without OPENCODE_OCCUPANCY_TOKEN.");
+      process.exitCode = 1;
+      return Promise.reject(new Error("token required"));
+    }
+    server = http.createServer((req, res) => void onRequest(req, res));
+    return new Promise((resolve) => {
+      server.listen(port, host, () => resolve(server));
+    });
+  }
+
+  function close() {
+    return new Promise((resolve, reject) => {
+      if (!server) {
+        resolve();
+        return;
+      }
+      server.close((err) => (err ? reject(err) : resolve()));
+      server = null;
+    });
+  }
+
+  return { onRequest, listen, close, occupancyJson, host, port, path: occupancyPath };
+}
+
+function urlPath(req) {
+  try {
+    return new URL(req.url || "/", "http://127.0.0.1").pathname;
+  } catch {
+    return "/";
+  }
+}
+
+function bearerMatches(req, token) {
+  const header = String(req.headers.authorization || "");
+  const got = header.startsWith("Bearer ") ? header.slice(7) : "";
+  return timingEqual(got, token);
+}
+
+const isMain =
+  Boolean(process.argv[1]) && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain) {
+  const helper = createOccupancyHelper();
+  await helper.listen();
+  const url = `http://${helper.host}:${helper.port}${helper.path}`;
+  console.error(`OpenCode occupancy helper on ${url}`);
+  console.error(
+    "In sparkDash: any LLM card → Settings → Occupancy sources → OpenCode → URL. Paste that URL and OPENCODE_OCCUPANCY_TOKEN, then Check and Save occupancy."
+  );
+}

--- a/scripts/opencode-occupancy-helper/index.test.js
+++ b/scripts/opencode-occupancy-helper/index.test.js
@@ -1,0 +1,155 @@
+/**
+ * Occupancy helper: projector-input JSON for sparkDash URL attach.
+ * Run: node --test scripts/opencode-occupancy-helper/index.test.js
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { createOccupancyHelper, loadOccupancy } from "./index.js";
+import { sanitizeOpenCodeRow } from "../../server/collectors/OpenCodeSessions.js";
+
+const JOHN = {
+  spark: { options: { baseURL: "http://john:8888/v1" } },
+};
+
+function sessionRow() {
+  return {
+    id: "ses_local",
+    title: "spark occupancy",
+    model: JSON.stringify({ id: "gpt-oss", providerID: "spark" }),
+    time_updated: 1_700_000_000_000,
+  };
+}
+
+function sessionColumns() {
+  return ["id", "title", "model", "time_updated"].map((name, cid) => ({ cid, name, type: "TEXT" }));
+}
+
+function fakeDb(rows) {
+  return {
+    prepare(sql) {
+      const text = String(sql);
+      if (/table_info\s*\(\s*session\s*\)/i.test(text)) {
+        return { all: () => sessionColumns() };
+      }
+      if (/\bfrom\s+session\b/i.test(text)) return { all: () => rows };
+      throw new Error(`unexpected sql: ${text}`);
+    },
+    close() {},
+  };
+}
+
+const localDeps = {
+  conventionalStateDir: "/tmp/opencode-data",
+  conventionalConfigDir: "/tmp/opencode-config",
+  readFile: async (filePath) => {
+    if (String(filePath).endsWith("opencode.json")) {
+      return JSON.stringify({ provider: JOHN });
+    }
+    const err = new Error("ENOENT");
+    err.code = "ENOENT";
+    throw err;
+  },
+  openDatabase: () => fakeDb([sessionRow()]),
+};
+
+test("helper maps a fixture db the same as local collect", async () => {
+  const payload = await loadOccupancy(localDeps);
+  assert.equal(payload.found, 1);
+  assert.equal(payload.rows.length, 1);
+  assert.equal(payload.rows[0].handle, "spark occupancy");
+  assert.equal(payload.rows[0].originHost, "john");
+  assert.equal(payload.rows[0].originPort, 8888);
+  assert.equal(payload.rows[0].midTurn, "unknown");
+  assert.equal(payload.rows[0].source, "opencode");
+});
+
+test("helper stamps cumulative tokens_input as approximate contextUsed", async () => {
+  const columns = ["id", "title", "model", "time_updated", "tokens_input"].map((name, cid) => ({
+    cid,
+    name,
+    type: "TEXT",
+  }));
+  const payload = await loadOccupancy({
+    ...localDeps,
+    openDatabase: () => ({
+      prepare(sql) {
+        const text = String(sql);
+        if (/table_info\s*\(\s*session\s*\)/i.test(text)) return { all: () => columns };
+        if (/\bfrom\s+session\b/i.test(text)) {
+          return { all: () => [{ ...sessionRow(), tokens_input: 75_000 }] };
+        }
+        throw new Error(`unexpected sql: ${text}`);
+      },
+      close() {},
+    }),
+  });
+  assert.equal(payload.rows[0].contextUsed, 75000);
+  assert.equal(payload.rows[0].contextApprox, true);
+});
+
+test("missing db is 503, not an empty list", async () => {
+  await assert.rejects(
+    () =>
+      loadOccupancy({
+        conventionalStateDir: "/no/such/opencode",
+        conventionalConfigDir: "/no/such/config",
+        readFile: async () => {
+          const err = new Error("ENOENT");
+          err.code = "ENOENT";
+          throw err;
+        },
+        openDatabase: () => {
+          const err = new Error("ENOENT");
+          err.code = "ENOENT";
+          throw err;
+        },
+      }),
+    (err) => err.status === 503
+  );
+
+  const helper = createOccupancyHelper({
+    token: "",
+    ttlMs: 0,
+    load: async () => {
+      const err = new Error("missing");
+      err.status = 503;
+      throw err;
+    },
+  });
+  const res = mockRes();
+  await helper.onRequest({ method: "GET", url: "/occupancy", headers: {} }, res);
+  assert.equal(res.statusCode, 503);
+  const body = JSON.parse(res.body);
+  assert.equal(Array.isArray(body), false);
+  assert.equal(body.error, "OpenCode state not found");
+});
+
+test("occupancy JSON has no transcript table keys", () => {
+  const row = sanitizeOpenCodeRow({
+    source: "opencode",
+    handle: "t",
+    originHost: "john",
+    originPort: 8888,
+    midTurn: "unknown",
+    title: "should-drop",
+    directory: "/home/art",
+  });
+  const dumped = JSON.stringify(row);
+  assert.equal(Object.hasOwn(row, "title"), false);
+  assert.equal(Object.hasOwn(row, "directory"), false);
+  assert.match(dumped, /"handle":"t"/);
+});
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    end(chunk) {
+      this.body = String(chunk ?? "");
+    },
+  };
+}

--- a/server/__tests__/session-sources.test.js
+++ b/server/__tests__/session-sources.test.js
@@ -1,0 +1,418 @@
+/**
+ * Session source attach config (U1).
+ *
+ * Uses temp dirs + env path injection so tests never touch the real config/ volume.
+ * Run: node --test server/__tests__/session-sources.test.js
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-session-sources-"));
+const sourcesPath = path.join(tmpDir, "session-sources.json");
+const secretsPath = path.join(tmpDir, "sparks-secrets.json");
+const keyPath = path.join(tmpDir, ".secrets-key");
+
+process.env.SESSION_SOURCES_JSON_PATH = sourcesPath;
+process.env.SPARKS_SECRETS_PATH = secretsPath;
+process.env.SECRETS_KEY_PATH = keyPath;
+process.env.SPARKDASH_SECRETS_KEY = "sparkdash-session-sources-test-key";
+delete process.env.OPENCLAW_STATE_DIR;
+delete process.env.HERMES_HOME;
+
+const secretsStore = await import("../secretsStore.js");
+const sessionSources = await import("../sessionSources.js");
+
+const {
+  loadSecrets,
+  saveSecrets,
+  resetSecretsKeyCache,
+} = secretsStore;
+const {
+  getPublicSessionSources,
+  updateSessionSources,
+  loadSessionSources,
+  SOURCE_IDS,
+  conventionalStateDir,
+} = sessionSources;
+
+function first(list) {
+  assert.ok(Array.isArray(list) && list.length > 0, "expected attach list");
+  return list[0];
+}
+
+function resetFiles() {
+  for (const filePath of [sourcesPath, secretsPath, keyPath]) {
+    try {
+      fs.unlinkSync(filePath);
+    } catch {
+      /* missing is fine */
+    }
+  }
+  if (typeof resetSecretsKeyCache === "function") {
+    resetSecretsKeyCache();
+  }
+}
+
+test.after(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("U1 registry: OpenClaw, Hermes, and OpenCode; config iterates registry kinds", async () => {
+  const registry = await import("../sessionSourceRegistry.js");
+  assert.deepEqual(registry.sessionSourceIds(), ["openclaw", "hermes", "opencode", "omp"]);
+  assert.equal(registry.kindById("openclaw")?.label, "OpenClaw");
+  assert.equal(registry.kindById("hermes")?.label, "Hermes Agent");
+  assert.equal(registry.kindById("opencode")?.label, "OpenCode");
+  assert.equal(registry.kindById("omp")?.label, "oh-my-pi");
+  assert.deepEqual([...SOURCE_IDS], registry.sessionSourceIds());
+  assert.equal(conventionalStateDir, registry.conventionalStateDir);
+
+  const src = fs.readFileSync(fileURLToPath(new URL("../sessionSources.js", import.meta.url)), "utf8");
+  assert.match(src, /sessionSourceRegistry/);
+  assert.equal(/\[["']openclaw["']\s*,\s*["']hermes["']\]/.test(src), false);
+
+  resetFiles();
+  const loaded = loadSessionSources();
+  const pub = getPublicSessionSources();
+  for (const kind of registry.sessionSourceIds()) {
+    assert.ok(Array.isArray(loaded[kind]), `expected ${kind} attach list`);
+    assert.equal(first(loaded[kind]).enabled, false);
+    assert.ok(Array.isArray(pub[kind]), `expected public ${kind} attach list`);
+    assert.equal(first(pub[kind]).conventionalStateDir, registry.conventionalStateDir(kind));
+  }
+  assert.equal(conventionalStateDir("openclaw-2"), "");
+  assert.equal(conventionalStateDir("opencode"), "~/.local/share/opencode");
+  assert.equal(registry.conventionalConfigDir("opencode"), "~/.config/opencode");
+  assert.equal(registry.conventionalConfigDir("openclaw"), "");
+  assert.equal(first(pub.opencode).urlPlaceholder, "http://127.0.0.1:8788/occupancy");
+  assert.equal(first(pub.opencode).kindLabel, "OpenCode");
+  assert.equal(first(pub.hermes).kindLabel, "Hermes Agent");
+  assert.equal(first(pub.hermes).usesUsername, true);
+  assert.equal(first(pub.openclaw).usesUsername, undefined);
+  assert.equal(
+    conventionalStateDir("hermes", { HERMES_HOME: " /custom/hermes " }),
+    "/custom/hermes"
+  );
+});
+
+test("public GET and save only emit registry kinds; kindLabel is not persisted", () => {
+  resetFiles();
+  fs.writeFileSync(
+    sourcesPath,
+    JSON.stringify({
+      openclaw: [{ id: "openclaw", enabled: false, mode: "local", url: "", stateDir: "" }],
+      hermes: [{ id: "hermes", enabled: false, mode: "local", url: "", stateDir: "" }],
+      leftover: [{ id: "leftover", enabled: true, mode: "local", url: "", stateDir: "" }],
+    })
+  );
+  const pub = getPublicSessionSources();
+  assert.deepEqual(Object.keys(pub).sort(), ["hermes", "omp", "openclaw", "opencode"]);
+  assert.equal("leftover" in pub, false);
+  const next = updateSessionSources({ opencode: { id: "opencode", enabled: false } });
+  assert.equal(first(next.opencode).kindLabel, "OpenCode");
+  const disk = JSON.parse(fs.readFileSync(sourcesPath, "utf8"));
+  assert.deepEqual(Object.keys(disk).sort(), ["hermes", "omp", "openclaw", "opencode"]);
+  assert.equal("kindLabel" in first(disk.opencode), false);
+});
+
+test("AE4 config: both sources disabled/absent is a valid normalized config", () => {
+  resetFiles();
+  const loaded = loadSessionSources();
+  assert.equal(first(loaded.openclaw).enabled, false);
+  assert.equal(first(loaded.hermes).enabled, false);
+  const pub = getPublicSessionSources();
+  assert.equal(first(pub.openclaw).enabled, false);
+  assert.equal(first(pub.hermes).enabled, false);
+  assert.equal(first(pub.openclaw).hasToken, false);
+  assert.equal(first(pub.hermes).hasToken, false);
+  assert.equal("token" in first(pub.openclaw), false);
+  assert.equal("token" in first(pub.hermes), false);
+});
+
+test("AE5: URL attach persists and round-trips without leaking the token on GET", () => {
+  resetFiles();
+  const token = "super-secret-openclaw-token";
+  const pub = updateSessionSources({
+    openclaw: {
+      enabled: true,
+      mode: "url",
+      url: "http://127.0.0.1:18789",
+      token,
+    },
+  });
+
+  assert.equal(first(pub.openclaw).enabled, true);
+  assert.equal(first(pub.openclaw).mode, "url");
+  assert.equal(first(pub.openclaw).url, "http://127.0.0.1:18789");
+  assert.equal(first(pub.openclaw).hasToken, true);
+  assert.equal("token" in first(pub.openclaw), false);
+  assert.equal(JSON.stringify(pub).includes(token), false);
+
+  const disk = JSON.parse(fs.readFileSync(sourcesPath, "utf8"));
+  assert.equal(first(disk.openclaw).enabled, true);
+  assert.equal(first(disk.openclaw).mode, "url");
+  assert.equal(first(disk.openclaw).url, "http://127.0.0.1:18789");
+  assert.equal(JSON.stringify(disk).includes(token), false);
+  assert.equal("token" in (first(disk.openclaw) || {}), false);
+
+  const secretsRaw = fs.readFileSync(secretsPath, "utf8");
+  assert.equal(secretsRaw.includes(token), false);
+
+  const reloaded = getPublicSessionSources();
+  assert.equal(first(reloaded.openclaw).enabled, true);
+  assert.equal(first(reloaded.openclaw).mode, "url");
+  assert.equal(first(reloaded.openclaw).url, "http://127.0.0.1:18789");
+  assert.equal(first(reloaded.openclaw).hasToken, true);
+  assert.equal("token" in first(reloaded.openclaw), false);
+  assert.equal(JSON.stringify(reloaded).includes(token), false);
+});
+
+test("local mode saves conventional product paths, not this fleet", () => {
+  resetFiles();
+  const pub = updateSessionSources({
+    openclaw: { enabled: true, mode: "local" },
+    hermes: { enabled: true, mode: "local" },
+  });
+
+  assert.equal(first(pub.openclaw).mode, "local");
+  assert.equal(first(pub.hermes).mode, "local");
+  assert.equal(first(pub.openclaw).conventionalStateDir, "~/.openclaw");
+  assert.equal(first(pub.hermes).conventionalStateDir, "~/.hermes");
+
+  const dumped = `${JSON.stringify(pub)}\n${fs.readFileSync(sourcesPath, "utf8")}`;
+  assert.equal(/alphaclaw/i.test(dumped), false);
+  assert.equal(dumped.includes("/.local/state/alphaclaw"), false);
+  assert.match(dumped, /~\/\.openclaw/);
+  assert.match(dumped, /~\/\.hermes/);
+});
+
+test("documented attach fields and unknown extras survive save/reload", () => {
+  resetFiles();
+  fs.writeFileSync(
+    sourcesPath,
+    JSON.stringify(
+      {
+        openclaw: {
+          enabled: true,
+          mode: "state-dir",
+          url: "http://127.0.0.1:18789",
+          stateDir: "/tmp/openclaw-state",
+          futureFlag: true,
+        },
+        hermes: {
+          enabled: false,
+          mode: "local",
+          url: "",
+          stateDir: "",
+          extraReader: "v2",
+        },
+      },
+      null,
+      2
+    ) + "\n"
+  );
+
+  const loaded = loadSessionSources();
+  assert.equal(first(loaded.openclaw).enabled, true);
+  assert.equal(first(loaded.openclaw).mode, "state-dir");
+  assert.equal(first(loaded.openclaw).url, "http://127.0.0.1:18789");
+  assert.equal(first(loaded.openclaw).stateDir, "/tmp/openclaw-state");
+  assert.equal(first(loaded.openclaw).futureFlag, true);
+  assert.equal(first(loaded.hermes).extraReader, "v2");
+
+  updateSessionSources({ openclaw: { enabled: false } });
+  const disk = JSON.parse(fs.readFileSync(sourcesPath, "utf8"));
+  assert.equal(first(disk.openclaw).enabled, false);
+  assert.equal(first(disk.openclaw).mode, "state-dir");
+  assert.equal(first(disk.openclaw).url, "http://127.0.0.1:18789");
+  assert.equal(first(disk.openclaw).stateDir, "/tmp/openclaw-state");
+  assert.equal(first(disk.openclaw).futureFlag, true);
+  assert.equal(first(disk.hermes).extraReader, "v2");
+});
+
+test("omitted token on PATCH does not wipe; empty string clears", () => {
+  resetFiles();
+  updateSessionSources({
+    openclaw: { enabled: true, mode: "url", url: "http://127.0.0.1:18789", token: "keep-me" },
+  });
+  assert.equal(first(getPublicSessionSources().openclaw).hasToken, true);
+
+  updateSessionSources({
+    openclaw: { enabled: true, mode: "url", url: "http://127.0.0.1:18789" },
+  });
+  assert.equal(first(getPublicSessionSources().openclaw).hasToken, true);
+
+  updateSessionSources({
+    openclaw: { token: "" },
+  });
+  assert.equal(first(getPublicSessionSources().openclaw).hasToken, false);
+});
+
+test("url-only PATCH to a new origin clears the stored token", () => {
+  resetFiles();
+  updateSessionSources({
+    openclaw: { enabled: true, mode: "url", url: "http://127.0.0.1:18789", token: "keep-me" },
+  });
+  assert.equal(first(getPublicSessionSources().openclaw).hasToken, true);
+
+  const pub = updateSessionSources({
+    openclaw: { enabled: true, mode: "url", url: "http://192.168.4.10:18789" },
+  });
+  assert.equal(first(pub.openclaw).hasToken, false);
+  assert.equal(first(pub.openclaw).url, "http://192.168.4.10:18789");
+});
+
+test("URL userinfo, non-http protocol, and NUL stateDir are rejected", () => {
+  resetFiles();
+  const userinfoUrl = new URL("http://127.0.0.1:18789");
+  userinfoUrl.username = "review-user";
+  userinfoUrl.password = "review-pass";
+  assert.throws(
+    () =>
+      updateSessionSources({
+        openclaw: { enabled: true, mode: "url", url: userinfoUrl.toString() },
+      }),
+    /userinfo/i
+  );
+  assert.throws(
+    () =>
+      updateSessionSources({
+        hermes: { enabled: true, mode: "url", url: "file:///tmp/sessions.json" },
+      }),
+    /protocol/i
+  );
+  assert.throws(
+    () =>
+      updateSessionSources({
+        openclaw: { enabled: true, mode: "state-dir", stateDir: "/tmp/openclaw\0evil" },
+      }),
+    /state dir/i
+  );
+});
+
+test("disallowed URL host is rejected", () => {
+  resetFiles();
+  assert.throws(
+    () =>
+      updateSessionSources({
+        openclaw: {
+          enabled: true,
+          mode: "url",
+          url: "http://169.254.169.254:18789",
+        },
+      }),
+    /disallowed host/i
+  );
+  assert.equal(fs.existsSync(sourcesPath), false);
+
+  assert.throws(
+    () =>
+      updateSessionSources({
+        hermes: {
+          enabled: true,
+          mode: "url",
+          url: "http://169.254.1.1:9119",
+        },
+      }),
+    /disallowed host/i
+  );
+});
+
+test("v1 sparks-secrets.json passwords still load after session-token field is added", () => {
+  resetFiles();
+  saveSecrets(new Map([["spark-a", "ssh-password-a"]]));
+  const v2 = JSON.parse(fs.readFileSync(secretsPath, "utf8"));
+  assert.equal(v2.version, 2);
+  assert.ok(v2.secrets["spark-a"]);
+  assert.equal(v2.sessionSourceTokens, undefined);
+  assert.equal(loadSecrets().passwords.get("spark-a"), "ssh-password-a");
+
+  updateSessionSources({ hermes: { token: "hermes-session-token" } });
+  assert.equal(loadSecrets().passwords.get("spark-a"), "ssh-password-a");
+  assert.equal(first(getPublicSessionSources().hermes).hasToken, true);
+
+  saveSecrets(new Map([["spark-a", "ssh-password-a"], ["spark-b", "ssh-password-b"]]));
+  assert.equal(loadSecrets().passwords.get("spark-a"), "ssh-password-a");
+  assert.equal(loadSecrets().passwords.get("spark-b"), "ssh-password-b");
+  assert.equal(first(getPublicSessionSources().hermes).hasToken, true);
+
+  saveSecrets(new Map());
+  assert.equal(loadSecrets().passwords.size, 0);
+  assert.equal(first(getPublicSessionSources().hermes).hasToken, true);
+});
+
+test("enabled state-dir requires a non-empty path", () => {
+  resetFiles();
+  assert.throws(
+    () =>
+      updateSessionSources({
+        openclaw: { enabled: true, mode: "state-dir", stateDir: "" },
+      }),
+    /state dir/i
+  );
+  const pub = updateSessionSources({
+    openclaw: { enabled: false, mode: "state-dir", stateDir: "" },
+  });
+  assert.equal(first(pub.openclaw).enabled, false);
+  assert.equal(first(pub.openclaw).mode, "state-dir");
+  assert.equal(first(pub.openclaw).stateDir, "");
+});
+
+test("token patch rolls back when session-sources.json cannot be saved", () => {
+  resetFiles();
+  updateSessionSources({
+    openclaw: { enabled: true, mode: "url", url: "http://127.0.0.1:18789", token: "keep-me" },
+  });
+  assert.equal(first(getPublicSessionSources().openclaw).hasToken, true);
+  fs.unlinkSync(sourcesPath);
+  fs.mkdirSync(sourcesPath);
+  try {
+    assert.throws(
+      () =>
+        updateSessionSources({
+          openclaw: { enabled: true, mode: "url", url: "http://192.168.4.10:18789" },
+        }),
+      /Failed to write|EISDIR|ENOTDIR/i
+    );
+    assert.equal(first(getPublicSessionSources().openclaw).hasToken, true);
+  } finally {
+    fs.rmSync(sourcesPath, { recursive: true, force: true });
+  }
+});
+
+test("two OpenClaw attaches persist distinct urls, labels, and tokens", () => {
+  resetFiles();
+  const pub = updateSessionSources({
+    openclaw: [
+      {
+        id: "openclaw",
+        enabled: true,
+        mode: "url",
+        url: "http://127.0.0.1:18789",
+        label: "theshop",
+        token: "token-a",
+      },
+      {
+        id: "openclaw-2",
+        enabled: true,
+        mode: "url",
+        url: "http://10.0.0.2:18789",
+        label: "mama",
+        token: "token-b",
+      },
+    ],
+  });
+  assert.equal(pub.openclaw.length, 2);
+  assert.equal(pub.openclaw[0].url, "http://127.0.0.1:18789");
+  assert.equal(pub.openclaw[0].label, "theshop");
+  assert.equal(pub.openclaw[0].hasToken, true);
+  assert.equal(pub.openclaw[1].id, "openclaw-2");
+  assert.equal(pub.openclaw[1].url, "http://10.0.0.2:18789");
+  assert.equal(pub.openclaw[1].hasToken, true);
+  assert.equal(JSON.stringify(pub).includes("token-a"), false);
+  assert.equal(JSON.stringify(pub).includes("token-b"), false);
+});

--- a/server/collectors/HermesSessions.js
+++ b/server/collectors/HermesSessions.js
@@ -1,0 +1,280 @@
+/**
+ * Hermes Agent conversation reader.
+ * Projector input rows only: source, handle, origin, midTurn.
+ * Recency is_active is never mid-turn. running:true or status working/running
+ * is mid-turn. Never transcripts. Never throws.
+ *
+ * Local/state-dir: sessions.json plus optional config.json or profile.json
+ * (`model.base_url`). URL mode: GET /api/sessions. Native sqlite (state.db)
+ * is not read — better-sqlite3 is not a dependency.
+ */
+import path from "node:path";
+import { conventionalStateDir } from "../sessionSources.js";
+import {
+  parseBaseUrl,
+  resolveStateDir,
+  defaultReadFile,
+  defaultFetchResponse,
+  normalizeSessionList,
+  sanitizeProbeError,
+  sessionLastUsedAt,
+  sessionAgent,
+  applySessionContext,
+  profileFromStateDir,
+  defaultReadDir,
+  stampAttachRows,
+} from "./sessionIo.js";
+import { hermesAuthedGetter } from "./hermesAuth.js";
+
+export { resetHermesAuthCache } from "./hermesAuth.js";
+
+const HANDLE_FIELDS = ["title", "source", "id"];
+const LIVE_STATUS = new Set(["working", "running"]);
+const PROFILE_FILES = ["config.json", "profile.json"];
+
+/**
+ * @param {unknown} sessions
+ * @param {object} [profiles]
+ * @returns {object[]}
+ */
+export function mapHermesSessions(sessions, profiles, agentFallback = "") {
+  const list = normalizeSessions(sessions);
+  const profileOrigin = parseBaseUrl(profileBaseUrl(profiles));
+  const fallback = sessionAgent(profiles, agentFallback);
+  const rows = [];
+  for (const item of list) {
+    const row = mapOneSession(item, profileOrigin, fallback);
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+/**
+ * @param {{ enabled?: boolean, mode?: string, url?: string, stateDir?: string }} attach
+ * @param {object} [deps]
+ * @returns {Promise<object[]>}
+ */
+export async function collectHermesSessions(attach, deps = {}) {
+  try {
+    if (!attach?.enabled) return [];
+    const loaded = await loadHermesPayload(attach, deps);
+    return stampAttachRows(mapLoadedHermes(loaded), attach);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Connectivity probe for Settings. Counts only — never session titles or transcripts.
+ * @returns {Promise<{ status: "disabled" | "ok" | "error", found: number, mapped: number, error: string | null }>}
+ */
+export async function diagnoseHermesSessions(attach, deps = {}) {
+  if (!attach?.enabled) {
+    return { status: "disabled", found: 0, mapped: 0, error: null };
+  }
+  if (attach.mode === "url" && !String(attach.url || "").trim()) {
+    return { status: "error", found: 0, mapped: 0, error: "URL is required" };
+  }
+  if (attach.mode === "state-dir" && !String(attach.stateDir || "").trim()) {
+    return { status: "error", found: 0, mapped: 0, error: "State dir is required" };
+  }
+  try {
+    const loaded = await loadHermesPayload(attach, deps);
+    const list = hermesBundles(loaded).flatMap((bundle) => normalizeSessions(bundle.sessions));
+    const rows = stampAttachRows(mapLoadedHermes(loaded), attach);
+    return {
+      status: "ok",
+      found: list.length,
+      mapped: deps.countMapped?.(rows) ?? rows.length,
+      error: null,
+    };
+  } catch (err) {
+    return { status: "error", found: 0, mapped: 0, error: sanitizeProbeError(err) };
+  }
+}
+
+function hermesBundles(loaded) {
+  if (Array.isArray(loaded?.bundles)) return loaded.bundles;
+  return [{ sessions: loaded?.sessions, profiles: loaded?.profiles, agent: loaded?.agent }];
+}
+
+function mapLoadedHermes(loaded) {
+  return hermesBundles(loaded).flatMap((bundle) =>
+    mapHermesSessions(bundle.sessions, bundle.profiles, bundle.agent)
+  );
+}
+
+function mapOneSession(session, profileOrigin, fallback) {
+  if (!session || typeof session !== "object") return null;
+  const origin = originOf(session, profileOrigin);
+  if (!origin) return null;
+  const handle = sessionHandle(session);
+  if (!handle) return null;
+  const lastUsedAt = sessionLastUsedAt(session);
+  const agent = sessionAgent(session, fallback);
+  const mapped = {
+    source: "hermes",
+    id: sessionIdentity(session) || handle,
+    handle,
+    originHost: origin.host,
+    originPort: origin.port,
+    midTurn: midTurnOf(session),
+  };
+  if (lastUsedAt != null) mapped.lastUsedAt = lastUsedAt;
+  if (agent) mapped.agent = agent;
+  return applySessionContext(mapped, session);
+}
+
+function sessionIdentity(session) {
+  for (const field of ["id", "session_id", "sessionId"]) {
+    const value = session[field];
+    if (typeof value === "string" && value.trim()) return value.trim();
+    if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  }
+  return "";
+}
+
+function sessionHandle(session) {
+  for (const field of HANDLE_FIELDS) {
+    const value = session[field];
+    if (typeof value === "string" && value.trim()) return value.trim();
+    if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  }
+  return "";
+}
+
+function midTurnOf(session) {
+  if (LIVE_STATUS.has(session.status)) return true;
+  if (session.running === true) return true;
+  return "unknown";
+}
+
+function originOf(session, profileOrigin) {
+  for (const raw of [session.billing_base_url, session.base_url, session.model?.base_url]) {
+    if (typeof raw === "string" && raw.trim()) {
+      const origin = parseBaseUrl(raw.trim());
+      if (origin) return origin;
+    }
+  }
+  return profileOrigin;
+}
+
+function profileBaseUrl(profiles) {
+  if (!profiles || typeof profiles !== "object") return "";
+  const nested = profiles.model?.base_url;
+  if (typeof nested === "string" && nested.trim()) return nested.trim();
+  if (typeof profiles.base_url === "string" && profiles.base_url.trim()) {
+    return profiles.base_url.trim();
+  }
+  return "";
+}
+
+function normalizeSessions(sessions) {
+  return normalizeSessionList(sessions) ?? [];
+}
+
+async function loadHermesPayload(attach, deps) {
+  if (typeof deps.listSessions === "function") {
+    return hermesBundle(await deps.listSessions(), deps.profiles ?? {}, "");
+  }
+  if (attach.mode === "url") return loadFromUrl(attach, deps);
+  return loadFromStateDir(attach, deps);
+}
+
+function hermesBundle(sessions, profiles, agent) {
+  return { bundles: [{ sessions, profiles, agent: sessionAgent(profiles, agent) }] };
+}
+
+async function loadFromUrl(attach, deps) {
+  const token = deps.token;
+  if (typeof deps.fetchJson === "function") {
+    const payload = await deps.fetchJson(sessionsUrl(attach.url), { token });
+    const profiles = deps.profiles ?? (await loadProfilesFromUrl(attach.url, deps.fetchJson, token));
+    return hermesBundle(payload, profiles, "");
+  }
+  const origin = gatewayOrigin(attach.url);
+  const fetchResponse = deps.fetchResponse ?? defaultFetchResponse;
+  const getJson = await hermesAuthedGetter(origin, token, fetchResponse, attach.username);
+  const payload = await getJson(sessionsUrl(attach.url));
+  const profiles = deps.profiles ?? (await loadProfilesFromUrl(attach.url, getJson, token));
+  return hermesBundle(payload, profiles, "");
+}
+
+function gatewayOrigin(raw) {
+  return String(raw || "")
+    .replace(/\/+$/, "")
+    .replace(/\/api\/sessions(?:\?.*)?$/, "");
+}
+
+function sessionsUrl(raw) {
+  const base = gatewayOrigin(raw);
+  if (!base) return "";
+  const original = String(raw || "");
+  if (/\/api\/sessions\?/.test(original)) return original.replace(/\/+$/, "");
+  return `${base}/api/sessions?limit=50&include_cli=1`;
+}
+
+async function loadProfilesFromUrl(raw, fetchJson, token) {
+  const base = gatewayOrigin(raw);
+  for (const suffix of ["/api/config", "/api/profile"]) {
+    try {
+      const payload = await fetchJson(`${base}${suffix}`, { token });
+      if (profileBaseUrl(payload)) return payload;
+    } catch {
+      // optional profile/config
+    }
+  }
+  return {};
+}
+
+async function loadFromStateDir(attach, deps) {
+  const dir = resolveStateDir(
+    attach,
+    deps,
+    deps.conventionalStateDir ?? conventionalStateDir("hermes")
+  );
+  if (!dir) return { bundles: [] };
+  const readFile = deps.readFile ?? defaultReadFile;
+  const readDir = deps.readDir ?? defaultReadDir;
+  const homes = await listHermesHomes(dir, readDir);
+  const bundles = [];
+  for (const home of homes) {
+    try {
+      const sessions = JSON.parse(await readFile(path.join(home.dir, "sessions.json")));
+      const profiles = await loadProfilesFromDir(home.dir, readFile);
+      bundles.push({ sessions, profiles, agent: home.agent });
+    } catch {
+      // skip missing or unreadable profile store
+    }
+  }
+  return { bundles };
+}
+
+async function listHermesHomes(dir, readDir) {
+  let names = [];
+  try {
+    names = await readDir(path.join(dir, "profiles"));
+  } catch {
+    names = [];
+  }
+  const homes = [];
+  for (const entry of names) {
+    const name = typeof entry === "string" ? entry : entry?.name;
+    if (!name || name.startsWith(".")) continue;
+    homes.push({ dir: path.join(dir, "profiles", name), agent: name });
+  }
+  if (homes.length > 0) return homes;
+  return [{ dir, agent: profileFromStateDir(dir) }];
+}
+
+async function loadProfilesFromDir(dir, readFile) {
+  for (const name of PROFILE_FILES) {
+    try {
+      const raw = JSON.parse(await readFile(path.join(dir, name)));
+      if (profileBaseUrl(raw)) return raw;
+    } catch {
+      // optional
+    }
+  }
+  return {};
+}

--- a/server/collectors/OmpSessions.js
+++ b/server/collectors/OmpSessions.js
@@ -18,6 +18,7 @@ import {
   defaultReadFile,
   defaultReadDir,
   defaultStat,
+  defaultFetchJson,
   sanitizeProbeError,
   stampAttachRows,
 } from "./sessionIo.js";
@@ -206,6 +207,34 @@ function uuidFromFileName(fileName) {
  * @returns {Promise<{ missingState: boolean, invalidHelper: boolean, found: number, rows: object[] }>}
  */
 export async function loadOmpOccupancy(attach, deps = {}) {
+  if (attach.mode === "url") return loadFromUrl(attach, deps);
+  return loadFromStateDir(attach, deps);
+}
+
+async function loadFromUrl(attach, deps) {
+  const fetchJson = deps.fetchJson ?? defaultFetchJson;
+  const payload = await fetchJson(String(attach.url || "").trim(), { token: deps.token });
+  const parsed = parseHelperPayload(payload);
+  if (parsed.error) return { missingState: false, invalidHelper: true, found: 0, rows: [] };
+  const preMapped = parsed.rows
+    .filter((row) => row && typeof row === "object")
+    .map((row) => sanitizeOmpRow(row));
+  return { missingState: false, invalidHelper: false, found: parsed.found, rows: stampAttachRows(preMapped, attach) };
+}
+
+function parseHelperPayload(payload) {
+  if (Array.isArray(payload)) {
+    if (payload.length > OMP_MAX_SESSION_FILES) return { error: true };
+    return { found: payload.length, rows: payload };
+  }
+  if (!payload || typeof payload !== "object") return { error: true };
+  if (!Array.isArray(payload.rows)) return { error: true };
+  if (payload.rows.length > OMP_MAX_SESSION_FILES) return { error: true };
+  const found = Number.isFinite(Number(payload.found)) ? Number(payload.found) : payload.rows.length;
+  return { found, rows: payload.rows };
+}
+
+async function loadFromStateDir(attach, deps) {
   const stateDir = resolveStateDir(
     attach,
     deps,
@@ -262,11 +291,17 @@ export async function diagnoseOmpSessions(attach, deps = {}) {
   if (!attach?.enabled) {
     return { status: "disabled", found: 0, mapped: 0, error: null };
   }
+  if (attach.mode === "url" && !String(attach.url || "").trim()) {
+    return { status: "error", found: 0, mapped: 0, error: "URL is required" };
+  }
   if (attach.mode === "state-dir" && !String(attach.stateDir || "").trim()) {
     return { status: "error", found: 0, mapped: 0, error: "State dir is required" };
   }
   try {
     const loaded = await loadOmpOccupancy(attach, deps);
+    if (loaded.invalidHelper) {
+      return { status: "error", found: 0, mapped: 0, error: "Invalid occupancy payload" };
+    }
     if (loaded.missingState) {
       return { status: "error", found: 0, mapped: 0, error: "oh-my-pi sessions not found" };
     }

--- a/server/collectors/OmpSessions.js
+++ b/server/collectors/OmpSessions.js
@@ -1,0 +1,340 @@
+/**
+ * oh-my-pi (omp) occupancy collector.
+ * Projector input rows only: source, handle, origin, midTurn unknown.
+ * Local attach reads JSONL session files under ~/.omp/agent/sessions.
+ * URL attach is not supported in this version. Never throws.
+ * Never reads history.db, agent.db, message transcripts, or credentials.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { conventionalStateDir } from "../sessionSourceRegistry.js";
+import {
+  parseBaseUrl,
+  parseSessionTime,
+  resolveStateDir,
+  resolveConfigDir,
+  readOptional,
+  sanitizeProjectorRow,
+  defaultReadFile,
+  defaultReadDir,
+  defaultStat,
+  sanitizeProbeError,
+  stampAttachRows,
+} from "./sessionIo.js";
+
+const SOURCE = "omp";
+const SESSIONS_SUBDIR = "agent/sessions";
+const PROVIDERS_FILE_NAME = "models.yml";
+const OMP_MAX_SESSION_FILES = 100;
+const OMP_SCAN_BYTE_CAP = 1_000_000;
+const OMP_SCAN_MAX_DEPTH = 4;
+
+const PROJECTOR_ROW_KEYS = [
+  "source",
+  "id",
+  "handle",
+  "originHost",
+  "originPort",
+  "lastUsedAt",
+  "midTurn",
+];
+
+export function sanitizeOmpRow(row) {
+  return sanitizeProjectorRow(row, SOURCE, PROJECTOR_ROW_KEYS);
+}
+
+/**
+ * Parse a shallow YAML-ish subset of omp's models.yml.
+ * Finds a top-level `providers:` key, then treats each deeper-indented
+ * child key as a provider id whose `baseUrl:` (or `baseURL:`) scalar value
+ * is copied into a flat { providerId: baseUrl } map.
+ * Adjacent apiKey values are never copied — only baseUrl/baseURL.
+ * @param {string} text
+ * @returns {Record<string, string>}
+ */
+export function extractOmpProviders(text) {
+  const src = String(text ?? "");
+  if (!src.trim()) return {};
+  const lines = src.split("\n");
+  let inProviders = false;
+  let providersIndent = -1;
+  const map = {};
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const indent = line.length - line.trimStart().length;
+    if (indent === 0) {
+      inProviders = trimmed === "providers:";
+      providersIndent = -1;
+      continue;
+    }
+    if (!inProviders) continue;
+    if (providersIndent === -1) {
+      providersIndent = indent;
+    }
+    if (indent < providersIndent) {
+      inProviders = false;
+      continue;
+    }
+    if (indent > providersIndent) continue;
+    const keyMatch = trimmed.match(/^([A-Za-z0-9_.-]+):\s*$/);
+    if (keyMatch) {
+      const providerId = keyMatch[1];
+      for (let j = i + 1; j < lines.length; j += 1) {
+        const childLine = lines[j];
+        const childTrimmed = childLine.trim();
+        if (!childTrimmed || childTrimmed.startsWith("#")) continue;
+        const childIndent = childLine.length - childLine.trimStart().length;
+        if (childIndent <= providersIndent) break;
+        const urlMatch = childTrimmed.match(/^(?:baseUrl|baseURL):\s*(.+)$/);
+        if (urlMatch) {
+          let value = urlMatch[1].trim();
+          if ((value.startsWith('"') && value.endsWith('"')) ||
+              (value.startsWith("'") && value.endsWith("'"))) {
+            value = value.slice(1, -1);
+          }
+          if (value) map[providerId] = value;
+          break;
+        }
+      }
+    }
+  }
+  return map;
+}
+
+/**
+ * Parse JSONL session text into metadata-only session objects.
+ * Reads title, model_change, session, and timestamp fields only.
+ * Ignores message/custom/thinking_level_change/mode_change event content.
+ * @param {string} text
+ * @param {string} fileName
+ * @returns {{ id: string, handle: string, model: string, lastUsedAt: number | null } | null}
+ */
+export function parseOmpSessionJsonl(text, fileName, fileMtime) {
+  const src = String(text ?? "");
+  if (!src) return null;
+  let title = "";
+  let model = "";
+  let sessionId = "";
+  let lastUsedAt = null;
+  const lines = src.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let event;
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      // Torn trailing line from byte cap or live append — skip silently.
+      continue;
+    }
+    if (!event || typeof event !== "object") continue;
+    const ts = parseSessionTime(event.timestamp ?? event.updatedAt ?? event.createdAt);
+    if (ts != null && (lastUsedAt == null || ts > lastUsedAt)) lastUsedAt = ts;
+    const type = event.type ?? event.event;
+    if (type === "title" || (event.title != null && typeof event.title === "object")) {
+      const titleValue = event.title?.title ?? event.title;
+      if (typeof titleValue === "string" && titleValue.trim()) title = titleValue.trim();
+    }
+    if (type === "model_change" || event.model != null) {
+      const modelValue = event.model_change?.model ?? event.model;
+      if (typeof modelValue === "string" && modelValue.trim()) model = modelValue.trim();
+    }
+    if (type === "session" || event.session != null) {
+      const idValue = event.session?.id ?? event.id;
+      if (typeof idValue === "string" && idValue.trim()) sessionId = idValue.trim();
+    }
+  }
+  if (!sessionId) sessionId = uuidFromFileName(fileName);
+  if (!sessionId) return null;
+  if (!title) title = `omp-${sessionId.slice(0, 8).toLowerCase()}`;
+  if (lastUsedAt == null && typeof fileMtime === "number") lastUsedAt = fileMtime;
+  return { id: sessionId, handle: title, model, lastUsedAt };
+}
+
+/**
+ * @param {object[]} parsed
+ * @param {Record<string, string>} providers
+ * @returns {object[]}
+ */
+export function mapOmpSessions(parsed, providers) {
+  const list = Array.isArray(parsed) ? parsed : [];
+  const byId = providers && typeof providers === "object" ? providers : {};
+  const rows = [];
+  for (const item of list) {
+    const row = mapOneSession(item, byId);
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+function mapOneSession(item, providers) {
+  if (!item || typeof item !== "object") return null;
+  const providerId = providerIdFromModel(item.model);
+  const origin = providerId ? parseBaseUrl(providers[providerId] ?? "") : null;
+  const mapped = {
+    source: SOURCE,
+    id: item.id || item.handle,
+    handle: item.handle || "",
+    midTurn: "unknown",
+  };
+  if (origin) {
+    mapped.originHost = origin.host;
+    mapped.originPort = origin.port;
+  }
+  if (item.lastUsedAt != null) mapped.lastUsedAt = item.lastUsedAt;
+  return mapped;
+}
+
+function providerIdFromModel(model) {
+  if (typeof model !== "string" || !model.trim()) return "";
+  const slashIndex = model.indexOf("/");
+  return slashIndex > 0 ? model.slice(0, slashIndex).trim() : "";
+}
+
+function uuidFromFileName(fileName) {
+  const base = path.basename(String(fileName || ""), ".jsonl");
+  const uuidMatch = base.match(/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/);
+  if (uuidMatch) return uuidMatch[1];
+  const shortMatch = base.match(/^([A-Za-z0-9-]{8,})/);
+  return shortMatch ? shortMatch[1] : "";
+}
+
+/**
+ * One read for collect and diagnose.
+ * @returns {Promise<{ missingState: boolean, invalidHelper: boolean, found: number, rows: object[] }>}
+ */
+export async function loadOmpOccupancy(attach, deps = {}) {
+  const stateDir = resolveStateDir(
+    attach,
+    deps,
+    deps.conventionalStateDir ?? conventionalStateDir(SOURCE)
+  );
+  const configDir = resolveConfigDir(SOURCE, deps);
+  const sessionsDir = stateDir ? path.join(stateDir, SESSIONS_SUBDIR) : "";
+  if (!sessionsDir) {
+    return { missingState: true, invalidHelper: false, found: 0, rows: [] };
+  }
+  const readFile = deps.readFile ?? defaultReadFile;
+  const readDir = deps.readDir ?? defaultReadDir;
+  const stat = deps.stat ?? defaultStat;
+  try {
+    const info = await stat(sessionsDir);
+    if (!info.isDirectory()) {
+      return { missingState: true, invalidHelper: false, found: 0, rows: [] };
+    }
+  } catch {
+    return { missingState: true, invalidHelper: false, found: 0, rows: [] };
+  }
+  const providers = await loadProviders(configDir, readFile);
+  const files = await scanOmpSessions(sessionsDir, deps, readDir, stat);
+  const readResults = await Promise.all(
+    files.map(async (fileEntry) => {
+      try {
+        const raw = await readFile(fileEntry.path);
+        const text = String(raw).slice(0, OMP_SCAN_BYTE_CAP);
+        return parseOmpSessionJsonl(text, path.basename(fileEntry.path), fileEntry.mtime);
+      } catch {
+        // One bad file never aborts the sweep. Live jsonl appends may torn-truncate.
+        return null;
+      }
+    })
+  );
+  const parsed = readResults.filter((s) => s != null);
+  const rows = stampAttachRows(mapOmpSessions(parsed, providers), attach).map(sanitizeOmpRow);
+  return { missingState: false, invalidHelper: false, found: parsed.length, rows };
+}
+
+export async function collectOmpSessions(attach, deps = {}) {
+  try {
+    if (!attach?.enabled) return [];
+    return (await loadOmpOccupancy(attach, deps)).rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * @returns {Promise<{ status: "disabled" | "ok" | "error", found: number, mapped: number, error: string | null }>}
+ */
+export async function diagnoseOmpSessions(attach, deps = {}) {
+  if (!attach?.enabled) {
+    return { status: "disabled", found: 0, mapped: 0, error: null };
+  }
+  if (attach.mode === "state-dir" && !String(attach.stateDir || "").trim()) {
+    return { status: "error", found: 0, mapped: 0, error: "State dir is required" };
+  }
+  try {
+    const loaded = await loadOmpOccupancy(attach, deps);
+    if (loaded.missingState) {
+      return { status: "error", found: 0, mapped: 0, error: "oh-my-pi sessions not found" };
+    }
+    return {
+      status: "ok",
+      found: loaded.found,
+      mapped: deps.countMapped?.(loaded.rows) ?? loaded.rows.length,
+      error: null,
+    };
+  } catch (err) {
+    return { status: "error", found: 0, mapped: 0, error: sanitizeProbeError(err) };
+  }
+}
+
+async function loadProviders(configDir, readFile) {
+  if (!configDir) return {};
+  const raw = await readOptional(readFile, path.join(configDir, PROVIDERS_FILE_NAME));
+  if (!raw) return {};
+  try {
+    return extractOmpProviders(raw);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Recursively discover .jsonl files under sessionsDir up to OMP_SCAN_MAX_DEPTH.
+ * Symlink-loop guard via visited realpaths. Sort newest-first by mtime.
+ * Slice to OMP_MAX_SESSION_FILES.
+ * @returns {Promise<string[]>}
+ */
+async function scanOmpSessions(sessionsDir, deps, readDir, stat) {
+  const results = [];
+  const visited = new Set();
+  const realpath = deps.realpath ?? ((p) => fs.realpathSync(p));
+  async function walk(dir, depth) {
+    if (depth > OMP_SCAN_MAX_DEPTH) return;
+    let real;
+    try {
+      real = realpath(dir);
+    } catch {
+      return;
+    }
+    if (visited.has(real)) return;
+    visited.add(real);
+    let entries;
+    try {
+      entries = await readDir(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry || entry.startsWith(".")) continue;
+      const fullPath = path.join(dir, entry);
+      let info;
+      try {
+        info = await stat(fullPath);
+      } catch {
+        continue;
+      }
+      if (info.isDirectory()) {
+        await walk(fullPath, depth + 1);
+      } else if (info.isFile() && entry.endsWith(".jsonl")) {
+        results.push({ path: fullPath, mtime: info.mtimeMs });
+      }
+    }
+  }
+  await walk(sessionsDir, 0);
+  results.sort((a, b) => b.mtime - a.mtime);
+  return results.slice(0, OMP_MAX_SESSION_FILES);
+}

--- a/server/collectors/OpenClawSessions.js
+++ b/server/collectors/OpenClawSessions.js
@@ -1,0 +1,227 @@
+/**
+ * OpenClaw conversation collector.
+ * Projector input rows only: source, handle, origin, midTurn.
+ * Occupancy is hasActiveRun (or status===running). Never transcripts. Never throws.
+ */
+import path from "node:path";
+import { conventionalStateDir } from "../sessionSources.js";
+import {
+  parseBaseUrl,
+  resolveStateDir,
+  defaultReadFile,
+  defaultReadDir,
+  readOptional,
+  normalizeSessionList,
+  sanitizeProbeError,
+  sessionLastUsedAt,
+  sessionAgent,
+  applySessionContext,
+  stampAttachRows,
+} from "./sessionIo.js";
+import { defaultOpenClawGatewayRpc, gatewayDeviceKey } from "./openclawGateway.js";
+
+const HANDLE_FIELDS = ["label", "displayName", "key"];
+
+/**
+ * @param {unknown} sessions
+ * @param {Record<string, { baseUrl?: string }>} providers
+ * @returns {object[]}
+ */
+export function mapOpenClawSessions(sessions, providers) {
+  const list = normalizeSessions(sessions);
+  const byId = providers && typeof providers === "object" ? providers : {};
+  const rows = [];
+  for (const item of list) {
+    const row = mapOneSession(item, byId);
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+/**
+ * @param {{ enabled?: boolean, mode?: string, url?: string, stateDir?: string }} attach
+ * @param {object} [deps]
+ * @returns {Promise<object[]>}
+ */
+export async function collectOpenClawSessions(attach, deps = {}) {
+  try {
+    if (!attach?.enabled) return [];
+    const loaded = await loadOpenClawPayload(attach, deps);
+    return stampAttachRows(mapOpenClawSessions(loaded.sessions, loaded.providers), attach);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Connectivity probe for Settings. Counts only — never session handles or transcripts.
+ * @returns {Promise<{ status: "disabled" | "ok" | "error", found: number, mapped: number, error: string | null }>}
+ */
+export async function diagnoseOpenClawSessions(attach, deps = {}) {
+  if (!attach?.enabled) {
+    return { status: "disabled", found: 0, mapped: 0, error: null };
+  }
+  if (attach.mode === "url" && !String(attach.url || "").trim()) {
+    return { status: "error", found: 0, mapped: 0, error: "URL is required" };
+  }
+  if (attach.mode === "state-dir" && !String(attach.stateDir || "").trim()) {
+    return { status: "error", found: 0, mapped: 0, error: "State dir is required" };
+  }
+  try {
+    const loaded = await loadOpenClawPayload(attach, deps);
+    if (attach.mode !== "url" && loaded.missingConfig) {
+      return { status: "error", found: 0, mapped: 0, error: "OpenClaw state not found" };
+    }
+    const list = normalizeSessions(loaded.sessions);
+    const rows = stampAttachRows(mapOpenClawSessions(loaded.sessions, loaded.providers), attach);
+    return {
+      status: "ok",
+      found: list.length,
+      mapped: deps.countMapped?.(rows) ?? rows.length,
+      error: null,
+    };
+  } catch (err) {
+    return { status: "error", found: 0, mapped: 0, error: sanitizeProbeError(err) };
+  }
+}
+
+function mapOneSession(session, providers) {
+  if (!session || typeof session !== "object") return null;
+  const origin = parseBaseUrl(providers[session.modelProvider]?.baseUrl);
+  if (!origin) return null;
+  const handle = sessionHandle(session);
+  if (!handle) return null;
+  const lastUsedAt = sessionLastUsedAt(session);
+  const agent = sessionAgent(session);
+  const mapped = {
+    source: "openclaw",
+    id: sessionIdentity(session) || handle,
+    handle,
+    originHost: origin.host,
+    originPort: origin.port,
+    midTurn: midTurnOf(session),
+  };
+  if (lastUsedAt != null) mapped.lastUsedAt = lastUsedAt;
+  if (agent) mapped.agent = agent;
+  return applySessionContext(mapped, session);
+}
+
+function sessionIdentity(session) {
+  for (const field of ["key", "sessionId", "id"]) {
+    const value = session[field];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function sessionHandle(session) {
+  for (const field of HANDLE_FIELDS) {
+    const value = session[field];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function midTurnOf(session) {
+  if (session.hasActiveRun === true) return true;
+  if (session.hasActiveRun === false) return false;
+  if (session.status === "running") return true;
+  return "unknown";
+}
+
+function normalizeSessions(sessions) {
+  const listed = normalizeSessionList(sessions);
+  if (listed) return listed;
+  if (sessions && typeof sessions === "object") return sessionsFromMap(sessions);
+  return [];
+}
+
+function sessionsFromMap(store) {
+  const rows = [];
+  for (const [key, value] of Object.entries(store)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    rows.push({ key, ...value });
+  }
+  return rows;
+}
+
+async function loadOpenClawPayload(attach, deps) {
+  if (attach.mode === "url") return loadFromUrl(attach, deps);
+  return loadFromStateDir(attach, deps);
+}
+
+async function loadFromUrl(attach, deps) {
+  if (typeof deps.gatewayRpc === "function") {
+    return unwrapGatewayPayload(await deps.gatewayRpc(attach.url, deps.token));
+  }
+  if (typeof deps.fetchJson === "function") {
+    return unwrapGatewayPayload(await deps.fetchJson(attach.url, { token: deps.token }));
+  }
+  return unwrapGatewayPayload(
+    await defaultOpenClawGatewayRpc(attach.url, deps.token, {
+      deviceKey: gatewayDeviceKey(attach.url, attach.id),
+    })
+  );
+}
+
+function unwrapGatewayPayload(payload) {
+  if (!payload || typeof payload !== "object") return { sessions: [], providers: {} };
+  const sessions = Array.isArray(payload)
+    ? payload
+    : (normalizeSessionList(payload.sessions) ?? payload.sessions ?? []);
+  return {
+    sessions,
+    providers: payload.providers ?? payload.models?.providers ?? {},
+  };
+}
+
+async function loadAgentSessionStores(dir, readFile, readDir) {
+  let names = [];
+  try {
+    names = await readDir(path.join(dir, "agents"));
+  } catch {
+    return {};
+  }
+  const rows = [];
+  for (const entry of names) {
+    const name = typeof entry === "string" ? entry : entry?.name;
+    if (!name || name.startsWith(".")) continue;
+    const raw = await readOptional(readFile, path.join(dir, "agents", name, "sessions", "sessions.json"));
+    if (!raw) continue;
+    try {
+      for (const session of normalizeSessions(JSON.parse(raw))) {
+        if (!session || typeof session !== "object") continue;
+        rows.push(session.agentId ? session : { ...session, agentId: name });
+      }
+    } catch {
+      /* skip corrupt agent store */
+    }
+  }
+  return rows;
+}
+
+async function loadFromStateDir(attach, deps) {
+  const dir = resolveStateDir(
+    attach,
+    deps,
+    deps.conventionalStateDir ?? conventionalStateDir("openclaw")
+  );
+  if (!dir) return { sessions: [], providers: {}, missingConfig: true };
+  const readFile = deps.readFile ?? defaultReadFile;
+  const readDir = deps.readDir ?? defaultReadDir;
+  const configRaw = await readOptional(readFile, path.join(dir, "openclaw.json"));
+  if (!configRaw) return { sessions: [], providers: {}, missingConfig: true };
+  const config = JSON.parse(configRaw);
+  const siblingRaw = await readOptional(readFile, path.join(dir, "sessions.json"));
+  let sessionsRaw;
+  if (siblingRaw) {
+    sessionsRaw = JSON.parse(siblingRaw);
+  } else {
+    sessionsRaw = await loadAgentSessionStores(dir, readFile, readDir);
+  }
+  return {
+    sessions: sessionsRaw?.sessions ?? sessionsRaw,
+    providers: config?.models?.providers ?? {},
+    missingConfig: false,
+  };
+}

--- a/server/collectors/OpenCodeSessions.js
+++ b/server/collectors/OpenCodeSessions.js
@@ -1,0 +1,372 @@
+/**
+ * OpenCode occupancy collector.
+ * Projector input rows only: source, handle, origin, midTurn unknown.
+ * Local attach reads sqlite session rows. URL attach polls a helper.
+ * Never throws. Never reads transcript tables.
+ */
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { conventionalStateDir } from "../sessionSourceRegistry.js";
+import {
+  parseBaseUrl,
+  parseSessionTime,
+  resolveStateDir,
+  resolveConfigDir,
+  readOptional,
+  sanitizeProjectorRow,
+  defaultReadFile,
+  defaultFetchJson,
+  sanitizeProbeError,
+  stampAttachRows,
+  applySessionContext,
+} from "./sessionIo.js";
+
+const SOURCE = "opencode";
+const MAX_HELPER_ROWS = 500;
+const SESSION_COLUMNS = ["id", "title", "model", "time_updated", "tokens_input"];
+const PROJECTOR_ROW_KEYS = [
+  "source",
+  "id",
+  "handle",
+  "originHost",
+  "originPort",
+  "lastUsedAt",
+  "midTurn",
+  "contextUsed",
+  "contextWindow",
+  "contextApprox",
+];
+const BUSY_RETRY_MS = 50;
+
+export function sanitizeOpenCodeRow(row) {
+  return sanitizeProjectorRow(row, SOURCE, PROJECTOR_ROW_KEYS);
+}
+
+/**
+ * Parse JSON with `//` comments and block comments. Strings are left intact.
+ * Trailing commas outside strings are stripped.
+ * @param {string} text
+ */
+export function parseJsonc(text) {
+  return JSON.parse(stripTrailingCommas(stripJsoncComments(String(text ?? ""))));
+}
+
+/**
+ * @param {unknown} sessions
+ * @param {Record<string, { options?: { baseURL?: string, baseUrl?: string } }>} providers
+ */
+export function mapOpenCodeSessions(sessions, providers) {
+  const list = Array.isArray(sessions) ? sessions : [];
+  const byId = providers && typeof providers === "object" ? providers : {};
+  const rows = [];
+  for (const item of list) {
+    const row = mapOneSession(item, byId);
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+/**
+ * One sqlite/helper read for collect, diagnose, and the occupancy helper.
+ * @returns {Promise<{ missingState: boolean, invalidHelper: boolean, found: number, rows: object[] }>}
+ */
+export async function loadOpenCodeOccupancy(attach, deps = {}) {
+  const loaded = await loadOpenCodePayload(attach, deps);
+  const rows = stampMapped(loaded, attach).map(sanitizeOpenCodeRow);
+  const found = loaded.found ?? (Array.isArray(loaded.sessions) ? loaded.sessions.length : rows.length);
+  return {
+    missingState: Boolean(loaded.missingState),
+    invalidHelper: Boolean(loaded.invalidHelper),
+    found,
+    rows,
+  };
+}
+
+export async function collectOpenCodeSessions(attach, deps = {}) {
+  try {
+    if (!attach?.enabled) return [];
+    return (await loadOpenCodeOccupancy(attach, deps)).rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * @returns {Promise<{ status: "disabled" | "ok" | "error", found: number, mapped: number, error: string | null }>}
+ */
+export async function diagnoseOpenCodeSessions(attach, deps = {}) {
+  if (!attach?.enabled) {
+    return { status: "disabled", found: 0, mapped: 0, error: null };
+  }
+  if (attach.mode === "url" && !String(attach.url || "").trim()) {
+    return { status: "error", found: 0, mapped: 0, error: "URL is required" };
+  }
+  if (attach.mode === "state-dir" && !String(attach.stateDir || "").trim()) {
+    return { status: "error", found: 0, mapped: 0, error: "State dir is required" };
+  }
+  try {
+    const loaded = await loadOpenCodeOccupancy(attach, deps);
+    if (loaded.invalidHelper) {
+      return { status: "error", found: 0, mapped: 0, error: "Invalid occupancy payload" };
+    }
+    if (attach.mode !== "url" && loaded.missingState) {
+      return { status: "error", found: 0, mapped: 0, error: "OpenCode state not found" };
+    }
+    return {
+      status: "ok",
+      found: loaded.found,
+      mapped: deps.countMapped?.(loaded.rows) ?? loaded.rows.length,
+      error: null,
+    };
+  } catch (err) {
+    return { status: "error", found: 0, mapped: 0, error: sanitizeProbeError(err) };
+  }
+}
+
+function stampMapped(loaded, attach) {
+  if (loaded.preMapped) return stampAttachRows(loaded.preMapped, attach);
+  return stampAttachRows(mapOpenCodeSessions(loaded.sessions, loaded.providers), attach);
+}
+
+function mapOneSession(session, providers) {
+  if (!session || typeof session !== "object") return null;
+  const handle = typeof session.title === "string" ? session.title.trim() : "";
+  if (!handle) return null;
+  const providerId = providerIdFromModel(session.model);
+  if (!providerId) return null;
+  const origin = parseBaseUrl(providerBaseUrl(providers[providerId]));
+  if (!origin) return null;
+  const lastUsedAt = parseSessionTime(session.time_updated) ?? parseSessionTime(session.updatedAt);
+  const mapped = {
+    source: SOURCE,
+    id: sessionIdentity(session) || handle,
+    handle,
+    originHost: origin.host,
+    originPort: origin.port,
+    midTurn: "unknown",
+  };
+  if (lastUsedAt != null) mapped.lastUsedAt = lastUsedAt;
+  // tokens_input is cumulative session usage, not KV-cache fill.
+  return applySessionContext(mapped, {
+    input_tokens: session.tokens_input,
+    totalTokensFresh: false,
+  });
+}
+
+function sessionIdentity(session) {
+  const value = session.id;
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function providerIdFromModel(model) {
+  if (model == null || model === "") return "";
+  let parsed = model;
+  if (typeof model === "string") {
+    try {
+      parsed = JSON.parse(model);
+    } catch {
+      return "";
+    }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "";
+  const id = parsed.providerID ?? parsed.providerId;
+  return typeof id === "string" && id.trim() ? id.trim() : "";
+}
+
+function providerBaseUrl(entry) {
+  if (!entry || typeof entry !== "object") return "";
+  const options = entry.options && typeof entry.options === "object" ? entry.options : {};
+  const raw = options.baseURL ?? options.baseUrl ?? entry.baseURL ?? entry.baseUrl;
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+async function loadOpenCodePayload(attach, deps) {
+  if (attach.mode === "url") return loadFromUrl(attach, deps);
+  return loadFromStateDir(attach, deps);
+}
+
+async function loadFromUrl(attach, deps) {
+  const fetchJson = deps.fetchJson ?? defaultFetchJson;
+  const payload = await fetchJson(String(attach.url || "").trim(), { token: deps.token });
+  const parsed = parseHelperPayload(payload);
+  if (parsed.error) return { sessions: [], providers: {}, preMapped: [], found: 0, invalidHelper: true };
+  const preMapped = parsed.rows
+    .filter((row) => row && typeof row === "object")
+    .map((row) => sanitizeOpenCodeRow(row));
+  return {
+    sessions: parsed.rows,
+    providers: {},
+    preMapped,
+    found: parsed.found,
+  };
+}
+
+function parseHelperPayload(payload) {
+  if (Array.isArray(payload)) {
+    if (payload.length > MAX_HELPER_ROWS) return { error: true };
+    return { found: payload.length, rows: payload };
+  }
+  if (!payload || typeof payload !== "object") return { error: true };
+  if (!Array.isArray(payload.rows)) return { error: true };
+  if (payload.rows.length > MAX_HELPER_ROWS) return { error: true };
+  const found = Number.isFinite(Number(payload.found)) ? Number(payload.found) : payload.rows.length;
+  return { found, rows: payload.rows };
+}
+
+async function loadFromStateDir(attach, deps) {
+  const dataDir = resolveStateDir(
+    attach,
+    deps,
+    deps.conventionalStateDir ?? conventionalStateDir(SOURCE)
+  );
+  const configDir = resolveConfigDir(SOURCE, deps);
+  if (!dataDir) return { sessions: [], providers: {}, missingState: true };
+  const readFile = deps.readFile ?? defaultReadFile;
+  const providers = await loadProviders(configDir, readFile);
+  try {
+    const sessions = await readSessionRows(path.join(dataDir, "opencode.db"), deps);
+    return { sessions, providers, missingState: false };
+  } catch (err) {
+    if (err?.code === "ENOENT") return { sessions: [], providers, missingState: true };
+    throw err;
+  }
+}
+
+async function loadProviders(configDir, readFile) {
+  if (!configDir) return {};
+  for (const name of ["opencode.jsonc", "opencode.json"]) {
+    const raw = await readOptional(readFile, path.join(configDir, name));
+    if (!raw) continue;
+    try {
+      const parsed = name.endsWith(".jsonc") ? parseJsonc(raw) : JSON.parse(raw);
+      const providers = parsed?.provider;
+      if (providers && typeof providers === "object") return providers;
+    } catch {
+      /* try the next config name */
+    }
+  }
+  return {};
+}
+
+async function readSessionRows(dbPath, deps, attempt = 0) {
+  const open = deps.openDatabase ?? defaultOpenDatabase;
+  let db;
+  try {
+    db = open(dbPath);
+  } catch (err) {
+    if (isBusy(err) && attempt < 1) {
+      await delay(BUSY_RETRY_MS);
+      return readSessionRows(dbPath, deps, attempt + 1);
+    }
+    throw err;
+  }
+  try {
+    const columns = tableColumns(db, "session");
+    if (columns.length === 0) return [];
+    const selected = SESSION_COLUMNS.filter((name) => columns.includes(name));
+    if (selected.length === 0) return [];
+    let sql = `SELECT ${selected.join(", ")} FROM session`;
+    if (columns.includes("time_updated")) {
+      sql += ` ORDER BY time_updated DESC LIMIT ${MAX_HELPER_ROWS}`;
+    } else {
+      sql += ` LIMIT ${MAX_HELPER_ROWS}`;
+    }
+    return db.prepare(sql).all() ?? [];
+  } catch (err) {
+    if (isBusy(err) && attempt < 1) {
+      db.close?.();
+      db = null;
+      await delay(BUSY_RETRY_MS);
+      return readSessionRows(dbPath, deps, attempt + 1);
+    }
+    throw err;
+  } finally {
+    db?.close?.();
+  }
+}
+
+function tableColumns(db, table) {
+  const info = db.prepare(`PRAGMA table_info(${table})`).all() ?? [];
+  return info
+    .map((row) => (typeof row?.name === "string" ? row.name : ""))
+    .filter(Boolean);
+}
+
+function defaultOpenDatabase(dbPath) {
+  return new DatabaseSync(dbPath, { readOnly: true, timeout: 1000 });
+}
+
+function isBusy(err) {
+  const code = String(err?.code ?? "");
+  return code.includes("BUSY") || /busy/i.test(String(err ?? ""));
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function stripTrailingCommas(src) {
+  let out = "";
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < src.length; i += 1) {
+    const c = src[i];
+    if (inString) {
+      out += c;
+      if (escape) escape = false;
+      else if (c === "\\") escape = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      continue;
+    }
+    if (c === ",") {
+      let j = i + 1;
+      while (j < src.length && /\s/.test(src[j])) j += 1;
+      if (src[j] === "}" || src[j] === "]") continue;
+    }
+    out += c;
+  }
+  return out;
+}
+
+function stripJsoncComments(src) {
+  let out = "";
+  let i = 0;
+  let inString = false;
+  let escape = false;
+  while (i < src.length) {
+    const c = src[i];
+    if (inString) {
+      out += c;
+      if (escape) escape = false;
+      else if (c === "\\") escape = true;
+      else if (c === '"') inString = false;
+      i += 1;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      i += 1;
+      continue;
+    }
+    if (c === "/" && src[i + 1] === "/") {
+      i += 2;
+      while (i < src.length && src[i] !== "\n") i += 1;
+      continue;
+    }
+    if (c === "/" && src[i + 1] === "*") {
+      i += 2;
+      while (i < src.length && !(src[i] === "*" && src[i + 1] === "/")) i += 1;
+      i += 2;
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}

--- a/server/collectors/__tests__/HermesSessions.test.js
+++ b/server/collectors/__tests__/HermesSessions.test.js
@@ -1,0 +1,735 @@
+/**
+ * Hermes Agent conversation reader (U4): dashboard sessions → projector rows.
+ *
+ * Recency is_active is never mid-turn. Fixture JSON / injected loaders only.
+ * Run: node --test server/collectors/__tests__/HermesSessions.test.js
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  mapHermesSessions,
+  collectHermesSessions,
+  diagnoseHermesSessions,
+  resetHermesAuthCache,
+} from "../HermesSessions.js";
+
+const MODULE_PATH = fileURLToPath(new URL("../HermesSessions.js", import.meta.url));
+
+const PROFILE = { model: { base_url: "http://127.0.0.1:8888/v1" } };
+
+function session(overrides = {}) {
+  return {
+    id: "sess-1",
+    source: "cli",
+    model: "local-model",
+    title: "Coding session",
+    is_active: true,
+    billing_base_url: "http://127.0.0.1:8888/v1",
+    preview: "user asked a secret question",
+    ...overrides,
+  };
+}
+
+function expectedRow(overrides = {}) {
+  return {
+    source: "hermes",
+    id: "sess-1",
+    handle: "Coding session",
+    originHost: "127.0.0.1",
+    originPort: 8888,
+    midTurn: "unknown",
+    ...overrides,
+  };
+}
+
+test("updated_at is lastUsedAt; is_active is still not mid-turn", () => {
+  const rows = mapHermesSessions([
+    session({ is_active: true, updated_at: "2024-01-15T12:00:00.000Z" }),
+  ]);
+  assert.equal(rows[0].midTurn, "unknown");
+  assert.equal(rows[0].lastUsedAt, Date.parse("2024-01-15T12:00:00.000Z"));
+});
+
+test("last_prompt_tokens is contextUsed; preview is never copied", () => {
+  const rows = mapHermesSessions([
+    session({ last_prompt_tokens: 42_000, input_tokens: 900_000, preview: "secret" }),
+  ]);
+  assert.equal(rows[0].contextUsed, 42000);
+  assert.equal("contextWindow" in rows[0], false);
+  assert.equal(JSON.stringify(rows).includes("secret"), false);
+});
+
+test("is_active true without a mid-turn field is midTurn unknown", () => {
+  const rows = mapHermesSessions([session({ is_active: true })]);
+  assert.deepEqual(rows, [expectedRow({ midTurn: "unknown" })]);
+});
+
+test("origin from billing_base_url is still emitted when midTurn is unknown", () => {
+  const rows = mapHermesSessions([session({ is_active: true })]);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].originHost, "127.0.0.1");
+  assert.equal(rows[0].originPort, 8888);
+  assert.equal(rows[0].midTurn, "unknown");
+  assert.equal(rows[0].source, "hermes");
+});
+
+test("billing_base_url http://127.0.0.1:8888/v1 → origin 127.0.0.1:8888", () => {
+  const rows = mapHermesSessions([
+    session({ billing_base_url: "http://127.0.0.1:8888/v1" }),
+  ]);
+  assert.equal(rows[0].originHost, "127.0.0.1");
+  assert.equal(rows[0].originPort, 8888);
+});
+
+test("is_active true + status working is midTurn true", () => {
+  const rows = mapHermesSessions([
+    session({ is_active: true, status: "working" }),
+  ]);
+  assert.deepEqual(rows, [expectedRow({ midTurn: true })]);
+});
+
+test("status running is midTurn true; is_active is ignored", () => {
+  const rows = mapHermesSessions([
+    session({ is_active: false, status: "running" }),
+  ]);
+  assert.equal(rows[0].midTurn, true);
+});
+
+test("running true is midTurn true; is_active is still ignored", () => {
+  const rows = mapHermesSessions([
+    session({ is_active: false, running: true }),
+  ]);
+  assert.equal(rows[0].midTurn, true);
+});
+
+test("running false without status stays unknown, never stalled", () => {
+  const rows = mapHermesSessions([
+    session({ is_active: true, running: false }),
+  ]);
+  assert.equal(rows[0].midTurn, "unknown");
+});
+
+test("handle is title; preview is absent from the JSON row", () => {
+  const rows = mapHermesSessions([
+    session({
+      title: "Topic A",
+      preview: "secret transcript body",
+    }),
+  ]);
+  assert.equal(rows[0].handle, "Topic A");
+  const json = JSON.stringify(rows);
+  assert.equal(json.includes("secret transcript body"), false);
+  assert.equal(json.includes("preview"), false);
+  assert.deepEqual(Object.keys(rows[0]).sort(), [
+    "handle",
+    "id",
+    "midTurn",
+    "originHost",
+    "originPort",
+    "source",
+  ]);
+});
+
+test("handle falls back to source, then id; preview is never the handle", () => {
+  const noTitle = mapHermesSessions([
+    session({ title: "", source: "telegram", preview: "sneaky preview" }),
+  ]);
+  assert.equal(noTitle[0].handle, "telegram");
+  assert.equal(JSON.stringify(noTitle).includes("sneaky preview"), false);
+
+  const idOnly = mapHermesSessions([
+    session({ title: "  ", source: "", id: "abc-123", preview: "body" }),
+  ]);
+  assert.equal(idOnly[0].handle, "abc-123");
+  assert.equal(JSON.stringify(idOnly).includes("body"), false);
+});
+
+test("profile model.base_url supplies origin when billing_base_url is absent", () => {
+  const { billing_base_url: _omit, ...rest } = session();
+  const rows = mapHermesSessions([rest], PROFILE);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].originHost, "127.0.0.1");
+  assert.equal(rows[0].originPort, 8888);
+});
+
+test("billing_base_url wins over profile model.base_url", () => {
+  const rows = mapHermesSessions(
+    [session({ billing_base_url: "http://10.0.0.2:4000/v1" })],
+    { model: { base_url: "http://127.0.0.1:8888/v1" } }
+  );
+  assert.equal(rows[0].originHost, "10.0.0.2");
+  assert.equal(rows[0].originPort, 4000);
+});
+
+test("session without origin URL is omitted", () => {
+  const { billing_base_url: _omit, ...rest } = session();
+  const rows = mapHermesSessions(
+    [rest, session({ title: "kept" })],
+    {}
+  );
+  assert.deepEqual(rows, [expectedRow({ handle: "kept" })]);
+});
+
+test("wrapped { sessions: [...] } list is accepted", () => {
+  const rows = mapHermesSessions({ sessions: [session({ is_active: true })] });
+  assert.equal(rows[0].midTurn, "unknown");
+  assert.equal(rows[0].handle, "Coding session");
+});
+
+test("disabled attach returns [] and does not load", async () => {
+  let loaded = false;
+  const rows = await collectHermesSessions(
+    { enabled: false, mode: "local" },
+    {
+      readFile: async () => {
+        loaded = true;
+        throw new Error("should not read");
+      },
+      fetchJson: async () => {
+        loaded = true;
+        throw new Error("should not fetch");
+      },
+      listSessions: async () => {
+        loaded = true;
+        throw new Error("should not list");
+      },
+    }
+  );
+  assert.deepEqual(rows, []);
+  assert.equal(loaded, false);
+});
+
+test("throwing fetch returns [] and does not throw", async () => {
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:9119" },
+    {
+      fetchJson: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    }
+  );
+  assert.deepEqual(rows, []);
+});
+
+test("url already pointing at /api/sessions still loads profile from the gateway origin", async () => {
+  const seen = [];
+  const { billing_base_url: _omit, ...rest } = session({ is_active: true });
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:9119/api/sessions" },
+    {
+      token: "from-deps",
+      fetchJson: async (url) => {
+        seen.push(String(url));
+        if (String(url).includes("/api/sessions")) {
+          return { sessions: [rest] };
+        }
+        if (String(url).includes("/api/config")) {
+          return PROFILE;
+        }
+        const err = new Error("HTTP 404");
+        err.status = 404;
+        throw err;
+      },
+    }
+  );
+  assert.ok(seen.some((u) => u.startsWith("http://127.0.0.1:9119/api/sessions")));
+  assert.ok(seen.includes("http://127.0.0.1:9119/api/config"));
+  assert.equal(
+    seen.some((u) => u.includes("/api/sessions/api/")),
+    false
+  );
+  assert.equal(rows[0].originHost, "127.0.0.1");
+  assert.equal(rows[0].originPort, 8888);
+});
+
+test("url mode GETs /api/sessions?limit=50 with Bearer token from deps", async () => {
+  let seenUrl;
+  let seenToken;
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:9119" },
+    {
+      token: "from-deps",
+      fetchJson: async (url, opts) => {
+        if (String(url).includes("/api/sessions")) {
+          seenUrl = url;
+          seenToken = opts.token;
+          return { sessions: [session({ is_active: true })] };
+        }
+        const err = new Error("HTTP 404");
+        err.status = 404;
+        throw err;
+      },
+    }
+  );
+  assert.equal(seenUrl, "http://127.0.0.1:9119/api/sessions?limit=50&include_cli=1");
+  assert.equal(seenToken, "from-deps");
+  assert.deepEqual(rows, [expectedRow({ midTurn: "unknown" })]);
+});
+
+test("injected listSessions is mapped; throwing listSessions returns []", async () => {
+  const listed = await collectHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:9119" },
+    {
+      listSessions: async () => [session({ status: "working" })],
+    }
+  );
+  assert.deepEqual(listed, [expectedRow({ midTurn: true })]);
+
+  const failed = await collectHermesSessions(
+    { enabled: true, mode: "local" },
+    {
+      listSessions: async () => {
+        throw new Error("boom");
+      },
+    }
+  );
+  assert.deepEqual(failed, []);
+});
+
+test("state-dir reads sessions.json + optional config.json via injected readFile", async () => {
+  const dir = "/tmp/hermes-fixture";
+  const { billing_base_url: _omit, ...rest } = session({ is_active: true });
+  const files = {
+    [`${dir}/sessions.json`]: JSON.stringify({ sessions: [rest] }),
+    [`${dir}/config.json`]: JSON.stringify(PROFILE),
+  };
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "state-dir", stateDir: dir },
+    {
+      readFile: async (filePath) => {
+        if (!(filePath in files)) {
+          const err = new Error(`ENOENT ${filePath}`);
+          err.code = "ENOENT";
+          throw err;
+        }
+        return files[filePath];
+      },
+    }
+  );
+  assert.deepEqual(rows, [expectedRow({ midTurn: "unknown" })]);
+});
+
+test("local mode reads conventional state dir; profile.json supplies base_url", async () => {
+  const dir = "/opt/hermes-home";
+  const { billing_base_url: _omit, ...rest } = session();
+  const files = {
+    [`${dir}/sessions.json`]: JSON.stringify([rest]),
+    [`${dir}/profile.json`]: JSON.stringify(PROFILE),
+  };
+  const seen = [];
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "local" },
+    {
+      conventionalStateDir: dir,
+      hostRoot: "",
+      readFile: async (filePath) => {
+        seen.push(filePath);
+        if (!(filePath in files)) {
+          const err = new Error(`ENOENT ${filePath}`);
+          err.code = "ENOENT";
+          throw err;
+        }
+        return files[filePath];
+      },
+    }
+  );
+  assert.ok(seen.some((p) => p.endsWith("sessions.json")));
+  assert.ok(seen.some((p) => p.endsWith("config.json") || p.endsWith("profile.json")));
+  assert.equal(rows[0].midTurn, "unknown");
+  assert.equal(rows[0].originHost, "127.0.0.1");
+  assert.equal(rows[0].originPort, 8888);
+});
+
+test("config.json without a base URL continues to profile.json", async () => {
+  const dir = "/tmp/hermes-profile-fallback";
+  const { billing_base_url: _omit, ...rest } = session();
+  const files = {
+    [`${dir}/sessions.json`]: JSON.stringify({ sessions: [rest] }),
+    [`${dir}/config.json`]: JSON.stringify({ theme: "dark" }),
+    [`${dir}/profile.json`]: JSON.stringify(PROFILE),
+  };
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "state-dir", stateDir: dir },
+    {
+      readFile: async (filePath) => {
+        if (!(filePath in files)) {
+          const err = new Error(`ENOENT ${filePath}`);
+          err.code = "ENOENT";
+          throw err;
+        }
+        return files[filePath];
+      },
+    }
+  );
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].originHost, "127.0.0.1");
+  assert.equal(rows[0].originPort, 8888);
+});
+
+test("url /api/config without a base URL continues to /api/profile", async () => {
+  const { billing_base_url: _omit, ...rest } = session();
+  const seen = [];
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:9119" },
+    {
+      fetchJson: async (url) => {
+        seen.push(String(url));
+        if (String(url).includes("/api/sessions")) return { sessions: [rest] };
+        if (String(url).includes("/api/config")) return { status: "ok" };
+        if (String(url).includes("/api/profile")) return PROFILE;
+        const err = new Error("HTTP 404");
+        err.status = 404;
+        throw err;
+      },
+    }
+  );
+  assert.ok(seen.includes("http://127.0.0.1:9119/api/config"));
+  assert.ok(seen.includes("http://127.0.0.1:9119/api/profile"));
+  assert.equal(rows[0].originPort, 8888);
+});
+
+test("missing state files return [] not throw", async () => {
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "state-dir", stateDir: "/no/such/hermes" },
+    {
+      readFile: async () => {
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      },
+    }
+  );
+  assert.deepEqual(rows, []);
+});
+
+test("url mode without fetchJson logs in then GETs sessions with Cookie", async () => {
+  resetHermesAuthCache();
+  const calls = [];
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:9119", username: "ops" },
+    {
+      token: "ui-password",
+      fetchResponse: async (url, opts = {}) => {
+        calls.push({ url: String(url), method: opts.method ?? "GET", cookie: opts.cookie, body: opts.body });
+        if (String(url).endsWith("/api/auth/providers")) {
+          return {
+            json: async () => ({
+              providers: [{ name: "basic", supports_password: true }],
+            }),
+            headers: { getSetCookie: () => [], get: () => null },
+          };
+        }
+        if (String(url).endsWith("/auth/password-login")) {
+          const body = JSON.parse(opts.body);
+          assert.equal(body.provider, "basic");
+          assert.equal(body.username, "ops");
+          assert.equal(body.password, "ui-password");
+          return {
+            json: async () => ({ ok: true }),
+            headers: {
+              getSetCookie: () => [
+                "hermes_session_at=abc.def; HttpOnly; Path=/",
+                "hermes_session_rt=rt.1; HttpOnly; Path=/",
+                "hermes_session_provider=basic; Path=/",
+              ],
+              get: () => null,
+            },
+          };
+        }
+        if (String(url).includes("/api/sessions")) {
+          assert.equal(
+            opts.cookie,
+            "hermes_session_at=abc.def; hermes_session_rt=rt.1; hermes_session_provider=basic"
+          );
+          return { json: async () => ({ sessions: [session({ is_active: true })] }) };
+        }
+        const err = new Error("HTTP 404");
+        err.status = 404;
+        throw err;
+      },
+    }
+  );
+  assert.equal(calls[0].url, "http://127.0.0.1:9119/api/auth/providers");
+  assert.equal(calls[1].url, "http://127.0.0.1:9119/auth/password-login");
+  assert.equal(calls[1].method, "POST");
+  assert.equal(
+    calls.some((c) => String(c.url).includes("/api/auth/login")),
+    false
+  );
+  assert.ok(calls.some((c) => c.url.includes("/api/sessions?limit=50&include_cli=1")));
+  assert.equal(rows.length, 1);
+});
+
+test("providers 401 falls back to Bearer instead of treating the token as a password", async () => {
+  resetHermesAuthCache();
+  const calls = [];
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:9119" },
+    {
+      token: "gateway-bearer",
+      fetchResponse: async (url, opts = {}) => {
+        calls.push({ url: String(url), method: opts.method ?? "GET", token: opts.token, cookie: opts.cookie });
+        if (String(url).endsWith("/api/auth/providers")) {
+          const err = new Error("HTTP 401");
+          err.status = 401;
+          throw err;
+        }
+        if (String(url).endsWith("/api/auth/login")) {
+          const err = new Error("HTTP 404");
+          err.status = 404;
+          throw err;
+        }
+        if (String(url).includes("/api/sessions")) {
+          assert.equal(opts.token, "gateway-bearer");
+          assert.equal(opts.cookie, undefined);
+          return { json: async () => ({ sessions: [session({ is_active: true })] }) };
+        }
+        const err = new Error("HTTP 404");
+        err.status = 404;
+        throw err;
+      },
+    }
+  );
+  assert.equal(calls[0].url, "http://127.0.0.1:9119/api/auth/providers");
+  assert.equal(
+    calls.some((c) => String(c.url).includes("/auth/password-login")),
+    false
+  );
+  assert.equal(rows.length, 1);
+});
+
+test("gated providers still use password-only /api/auth/login", async () => {
+  resetHermesAuthCache();
+  const calls = [];
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:8787" },
+    {
+      token: "webui-password",
+      fetchResponse: async (url, opts = {}) => {
+        calls.push({ url: String(url), method: opts.method ?? "GET", cookie: opts.cookie, body: opts.body });
+        if (String(url).endsWith("/api/auth/providers")) {
+          const err = new Error("HTTP 401");
+          err.status = 401;
+          throw err;
+        }
+        if (String(url).endsWith("/api/auth/login")) {
+          assert.equal(JSON.parse(opts.body).password, "webui-password");
+          return {
+            json: async () => ({ ok: true }),
+            headers: {
+              getSetCookie: () => ["hermes_session=webui.cookie; HttpOnly; Path=/"],
+              get: () => null,
+            },
+          };
+        }
+        if (String(url).includes("/api/sessions")) {
+          assert.equal(opts.cookie, "hermes_session=webui.cookie");
+          return { json: async () => ({ sessions: [session({ is_active: true })] }) };
+        }
+        const err = new Error("HTTP 404");
+        err.status = 404;
+        throw err;
+      },
+    }
+  );
+  assert.equal(
+    calls.some((c) => String(c.url).includes("/auth/password-login")),
+    false
+  );
+  assert.ok(calls.some((c) => String(c.url).endsWith("/api/auth/login")));
+  assert.equal(rows.length, 1);
+});
+
+test("password login defaults username to admin", async () => {
+  resetHermesAuthCache();
+  let loginBody;
+  await collectHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:9119" },
+    {
+      token: "ui-password",
+      fetchResponse: async (url, opts = {}) => {
+        if (String(url).endsWith("/api/auth/providers")) {
+          return {
+            json: async () => ({ providers: [{ name: "basic", supports_password: true }] }),
+            headers: { getSetCookie: () => [], get: () => null },
+          };
+        }
+        if (String(url).endsWith("/auth/password-login")) {
+          loginBody = JSON.parse(opts.body);
+          return {
+            json: async () => ({ ok: true }),
+            headers: {
+              getSetCookie: () => ["hermes_session_at=tok; HttpOnly; Path=/"],
+              get: () => null,
+            },
+          };
+        }
+        if (String(url).includes("/api/sessions")) {
+          return { json: async () => ({ sessions: [] }) };
+        }
+        const err = new Error("HTTP 404");
+        err.status = 404;
+        throw err;
+      },
+    }
+  );
+  assert.equal(loginBody.username, "admin");
+});
+
+test("diagnose reports HTTP 401 when Hermes login fails", async () => {
+  resetHermesAuthCache();
+  const result = await diagnoseHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:9119" },
+    {
+      token: "wrong",
+      fetchResponse: async () => {
+        const err = new Error("HTTP 401");
+        err.status = 401;
+        throw err;
+      },
+    }
+  );
+  assert.equal(result.status, "error");
+  assert.equal(result.error, "HTTP 401 (auth failed)");
+  assert.equal(result.found, 0);
+});
+
+test("CLI billing_base_url hostname origin is mapped", () => {
+  const rows = mapHermesSessions([
+    {
+      session_id: "cli-1",
+      title: "Telegram chat",
+      billing_base_url: "http://john:8888/v1",
+      is_cli_session: true,
+    },
+  ]);
+  assert.equal(rows[0].originHost, "john");
+  assert.equal(rows[0].originPort, 8888);
+  assert.equal(rows[0].handle, "Telegram chat");
+});
+
+test("diagnose JSON has counts only", async () => {
+  const result = await diagnoseHermesSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:9119" },
+    {
+      fetchJson: async (url) => {
+        if (String(url).includes("/api/sessions")) {
+          return { sessions: [session({ title: "Secret title", preview: "do not leak" })] };
+        }
+        const err = new Error("HTTP 404");
+        err.status = 404;
+        throw err;
+      },
+    }
+  );
+  const json = JSON.stringify(result);
+  assert.equal(json.includes("Secret title"), false);
+  assert.equal(json.includes("do not leak"), false);
+  assert.equal(result.status, "ok");
+  assert.equal(result.found, 1);
+  assert.equal(result.mapped, 1);
+});
+
+test("profile fallback labels the Hermes lane", () => {
+  const rows = mapHermesSessions([session()], PROFILE, "unleashed");
+  assert.equal(rows[0].agent, "unleashed");
+});
+
+test("session profile wins over fallback", () => {
+  const rows = mapHermesSessions([session({ profile: "planner" })], PROFILE, "unleashed");
+  assert.equal(rows[0].agent, "planner");
+});
+
+test("profiles/<name> state dir labels that profile", async () => {
+  const dir = "/tmp/hermes/profiles/unleashed";
+  const files = {
+    [`${dir}/sessions.json`]: JSON.stringify([session({ title: "FromUnleashed" })]),
+    [`${dir}/profile.json`]: JSON.stringify(PROFILE),
+  };
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "state-dir", stateDir: dir },
+    {
+      hostRoot: "",
+      readFile: async (filePath) => {
+        if (!(filePath in files)) {
+          const err = new Error(`ENOENT ${filePath}`);
+          err.code = "ENOENT";
+          throw err;
+        }
+        return files[filePath];
+      },
+      readDir: async () => {
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      },
+    }
+  );
+  assert.equal(rows[0].handle, "FromUnleashed");
+  assert.equal(rows[0].agent, "unleashed");
+});
+
+test("local profiles/* are collected as separate lanes", async () => {
+  const dir = "/tmp/hermes-root";
+  const files = {
+    [`${dir}/profiles/unleashed/sessions.json`]: JSON.stringify([
+      session({ id: "u1", title: "Unleashed chat" }),
+    ]),
+    [`${dir}/profiles/unleashed/profile.json`]: JSON.stringify(PROFILE),
+    [`${dir}/profiles/planner/sessions.json`]: JSON.stringify([
+      session({
+        id: "p1",
+        title: "Planner chat",
+        billing_base_url: "http://127.0.0.1:4000/v1",
+      }),
+    ]),
+    [`${dir}/profiles/planner/profile.json`]: JSON.stringify({
+      model: { base_url: "http://127.0.0.1:4000/v1" },
+    }),
+  };
+  const rows = await collectHermesSessions(
+    { enabled: true, mode: "local" },
+    {
+      conventionalStateDir: dir,
+      hostRoot: "",
+      readFile: async (filePath) => {
+        if (!(filePath in files)) {
+          const err = new Error(`ENOENT ${filePath}`);
+          err.code = "ENOENT";
+          throw err;
+        }
+        return files[filePath];
+      },
+      readDir: async (dirPath) => {
+        if (dirPath === `${dir}/profiles`) return ["unleashed", "planner"];
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      },
+    }
+  );
+  const byHandle = Object.fromEntries(rows.map((r) => [r.handle, r]));
+  assert.equal(rows.length, 2);
+  assert.equal(byHandle["Unleashed chat"].agent, "unleashed");
+  assert.equal(byHandle["Unleashed chat"].originPort, 8888);
+  assert.equal(byHandle["Planner chat"].agent, "planner");
+  assert.equal(byHandle["Planner chat"].originPort, 4000);
+});
+
+test("module has no CLI update probe, alphaclaw, or llmPorts HTTP", () => {
+  const src = readFileSync(MODULE_PATH, "utf8");
+  assert.equal(/hermes update/.test(src), false);
+  assert.equal(/check\(/.test(src), false);
+  assert.equal(/alphaclaw/i.test(src), false);
+  assert.equal(/\bmama\b/i.test(src), false);
+  assert.equal(/kalliope/i.test(src), false);
+  assert.equal(/llmPorts/.test(src), false);
+  assert.equal(/projectConversations/.test(src), false);
+  assert.equal(/OpenClawSessions/.test(src), false);
+  assert.equal(/HermesProbe/.test(src), false);
+  assert.equal(/POLL_INTERVAL_HERMES/.test(src), false);
+  assert.equal(/\/v1\/chat/.test(src), false);
+  assert.equal(/\/v1\/models/.test(src), false);
+});

--- a/server/collectors/__tests__/OmpSessions.test.js
+++ b/server/collectors/__tests__/OmpSessions.test.js
@@ -1,0 +1,544 @@
+/**
+ * oh-my-pi (omp) occupancy collector: JSONL session files + provider origins → projector rows.
+ *
+ * Injected file/dir/stat loaders — no live ~/.omp.
+ * Run: node --test server/collectors/__tests__/OmpSessions.test.js
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  extractOmpProviders,
+  parseOmpSessionJsonl,
+  mapOmpSessions,
+  collectOmpSessions,
+  diagnoseOmpSessions,
+} from "../OmpSessions.js";
+
+const JOHN_PROVIDERS = {
+  "john-ofus": "http://192.168.4.52:8888/v1",
+};
+
+function jsonlLine(obj) {
+  return JSON.stringify(obj);
+}
+
+function sessionJsonl(overrides = {}) {
+  const {
+    title = "Wrap up task",
+    model = "john-ofus/deepseek-v4-flash-dspark",
+    sessionId = "01a01604-537f-7000-90bb-3cbf3f8af435",
+    timestamp = "2026-08-18T18:10:51.196Z",
+  } = overrides;
+  const lines = [];
+  if (sessionId) lines.push(jsonlLine({ type: "session", session: { id: sessionId }, timestamp }));
+  if (title) lines.push(jsonlLine({ type: "title", title: { title }, timestamp }));
+  if (model) lines.push(jsonlLine({ type: "model_change", model_change: { model }, timestamp }));
+  return lines.join("\n");
+}
+
+function expectedRow(overrides = {}) {
+  return {
+    source: "omp",
+    id: "01a01604-537f-7000-90bb-3cbf3f8af435",
+    handle: "Wrap up task",
+    originHost: "192.168.4.52",
+    originPort: 8888,
+    midTurn: "unknown",
+    lastUsedAt: Date.parse("2026-08-18T18:10:51.196Z"),
+    ...overrides,
+  };
+}
+
+// T1: provider-origin join
+test("T1: provider-origin join maps john-ofus to 192.168.4.52:8888", () => {
+  const parsed = [parseOmpSessionJsonl(sessionJsonl(), "test.jsonl")];
+  const rows = mapOmpSessions(parsed, JOHN_PROVIDERS);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].originHost, "192.168.4.52");
+  assert.equal(rows[0].originPort, 8888);
+});
+
+// T2: cloud-only provider stays unmatched
+test("T2: cloud-only provider produces row without origin fields", () => {
+  const parsed = [parseOmpSessionJsonl(sessionJsonl({ model: "openai/gpt-4o" }), "test.jsonl")];
+  const rows = mapOmpSessions(parsed, JOHN_PROVIDERS);
+  assert.equal(rows.length, 1);
+  assert.equal("originHost" in rows[0], false);
+  assert.equal("originPort" in rows[0], false);
+});
+
+// T3: handle from title event
+test("T3: title event supplies handle; last non-empty wins", () => {
+  const jsonl = [
+    jsonlLine({ type: "title", title: { title: "First title" }, timestamp: "2026-08-18T17:00:00.000Z" }),
+    jsonlLine({ type: "title", title: { title: "Final title" }, timestamp: "2026-08-18T18:00:00.000Z" }),
+    jsonlLine({ type: "session", session: { id: "abc12345-537f-7000-90bb-3cbf3f8af435" }, timestamp: "2026-08-18T17:00:00.000Z" }),
+    jsonlLine({ type: "model_change", model_change: { model: "john-ofus/test" }, timestamp: "2026-08-18T18:00:00.000Z" }),
+  ].join("\n");
+  const parsed = [parseOmpSessionJsonl(jsonl, "test.jsonl")];
+  const rows = mapOmpSessions(parsed, JOHN_PROVIDERS);
+  assert.equal(rows[0].handle, "Final title");
+});
+
+// T4: synthetic handle fallback
+test("T4: empty title produces synthetic handle from session id", () => {
+  const jsonl = [
+    jsonlLine({ type: "session", session: { id: "01a01604-537f-7000-90bb-3cbf3f8af435" }, timestamp: "2026-08-18T17:00:00.000Z" }),
+    jsonlLine({ type: "title", title: { title: "" }, timestamp: "2026-08-18T17:00:00.000Z" }),
+    jsonlLine({ type: "model_change", model_change: { model: "john-ofus/test" }, timestamp: "2026-08-18T18:00:00.000Z" }),
+  ].join("\n");
+  const parsed = [parseOmpSessionJsonl(jsonl, "test.jsonl")];
+  const rows = mapOmpSessions(parsed, JOHN_PROVIDERS);
+  assert.equal(rows[0].handle, "omp-01a01604");
+});
+
+test("T4b: no session event falls back to filename UUID suffix", () => {
+  const jsonl = [
+    jsonlLine({ type: "title", title: { title: "" }, timestamp: "2026-08-18T17:00:00.000Z" }),
+    jsonlLine({ type: "model_change", model_change: { model: "john-ofus/test" }, timestamp: "2026-08-18T18:00:00.000Z" }),
+  ].join("\n");
+  const fileName = "2026-08-18T17-56-17-407Z_01a01604-537f-7000-90bb-3cbf3f8af435.jsonl";
+  const parsed = [parseOmpSessionJsonl(jsonl, fileName)];
+  const rows = mapOmpSessions(parsed, JOHN_PROVIDERS);
+  assert.equal(rows[0].handle, "omp-01a01604");
+});
+
+// T5: midTurn is always "unknown"
+test("T5: midTurn is always unknown string", () => {
+  const parsed = [parseOmpSessionJsonl(sessionJsonl(), "test.jsonl")];
+  const rows = mapOmpSessions(parsed, JOHN_PROVIDERS);
+  assert.equal(rows[0].midTurn, "unknown");
+  assert.equal(typeof rows[0].midTurn, "string");
+});
+
+// T6: recency from max timestamp
+test("T6: lastUsedAt uses max valid timestamp", () => {
+  const jsonl = [
+    jsonlLine({ type: "session", session: { id: "01a01604-537f-7000-90bb-3cbf3f8af435" }, timestamp: "2026-08-18T17:56:17.407Z" }),
+    jsonlLine({ type: "title", title: { title: "Test" }, timestamp: "2026-08-18T18:10:51.196Z" }),
+    jsonlLine({ type: "model_change", model_change: { model: "john-ofus/test" }, timestamp: "2026-08-18T18:05:00.000Z" }),
+  ].join("\n");
+  const parsed = [parseOmpSessionJsonl(jsonl, "test.jsonl")];
+  const rows = mapOmpSessions(parsed, JOHN_PROVIDERS);
+  assert.equal(rows[0].lastUsedAt, Date.parse("2026-08-18T18:10:51.196Z"));
+});
+
+// T7: byte-cap truncation fallback (no timestamps → null lastUsedAt, mtime fallback)
+test("T7: truncated text with no timestamps produces null lastUsedAt", () => {
+  const jsonl = '{ type: "session", session: { id: "01a01604-537f'; // torn JSON
+  const parsed = parseOmpSessionJsonl(jsonl, "2026-08-18T17-56-17-407Z_01a01604-537f-7000-90bb-3cbf3f8af435.jsonl");
+  assert.ok(parsed);
+  assert.equal(parsed.lastUsedAt, null);
+});
+
+test("T7b: mtime fallback when no valid timestamps in JSONL", () => {
+  const jsonl = [
+    jsonlLine({ type: "session", session: { id: "01a01604-537f-7000-90bb-3cbf3f8af435" } }),
+    jsonlLine({ type: "title", title: { title: "Test" } }),
+    jsonlLine({ type: "model_change", model_change: { model: "john-ofus/test" } }),
+  ].join("\n");
+  const mtime = 1723990000000;
+  const parsed = parseOmpSessionJsonl(jsonl, "test.jsonl", mtime);
+  assert.equal(parsed.lastUsedAt, mtime);
+});
+
+test("T7c: mtime does not override valid timestamps", () => {
+  const jsonl = [
+    jsonlLine({ type: "session", session: { id: "01a01604-537f-7000-90bb-3cbf3f8af435" }, timestamp: "2026-08-18T18:00:00.000Z" }),
+    jsonlLine({ type: "title", title: { title: "Test" }, timestamp: "2026-08-18T18:00:00.000Z" }),
+    jsonlLine({ type: "model_change", model_change: { model: "john-ofus/test" }, timestamp: "2026-08-18T18:00:00.000Z" }),
+  ].join("\n");
+  const mtime = 1000000000000;
+  const parsed = parseOmpSessionJsonl(jsonl, "test.jsonl", mtime);
+  assert.equal(parsed.lastUsedAt, Date.parse("2026-08-18T18:00:00.000Z"));
+});
+
+// T8: missing root hides lane
+test("T8: missing state dir returns empty rows and error diagnosis", async () => {
+  const rows = await collectOmpSessions(
+    { enabled: true, mode: "local" },
+    {
+      conventionalStateDir: "/nonexistent/omp",
+      conventionalConfigDir: "/nonexistent/omp/agent",
+      readFile: async () => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; },
+      readDir: async () => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; },
+      stat: async () => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; },
+    }
+  );
+  assert.deepEqual(rows, []);
+
+  const diag = await diagnoseOmpSessions(
+    { enabled: true, mode: "local" },
+    {
+      conventionalStateDir: "/nonexistent/omp",
+      conventionalConfigDir: "/nonexistent/omp/agent",
+      readFile: async () => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; },
+      readDir: async () => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; },
+      stat: async () => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; },
+    }
+  );
+  assert.equal(diag.status, "error");
+  assert.equal(diag.error, "oh-my-pi sessions not found");
+});
+
+// T9: url-mode graceful degradation
+test("T9: url-mode attach degrades to local collection", async () => {
+  const files = {
+    "/tmp/omp/agent/sessions/test.jsonl": sessionJsonl(),
+  };
+  const dirs = {
+    "/tmp/omp/agent/sessions": ["test.jsonl"],
+    "/tmp/omp": ["agent"],
+    "/tmp/omp/agent": ["sessions"],
+  };
+  const stats = {
+    "/tmp/omp": { isDirectory: () => true, isFile: () => false, mtimeMs: 1000 },
+    "/tmp/omp/agent": { isDirectory: () => true, isFile: () => false, mtimeMs: 1000 },
+    "/tmp/omp/agent/sessions": { isDirectory: () => true, isFile: () => false, mtimeMs: 1000 },
+    "/tmp/omp/agent/sessions/test.jsonl": { isDirectory: () => false, isFile: () => true, mtimeMs: 2000 },
+  };
+  const rows = await collectOmpSessions(
+    { enabled: true, mode: "url", id: "omp" },
+    {
+      conventionalStateDir: "/tmp/omp",
+      conventionalConfigDir: "/tmp/omp/agent",
+      readFile: async (p) => files[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+      readDir: async (p) => dirs[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+      stat: async (p) => stats[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+    }
+  );
+  assert.ok(Array.isArray(rows));
+});
+
+// T10: provider yaml extractor purity
+test("T10: extractOmpProviders never includes apiKey", () => {
+  const yaml = `providers:
+  john-ofus:
+    baseUrl: "http://192.168.4.52:8888/v1"
+    apiKey: "REDACTED-TEST-FIXTURE-NOT-A-SECRET"
+  openai:
+    baseURL: "https://api.openai.com/v1"
+    apiKey: "REDACTED-TEST-FIXTURE-NOT-A-SECRET"
+`;
+  const map = extractOmpProviders(yaml);
+  assert.equal(map["john-ofus"], "http://192.168.4.52:8888/v1");
+  assert.equal(map["openai"], "https://api.openai.com/v1");
+  assert.equal("apiKey" in map, false);
+  assert.equal(Object.values(map).some((v) => v.includes("REDACTED")), false);
+});
+
+test("T10b: broken yaml returns empty map without throwing", () => {
+  assert.deepEqual(extractOmpProviders(""), {});
+  assert.deepEqual(extractOmpProviders(null), {});
+  assert.deepEqual(extractOmpProviders("not: yaml: at: all"), {});
+  assert.deepEqual(extractOmpProviders("providers:\n  # only comments\n"), {});
+});
+
+test("T10c: duplicate provider ids resolve last-wins", () => {
+  const yaml = `providers:
+  john:
+    baseUrl: "http://first:8000/v1"
+  john:
+    baseUrl: "http://second:9000/v1"
+`;
+  const map = extractOmpProviders(yaml);
+  assert.equal(map["john"], "http://second:9000/v1");
+});
+
+// T11: file selection and depth bounds
+test("T11: file count capped at OMP_MAX_SESSION_FILES", async () => {
+  // Create a mock with >100 files
+  const files = {};
+  const dirs = { "/tmp/omp/sessions": [] };
+  const stats = {};
+  for (let i = 0; i < 150; i += 1) {
+    const name = `session-${i}.jsonl`;
+    files[`/tmp/omp/sessions/${name}`] = sessionJsonl();
+    dirs["/tmp/omp/sessions"].push(name);
+    stats[`/tmp/omp/sessions/${name}`] = { isDirectory: () => false, isFile: () => true, mtimeMs: i };
+  }
+  stats["/tmp/omp/sessions"] = { isDirectory: () => true, isFile: () => false, mtimeMs: 0 };
+
+  const rows = await collectOmpSessions(
+    { enabled: true, mode: "local", id: "omp" },
+    {
+      conventionalStateDir: "/tmp/omp",
+      conventionalConfigDir: "/tmp/omp/agent",
+      readFile: async (p) => files[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+      readDir: async (p) => dirs[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+      stat: async (p) => stats[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+    }
+  );
+  // Should process at most 100 files (OMP_MAX_SESSION_FILES)
+  // Some may not produce rows if provider mapping fails, but it must not crash
+  assert.ok(Array.isArray(rows));
+});
+
+// T12: registry integration
+test("T12: registry includes omp with correct metadata", async () => {
+  const registry = await import("../../sessionSourceRegistry.js");
+  const ids = registry.sessionSourceIds();
+  assert.ok(ids.includes("omp"));
+  assert.equal(registry.kindById("omp")?.label, "oh-my-pi");
+  assert.equal(registry.conventionalStateDir("omp"), "~/.omp");
+  assert.equal(registry.conventionalConfigDir("omp"), "~/.omp/agent");
+  assert.equal(registry.kindById("omp")?.urlPlaceholder, undefined);
+});
+
+// T13: adapter wiring
+test("T13: occupancyCollectors and occupancyDiagnosers expose omp", async () => {
+  const adapters = await import("../sessionSourceAdapters.js");
+  const collectors = adapters.occupancyCollectors();
+  const diagnosers = adapters.occupancyDiagnosers();
+  assert.equal(typeof collectors.omp, "function");
+  assert.equal(typeof diagnosers.omp, "function");
+});
+
+test("T4c: no session ID and no UUID in filename returns null", () => {
+  const jsonl = [
+    jsonlLine({ type: "title", title: { title: "Test" }, timestamp: "2026-08-18T17:00:00.000Z" }),
+    jsonlLine({ type: "model_change", model_change: { model: "john-ofus/test" }, timestamp: "2026-08-18T18:00:00.000Z" }),
+  ].join("\n");
+  const parsed = parseOmpSessionJsonl(jsonl, "plain.jsonl");
+  assert.equal(parsed, null);
+});
+
+test("T4d: shortMatch fallback extracts first 8+ alnum chars from filename", () => {
+  const jsonl = [
+    jsonlLine({ type: "title", title: { title: "Test" }, timestamp: "2026-08-18T17:00:00.000Z" }),
+    jsonlLine({ type: "model_change", model_change: { model: "john-ofus/test" }, timestamp: "2026-08-18T18:00:00.000Z" }),
+  ].join("\n");
+  const parsed = parseOmpSessionJsonl(jsonl, "my-session-name.jsonl");
+  assert.ok(parsed);
+  assert.equal(parsed.id, "my-session-name");
+});
+
+// T15: empty sessions directory
+test("T15: empty sessions dir returns found=0, missingState=false", async () => {
+  const dirs = { "/tmp/omp/agent/sessions": [] };
+  const stats = {
+    "/tmp/omp/agent/sessions": { isDirectory: () => true, isFile: () => false, mtimeMs: 0 },
+  };
+  const loaded = await collectOmpSessions(
+    { enabled: true, mode: "local", id: "omp" },
+    {
+      conventionalStateDir: "/tmp/omp",
+      conventionalConfigDir: "/tmp/omp/agent",
+      readFile: async () => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; },
+      readDir: async (p) => dirs[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+      stat: async (p) => stats[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+    }
+  );
+  assert.deepEqual(loaded, []);
+});
+
+// Additional: disabled attach returns no rows
+test("disabled attach returns empty array", async () => {
+  const rows = await collectOmpSessions({ enabled: false }, {});
+  assert.deepEqual(rows, []);
+  const diag = await diagnoseOmpSessions({ enabled: false }, {});
+  assert.equal(diag.status, "disabled");
+});
+
+// Additional: message events are ignored
+test("message events are ignored for handle but timestamp contributes to recency", () => {
+  const jsonl = [
+    jsonlLine({ type: "session", session: { id: "01a01604-537f-7000-90bb-3cbf3f8af435" }, timestamp: "2026-08-18T17:00:00.000Z" }),
+    jsonlLine({ type: "title", title: { title: "Real title" }, timestamp: "2026-08-18T17:00:00.000Z" }),
+    jsonlLine({ type: "model_change", model_change: { model: "john-ofus/test" }, timestamp: "2026-08-18T17:00:00.000Z" }),
+    jsonlLine({ type: "message", message: { content: "secret prompt data" }, timestamp: "2026-08-18T19:00:00.000Z" }),
+  ].join("\n");
+  const parsed = [parseOmpSessionJsonl(jsonl, "test.jsonl")];
+  const rows = mapOmpSessions(parsed, JOHN_PROVIDERS);
+  assert.equal(rows[0].handle, "Real title");
+  assert.equal(rows[0].lastUsedAt, Date.parse("2026-08-18T19:00:00.000Z"));
+  // No message content in any row field
+  assert.equal(JSON.stringify(rows[0]).includes("secret prompt data"), false);
+});
+
+// Additional: malformed JSONL lines are skipped
+test("malformed JSONL lines are skipped without failing the session", () => {
+  const jsonl = [
+    '{ "type": "session", "session": { "id": "01a01604-537f-7000-90bb-3cbf3f8af435" }, "timestamp": "2026-08-18T17:00:00.000Z" }',
+    'this is not valid json',
+    '{ "type": "title", "title": { "title": "OK" }, "timestamp": "2026-08-18T18:00:00.000Z" }',
+    '{ "type": "model_change", "model_change": { "model": "john-ofus/test" }, "timestamp": "2026-08-18T18:00:00.000Z" }',
+  ].join("\n");
+  const parsed = [parseOmpSessionJsonl(jsonl, "test.jsonl")];
+  const rows = mapOmpSessions(parsed, JOHN_PROVIDERS);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].handle, "OK");
+});
+
+// Additional: row sanitization removes unexpected keys
+test("sanitizeOmpRow removes unexpected keys", async () => {
+  const { sanitizeOmpRow } = await import("../OmpSessions.js");
+  const sanitized = sanitizeOmpRow({
+    source: "omp",
+    id: "test",
+    handle: "test",
+    originHost: "localhost",
+    originPort: 8080,
+    midTurn: "unknown",
+    secret: "should-be-removed",
+    message: "should-be-removed",
+  });
+  assert.equal("secret" in sanitized, false);
+  assert.equal("message" in sanitized, false);
+  assert.equal(sanitized.source, "omp");
+  assert.equal(sanitized.midTurn, "unknown");
+});
+
+// Additional: state-dir mode requires stateDir
+test("state-dir mode with empty stateDir returns error", async () => {
+  const diag = await diagnoseOmpSessions(
+    { enabled: true, mode: "state-dir", stateDir: "" },
+    {}
+  );
+  assert.equal(diag.status, "error");
+  assert.equal(diag.error, "State dir is required");
+});
+
+// Additional: collect never throws
+test("collect never throws on filesystem errors", async () => {
+  const rows = await collectOmpSessions(
+    { enabled: true, mode: "local" },
+    {
+      conventionalStateDir: "/nonexistent",
+      conventionalConfigDir: "/nonexistent",
+      stat: async () => { throw new Error("EPERM"); },
+    }
+  );
+  assert.deepEqual(rows, []);
+});
+
+test("partial file read failure: one bad file does not abort the sweep", async () => {
+  const files = {
+    "/tmp/omp/agent/sessions/good.jsonl": sessionJsonl(),
+    "/tmp/omp/agent/sessions/bad.jsonl": null,
+  };
+  const dirs = { "/tmp/omp/agent/sessions": ["good.jsonl", "bad.jsonl"] };
+  const stats = {
+    "/tmp/omp/agent/sessions": { isDirectory: () => true, isFile: () => false, mtimeMs: 0 },
+    "/tmp/omp/agent/sessions/good.jsonl": { isDirectory: () => false, isFile: () => true, mtimeMs: 2000 },
+    "/tmp/omp/agent/sessions/bad.jsonl": { isDirectory: () => false, isFile: () => true, mtimeMs: 1000 },
+  };
+  const rows = await collectOmpSessions(
+    { enabled: true, mode: "local", id: "omp" },
+    {
+      conventionalStateDir: "/tmp/omp",
+      conventionalConfigDir: "/tmp/omp/agent",
+      realpath: (p) => p,
+      readFile: async (p) => {
+        if (p === "/tmp/omp/agent/sessions/bad.jsonl") {
+          const e = new Error("EIO"); e.code = "EIO"; throw e;
+        }
+        return files[p];
+      },
+      readDir: async (p) => dirs[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+      stat: async (p) => stats[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+    }
+  );
+  assert.ok(rows.length >= 1);
+  assert.equal(rows[0].handle, "Wrap up task");
+});
+
+test("found count reflects successfully parsed sessions, not files attempted", async () => {
+  const files = {
+    "/tmp/omp/agent/sessions/good.jsonl": sessionJsonl(),
+    "/tmp/omp/agent/sessions/bad.jsonl": null,
+  };
+  const dirs = { "/tmp/omp/agent/sessions": ["good.jsonl", "bad.jsonl"] };
+  const stats = {
+    "/tmp/omp/agent/sessions": { isDirectory: () => true, isFile: () => false, mtimeMs: 0 },
+    "/tmp/omp/agent/sessions/good.jsonl": { isDirectory: () => false, isFile: () => true, mtimeMs: 2000 },
+    "/tmp/omp/agent/sessions/bad.jsonl": { isDirectory: () => false, isFile: () => true, mtimeMs: 1000 },
+  };
+  const diag = await diagnoseOmpSessions(
+    { enabled: true, mode: "local", id: "omp" },
+    {
+      conventionalStateDir: "/tmp/omp",
+      conventionalConfigDir: "/tmp/omp/agent",
+      realpath: (p) => p,
+      readFile: async (p) => {
+        if (p === "/tmp/omp/agent/sessions/bad.jsonl") {
+          const e = new Error("EIO"); e.code = "EIO"; throw e;
+        }
+        return files[p];
+      },
+      readDir: async (p) => dirs[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+      stat: async (p) => stats[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+    }
+  );
+  assert.equal(diag.status, "ok");
+  assert.equal(diag.found, 1);
+});
+
+test("symlink loop: visited realpath set prevents infinite recursion", async () => {
+  // Simulate a directory that symlinks back into itself.
+  // realpath returns the same path for both the original and the symlink,
+  // so the second visit is skipped by the visited set.
+  const sessionPath = "/tmp/omp-loop/agent/sessions";
+  const linkPath = `${sessionPath}/loopback`;
+  const files = {
+    [`${sessionPath}/real.jsonl`]: sessionJsonl(),
+  };
+  const dirs = {
+    [sessionPath]: ["real.jsonl", "loopback"],
+    [linkPath]: ["loopback"], // points back to parent
+  };
+  const stats = {
+    [sessionPath]: { isDirectory: () => true, isFile: () => false, mtimeMs: 0 },
+    [`${sessionPath}/real.jsonl`]: { isDirectory: () => false, isFile: () => true, mtimeMs: 2000 },
+    [linkPath]: { isDirectory: () => true, isFile: () => false, mtimeMs: 0 },
+  };
+  // realpath maps both sessionPath and linkPath to the same real path,
+  // simulating a symlink loop.
+  const realPaths = new Map();
+  realPaths.set(sessionPath, "/real/sessions");
+  realPaths.set(linkPath, "/real/sessions");
+  const rows = await collectOmpSessions(
+    { enabled: true, mode: "local", id: "omp" },
+    {
+      conventionalStateDir: "/tmp/omp-loop",
+      conventionalConfigDir: "/tmp/omp-loop/agent",
+      realpath: (p) => realPaths.get(p) ?? p,
+      readFile: async (p) => files[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+      readDir: async (p) => dirs[p] ?? [],
+      stat: async (p) => stats[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+    }
+  );
+  // Should find exactly one session (real.jsonl), not loop infinitely.
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].source, "omp");
+});
+
+test("dot entries are skipped during recursive scan", async () => {
+  const sessionPath = "/tmp/omp-dot/agent/sessions";
+  const files = {
+    [`${sessionPath}/visible.jsonl`]: sessionJsonl(),
+    [`${sessionPath}/.hidden.jsonl`]: sessionJsonl({ sessionId: "hidden-session-id" }),
+  };
+  const dirs = {
+    [sessionPath]: ["visible.jsonl", ".hidden.jsonl"],
+  };
+  const stats = {
+    [sessionPath]: { isDirectory: () => true, isFile: () => false, mtimeMs: 0 },
+    [`${sessionPath}/visible.jsonl`]: { isDirectory: () => false, isFile: () => true, mtimeMs: 2000 },
+    [`${sessionPath}/.hidden.jsonl`]: { isDirectory: () => false, isFile: () => true, mtimeMs: 1000 },
+  };
+  const rows = await collectOmpSessions(
+    { enabled: true, mode: "local", id: "omp" },
+    {
+      conventionalStateDir: "/tmp/omp-dot",
+      conventionalConfigDir: "/tmp/omp-dot/agent",
+      realpath: (p) => p,
+      readFile: async (p) => files[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+      readDir: async (p) => dirs[p] ?? [],
+      stat: async (p) => stats[p] ?? (() => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; })(),
+    }
+  );
+  // Only the non-dot file should be collected.
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].handle, "Wrap up task");
+});

--- a/server/collectors/__tests__/OmpSessions.test.js
+++ b/server/collectors/__tests__/OmpSessions.test.js
@@ -282,7 +282,7 @@ test("T12: registry includes omp with correct metadata", async () => {
   assert.equal(registry.kindById("omp")?.label, "oh-my-pi");
   assert.equal(registry.conventionalStateDir("omp"), "~/.omp");
   assert.equal(registry.conventionalConfigDir("omp"), "~/.omp/agent");
-  assert.equal(registry.kindById("omp")?.urlPlaceholder, undefined);
+  assert.equal(registry.kindById("omp")?.urlPlaceholder, "http://127.0.0.1:8789/occupancy");
 });
 
 // T13: adapter wiring

--- a/server/collectors/__tests__/OpenClawSessions.test.js
+++ b/server/collectors/__tests__/OpenClawSessions.test.js
@@ -1,0 +1,473 @@
+/**
+ * OpenClaw conversation collector (U3): sessions + provider origins → projector rows.
+ *
+ * Fixture JSON only. Injected loaders — no live gateway, no host ~/.openclaw.
+ * Run: node --test server/collectors/__tests__/OpenClawSessions.test.js
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  mapOpenClawSessions,
+  collectOpenClawSessions,
+  diagnoseOpenClawSessions,
+} from "../OpenClawSessions.js";
+
+const MODULE_PATH = fileURLToPath(new URL("../OpenClawSessions.js", import.meta.url));
+
+const SPARK_PROVIDERS = {
+  spark: { baseUrl: "http://127.0.0.1:4000/v1" },
+};
+
+function session(overrides = {}) {
+  return {
+    key: "agent:main:telegram:topic:1",
+    label: "World Cup",
+    modelProvider: "spark",
+    hasActiveRun: true,
+    ...overrides,
+  };
+}
+
+function expectedRow(overrides = {}) {
+  return {
+    source: "openclaw",
+    id: "agent:main:telegram:topic:1",
+    handle: "World Cup",
+    originHost: "127.0.0.1",
+    originPort: 4000,
+    midTurn: true,
+    agent: "main",
+    ...overrides,
+  };
+}
+
+test("hasActiveRun true + baseUrl http://127.0.0.1:4000 maps origin and midTurn true", () => {
+  const rows = mapOpenClawSessions([session({ hasActiveRun: true })], SPARK_PROVIDERS);
+  assert.deepEqual(rows, [expectedRow({ midTurn: true })]);
+});
+
+test("hasActiveRun false is midTurn false", () => {
+  const rows = mapOpenClawSessions([session({ hasActiveRun: false })], SPARK_PROVIDERS);
+  assert.deepEqual(rows, [expectedRow({ midTurn: false })]);
+});
+
+test("missing occupancy field is midTurn unknown", () => {
+  const rows = mapOpenClawSessions(
+    [session({ hasActiveRun: undefined, status: undefined })],
+    SPARK_PROVIDERS
+  );
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].midTurn, "unknown");
+});
+
+test("status running is midTurn true when hasActiveRun is absent", () => {
+  const { hasActiveRun: _omit, ...rest } = session();
+  const rows = mapOpenClawSessions([{ ...rest, status: "running" }], SPARK_PROVIDERS);
+  assert.equal(rows[0].midTurn, true);
+});
+
+test("hasActiveRun false wins over status running", () => {
+  const rows = mapOpenClawSessions(
+    [session({ hasActiveRun: false, status: "running" })],
+    SPARK_PROVIDERS
+  );
+  assert.equal(rows[0].midTurn, false);
+});
+
+test("updatedAt is lastUsedAt and is not a transcript", () => {
+  const rows = mapOpenClawSessions(
+    [session({ updatedAt: 1_700_000_000_000, lastMessage: "secret" })],
+    SPARK_PROVIDERS
+  );
+  assert.equal(rows[0].lastUsedAt, 1_700_000_000_000);
+  assert.equal(JSON.stringify(rows).includes("secret"), false);
+});
+
+test("totalTokens and contextTokens become contextUsed and contextWindow", () => {
+  const rows = mapOpenClawSessions(
+    [session({ totalTokens: 12_345, contextTokens: 128_000, lastMessage: "secret" })],
+    SPARK_PROVIDERS
+  );
+  assert.equal(rows[0].contextUsed, 12345);
+  assert.equal(rows[0].contextWindow, 128000);
+  assert.equal("contextApprox" in rows[0], false);
+  assert.equal(JSON.stringify(rows).includes("secret"), false);
+});
+
+test("stale totalTokens is contextApprox; zero tokens are omitted", () => {
+  const stale = mapOpenClawSessions(
+    [session({ totalTokens: 99, contextTokens: 200_000, totalTokensFresh: false })],
+    SPARK_PROVIDERS
+  );
+  assert.equal(stale[0].contextUsed, 99);
+  assert.equal(stale[0].contextApprox, true);
+  const empty = mapOpenClawSessions([session({ totalTokens: 0, contextTokens: 0 })], SPARK_PROVIDERS);
+  assert.equal("contextUsed" in empty[0], false);
+  assert.equal("contextWindow" in empty[0], false);
+});
+
+test("handle comes from label, never lastMessage / preview / transcript", () => {
+  const rows = mapOpenClawSessions(
+    [
+      session({
+        label: "Topic A",
+        lastMessage: "secret transcript body",
+        preview: "preview text",
+        transcript: "full transcript",
+      }),
+    ],
+    SPARK_PROVIDERS
+  );
+  assert.equal(rows[0].handle, "Topic A");
+  const json = JSON.stringify(rows);
+  assert.equal(json.includes("secret transcript body"), false);
+  assert.equal(json.includes("preview text"), false);
+  assert.equal(json.includes("full transcript"), false);
+  assert.deepEqual(Object.keys(rows[0]).sort(), [
+    "agent",
+    "handle",
+    "id",
+    "midTurn",
+    "originHost",
+    "originPort",
+    "source",
+  ]);
+});
+
+test("handle falls back to key, never a transcript field", () => {
+  const rows = mapOpenClawSessions(
+    [
+      session({
+        label: "",
+        displayName: "",
+        key: "agent:main:discord:ch1",
+        lastMessage: "hello world transcript",
+        preview: "sneaky preview",
+      }),
+    ],
+    SPARK_PROVIDERS
+  );
+  assert.equal(rows[0].handle, "agent:main:discord:ch1");
+  assert.equal(JSON.stringify(rows).includes("hello world transcript"), false);
+  assert.equal(JSON.stringify(rows).includes("sneaky preview"), false);
+});
+
+test("handle falls back to displayName when label is empty", () => {
+  const rows = mapOpenClawSessions(
+    [session({ label: "  ", displayName: "Agent Main" })],
+    SPARK_PROVIDERS
+  );
+  assert.equal(rows[0].handle, "Agent Main");
+});
+
+test("cloud provider https://api.openai.com/v1 still emits a row", () => {
+  const rows = mapOpenClawSessions(
+    [session({ modelProvider: "openai", label: "cloud-chat" })],
+    { openai: { baseUrl: "https://api.openai.com/v1" } }
+  );
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].originHost, "api.openai.com");
+  assert.equal(rows[0].originPort, 443);
+  assert.equal(rows[0].handle, "cloud-chat");
+  assert.equal(rows[0].source, "openclaw");
+});
+
+test("session without provider baseUrl is omitted", () => {
+  const rows = mapOpenClawSessions(
+    [session({ modelProvider: "missing" }), session({ hasActiveRun: true })],
+    SPARK_PROVIDERS
+  );
+  assert.deepEqual(rows, [expectedRow()]);
+});
+
+test("store map without hasActiveRun is unknown unless status running", () => {
+  const store = {
+    "sess-a": { modelProvider: "spark", label: "A" },
+    "sess-b": { modelProvider: "spark", label: "B", status: "running" },
+  };
+  const rows = mapOpenClawSessions(store, SPARK_PROVIDERS);
+  const byHandle = Object.fromEntries(rows.map((r) => [r.handle, r]));
+  assert.equal(byHandle.A.midTurn, "unknown");
+  assert.equal(byHandle.B.midTurn, true);
+  assert.equal(byHandle.A.originPort, 4000);
+});
+
+test("wrapped { sessions: [...] } list is accepted", () => {
+  const rows = mapOpenClawSessions({ sessions: [session({ hasActiveRun: false })] }, SPARK_PROVIDERS);
+  assert.equal(rows[0].midTurn, false);
+});
+
+test("disabled attach returns [] and does not load", async () => {
+  let loaded = false;
+  const rows = await collectOpenClawSessions(
+    { enabled: false, mode: "local" },
+    {
+      readFile: async () => {
+        loaded = true;
+        throw new Error("should not read");
+      },
+      fetchJson: async () => {
+        loaded = true;
+        throw new Error("should not fetch");
+      },
+    }
+  );
+  assert.deepEqual(rows, []);
+  assert.equal(loaded, false);
+});
+
+test("unreachable / throwing loader returns [] and does not throw", async () => {
+  const rows = await collectOpenClawSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:18789" },
+    {
+      fetchJson: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    }
+  );
+  assert.deepEqual(rows, []);
+});
+
+test("url 404 returns []", async () => {
+  const rows = await collectOpenClawSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:18789" },
+    {
+      fetchJson: async () => {
+        const err = new Error("HTTP 404");
+        err.status = 404;
+        throw err;
+      },
+    }
+  );
+  assert.deepEqual(rows, []);
+});
+
+test("url mode unwraps a top-level sessions array plus providers", async () => {
+  const payload = [session({ hasActiveRun: false })];
+  payload.models = { providers: SPARK_PROVIDERS };
+  const rows = await collectOpenClawSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:18789" },
+    { fetchJson: async () => payload }
+  );
+  assert.deepEqual(rows, [expectedRow({ midTurn: false })]);
+});
+
+test("url mode unwraps models.providers and nested sessions; token from deps", async () => {
+  let seenToken;
+  const rows = await collectOpenClawSessions(
+    {
+      enabled: true,
+      mode: "url",
+      url: "http://127.0.0.1:18789",
+      token: "from-attach",
+    },
+    {
+      token: "from-deps",
+      fetchJson: async (url, opts) => {
+        assert.equal(url, "http://127.0.0.1:18789");
+        seenToken = opts.token;
+        return {
+          sessions: { sessions: [session({ hasActiveRun: false })] },
+          models: { providers: SPARK_PROVIDERS },
+        };
+      },
+    }
+  );
+  assert.equal(seenToken, "from-deps");
+  assert.deepEqual(rows, [expectedRow({ midTurn: false })]);
+});
+
+test("url mode prefers gatewayRpc over fetchJson and stamps attach id", async () => {
+  let fetched = false;
+  const rows = await collectOpenClawSessions(
+    {
+      id: "openclaw",
+      enabled: true,
+      mode: "url",
+      url: "http://127.0.0.1:18789",
+      label: "theshop",
+    },
+    {
+      token: "rpc-token",
+      fetchJson: async () => {
+        fetched = true;
+        throw new Error("should not fetch");
+      },
+      gatewayRpc: async (url, token) => {
+        assert.equal(url, "http://127.0.0.1:18789");
+        assert.equal(token, "rpc-token");
+        return { sessions: [session({ hasActiveRun: false })], providers: SPARK_PROVIDERS };
+      },
+    }
+  );
+  assert.equal(fetched, false);
+  assert.equal(rows[0].id, "openclaw:agent:main:telegram:topic:1");
+  assert.equal(rows[0].gateway, "theshop");
+  assert.equal(rows[0].handle, "World Cup");
+});
+
+test("state-dir reads openclaw.json + sessions.json via injected readFile", async () => {
+  const dir = "/tmp/openclaw-fixture";
+  const files = {
+    [`${dir}/openclaw.json`]: JSON.stringify({ models: { providers: SPARK_PROVIDERS } }),
+    [`${dir}/sessions.json`]: JSON.stringify({ sessions: [session({ hasActiveRun: true })] }),
+  };
+  const rows = await collectOpenClawSessions(
+    { enabled: true, mode: "state-dir", stateDir: dir },
+    {
+      readFile: async (filePath) => {
+        if (!(filePath in files)) {
+          const err = new Error(`ENOENT ${filePath}`);
+          err.code = "ENOENT";
+          throw err;
+        }
+        return files[filePath];
+      },
+    }
+  );
+  assert.deepEqual(rows, [expectedRow({ midTurn: true })]);
+});
+
+test("local mode reads conventional state dir files", async () => {
+  const dir = "/opt/openclaw-home";
+  const files = {
+    [`${dir}/openclaw.json`]: JSON.stringify({ models: { providers: SPARK_PROVIDERS } }),
+    [`${dir}/sessions.json`]: JSON.stringify({
+      "agent:main:telegram:topic:1": {
+        modelProvider: "spark",
+        label: "World Cup",
+      },
+    }),
+  };
+  const seen = [];
+  const rows = await collectOpenClawSessions(
+    { enabled: true, mode: "local" },
+    {
+      conventionalStateDir: dir,
+      hostRoot: "",
+      readFile: async (filePath) => {
+        seen.push(filePath);
+        if (!(filePath in files)) throw new Error(`missing ${filePath}`);
+        return files[filePath];
+      },
+    }
+  );
+  assert.ok(seen.some((p) => p.endsWith("openclaw.json")));
+  assert.ok(seen.some((p) => p.endsWith("sessions.json")));
+  assert.equal(rows[0].midTurn, "unknown");
+  assert.equal(rows[0].originHost, "127.0.0.1");
+  assert.equal(rows[0].originPort, 4000);
+});
+
+test("state-dir falls back to agents/*/sessions/sessions.json", async () => {
+  const dir = "/tmp/openclaw-agents";
+  const files = {
+    [`${dir}/openclaw.json`]: JSON.stringify({ models: { providers: SPARK_PROVIDERS } }),
+    [`${dir}/agents/main/sessions/sessions.json`]: JSON.stringify({
+      sessions: [session({ hasActiveRun: true })],
+    }),
+  };
+  const rows = await collectOpenClawSessions(
+    { enabled: true, mode: "state-dir", stateDir: dir },
+    {
+      readFile: async (filePath) => {
+        if (!(filePath in files)) {
+          const err = new Error(`ENOENT ${filePath}`);
+          err.code = "ENOENT";
+          throw err;
+        }
+        return files[filePath];
+      },
+      readDir: async (dirPath) => {
+        assert.equal(dirPath, `${dir}/agents`);
+        return ["main"];
+      },
+    }
+  );
+  assert.deepEqual(rows, [expectedRow({ midTurn: true })]);
+});
+
+test("mixed array-form and map-form agent stores are merged", async () => {
+  const dir = "/tmp/openclaw-mixed-stores";
+  const files = {
+    [`${dir}/openclaw.json`]: JSON.stringify({ models: { providers: SPARK_PROVIDERS } }),
+    [`${dir}/agents/main/sessions/sessions.json`]: JSON.stringify([
+      session({ key: "array-sess", label: "FromArray", hasActiveRun: true }),
+    ]),
+    [`${dir}/agents/work/sessions/sessions.json`]: JSON.stringify({
+      "map-sess": { modelProvider: "spark", label: "FromMap", hasActiveRun: false },
+    }),
+  };
+  const rows = await collectOpenClawSessions(
+    { enabled: true, mode: "state-dir", stateDir: dir },
+    {
+      readFile: async (filePath) => {
+        if (!(filePath in files)) {
+          const err = new Error(`ENOENT ${filePath}`);
+          err.code = "ENOENT";
+          throw err;
+        }
+        return files[filePath];
+      },
+      readDir: async (dirPath) => {
+        assert.equal(dirPath, `${dir}/agents`);
+        return ["main", "work"];
+      },
+    }
+  );
+  const byHandle = Object.fromEntries(rows.map((r) => [r.handle, r]));
+  assert.equal(rows.length, 2);
+  assert.equal(byHandle.FromArray.midTurn, true);
+  assert.equal(byHandle.FromArray.id, "array-sess");
+  assert.equal(byHandle.FromArray.agent, "main");
+  assert.equal(byHandle.FromMap.midTurn, false);
+  assert.equal(byHandle.FromMap.id, "map-sess");
+  assert.equal(byHandle.FromMap.agent, "work");
+});
+
+test("missing state files return [] not throw", async () => {
+  const rows = await collectOpenClawSessions(
+    { enabled: true, mode: "state-dir", stateDir: "/no/such/openclaw" },
+    {
+      readFile: async () => {
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      },
+    }
+  );
+  assert.deepEqual(rows, []);
+});
+
+test("diagnose reports missing OpenClaw state as error not empty ok", async () => {
+  const result = await diagnoseOpenClawSessions(
+    { enabled: true, mode: "state-dir", stateDir: "/no/such/openclaw" },
+    {
+      readFile: async () => {
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      },
+    }
+  );
+  assert.equal(result.status, "error");
+  assert.equal(result.error, "OpenClaw state not found");
+});
+
+test("disabled OpenClaw diagnose is disabled", async () => {
+  const result = await diagnoseOpenClawSessions({ enabled: false, mode: "url", url: "http://127.0.0.1:18789" });
+  assert.deepEqual(result, { status: "disabled", found: 0, mapped: 0, error: null });
+});
+
+test("module has no alphaclaw strings and no llmPorts HTTP", () => {
+  const src = readFileSync(MODULE_PATH, "utf8");
+  assert.equal(/alphaclaw/i.test(src), false);
+  assert.equal(/\bmama\b/i.test(src), false);
+  assert.equal(/kalliope/i.test(src), false);
+  assert.equal(/llmPorts/.test(src), false);
+  assert.equal(/projectConversations/.test(src), false);
+  assert.equal(/\/v1\/chat/.test(src), false);
+  assert.equal(/\/v1\/models/.test(src), false);
+});

--- a/server/collectors/__tests__/OpenCodeSessions.test.js
+++ b/server/collectors/__tests__/OpenCodeSessions.test.js
@@ -1,0 +1,341 @@
+/**
+ * OpenCode conversation collector: sqlite session rows + provider origins → projector rows.
+ *
+ * Injected db/config loaders — no live ~/.local/share/opencode.
+ * Run: node --test server/collectors/__tests__/OpenCodeSessions.test.js
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  parseJsonc,
+  mapOpenCodeSessions,
+  collectOpenCodeSessions,
+  diagnoseOpenCodeSessions,
+} from "../OpenCodeSessions.js";
+
+const MODULE_PATH = fileURLToPath(new URL("../OpenCodeSessions.js", import.meta.url));
+
+const JOHN_PROVIDERS = {
+  spark: { options: { baseURL: "http://john:8888/v1" } },
+};
+
+function session(overrides = {}) {
+  return {
+    id: "ses_local",
+    title: "spark occupancy",
+    model: JSON.stringify({ id: "gpt-oss", providerID: "spark" }),
+    time_updated: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function expectedRow(overrides = {}) {
+  return {
+    source: "opencode",
+    id: "ses_local",
+    handle: "spark occupancy",
+    originHost: "john",
+    originPort: 8888,
+    midTurn: "unknown",
+    lastUsedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function sessionColumns() {
+  return ["id", "title", "model", "time_updated"].map((name, cid) => ({
+    cid,
+    name,
+    type: "TEXT",
+  }));
+}
+
+function fakeDb({ tables = { session: sessionColumns() }, rows = [], queries = [] } = {}) {
+  return {
+    prepare(sql) {
+      queries.push(sql);
+      const text = String(sql);
+      if (/table_info\s*\(\s*session\s*\)/i.test(text)) {
+        return { all: () => tables.session ?? [] };
+      }
+      if (/\bfrom\s+session\b/i.test(text)) {
+        return { all: () => rows };
+      }
+      throw new Error(`unexpected sql: ${text}`);
+    },
+    close() {},
+  };
+}
+
+const JSONC_CONFIG = `{
+  // occupancy fixture
+  "provider": {
+    "spark": { "options": { "baseURL": "http://john:8888/v1" } }
+  }
+}
+`;
+
+test("fixture session with providerID maps origin john:8888 and title handle", () => {
+  const rows = mapOpenCodeSessions([session()], JOHN_PROVIDERS);
+  assert.deepEqual(rows, [expectedRow()]);
+});
+
+test("cloud baseURL still emits a row", () => {
+  const rows = mapOpenCodeSessions(
+    [session({ model: JSON.stringify({ id: "opus", providerID: "anthropic" }) })],
+    { anthropic: { options: { baseURL: "https://api.anthropic.com/v1" } } }
+  );
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].originHost, "api.anthropic.com");
+  assert.equal(rows[0].originPort, 443);
+});
+
+test("recent time_updated with no in-flight field is midTurn unknown", () => {
+  const rows = mapOpenCodeSessions(
+    [session({ time_updated: Date.now() })],
+    JOHN_PROVIDERS
+  );
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].midTurn, "unknown");
+});
+
+test("malformed model JSON is skipped without failing the batch", () => {
+  const rows = mapOpenCodeSessions(
+    [
+      session({ id: "bad", model: "{not-json" }),
+      session({ id: "empty", model: "" }),
+      session({ id: "null-model", model: null }),
+      session({ id: "ok", title: "kept" }),
+    ],
+    JOHN_PROVIDERS
+  );
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].id, "ok");
+  assert.equal(rows[0].handle, "kept");
+});
+
+test("parseJsonc strips comments and keeps strings that look like comments", () => {
+  const parsed = parseJsonc(`{
+    // line
+    "provider": { "spark": { "options": { "baseURL": "http://john:8888/v1" } } },
+    "note": "http://example.com/path" /* block */
+  }`);
+  assert.equal(parsed.provider.spark.options.baseURL, "http://john:8888/v1");
+  assert.equal(parsed.note, "http://example.com/path");
+});
+
+test("parseJsonc accepts trailing commas outside strings", () => {
+  const parsed = parseJsonc(`{
+    "provider": {
+      "spark": { "options": { "baseURL": "http://john:8888/v1" }, },
+    },
+  }`);
+  assert.equal(parsed.provider.spark.options.baseURL, "http://john:8888/v1");
+});
+
+test("tokens_input is approximate contextUsed; zero is omitted", () => {
+  const withTokens = mapOpenCodeSessions([session({ tokens_input: 75_000 })], JOHN_PROVIDERS);
+  assert.equal(withTokens[0].contextUsed, 75000);
+  assert.equal(withTokens[0].contextApprox, true);
+  assert.equal("contextWindow" in withTokens[0], false);
+
+  const missing = mapOpenCodeSessions([session()], JOHN_PROVIDERS);
+  assert.equal("contextUsed" in missing[0], false);
+  assert.equal("contextApprox" in missing[0], false);
+
+  const zero = mapOpenCodeSessions([session({ tokens_input: 0 })], JOHN_PROVIDERS);
+  assert.equal("contextUsed" in zero[0], false);
+});
+
+test("local collect reads JSONC-only provider config and sqlite session rows", async () => {
+  const queries = [];
+  const files = {
+    "/tmp/opencode-config/opencode.jsonc": JSONC_CONFIG,
+  };
+  const rows = await collectOpenCodeSessions(
+    { enabled: true, mode: "local" },
+    {
+      conventionalStateDir: "/tmp/opencode-data",
+      conventionalConfigDir: "/tmp/opencode-config",
+      readFile: async (filePath) => {
+        if (files[filePath]) return files[filePath];
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      },
+      openDatabase: (dbPath) => {
+        assert.equal(dbPath, "/tmp/opencode-data/opencode.db");
+        return fakeDb({
+          queries,
+          rows: [session()],
+        });
+      },
+    }
+  );
+  assert.deepEqual(rows, [expectedRow()]);
+  assert.equal(queries.some((sql) => /message|part/i.test(sql)), false);
+  assert.equal(queries.some((sql) => /table_info\s*\(\s*session\s*\)/i.test(sql)), true);
+  assert.equal(queries.some((sql) => /\bfrom\s+session\b/i.test(sql)), true);
+});
+
+test("local collect selects tokens_input when the session table has it", async () => {
+  const queries = [];
+  const columns = ["id", "title", "model", "time_updated", "tokens_input"].map((name, cid) => ({
+    cid,
+    name,
+    type: "TEXT",
+  }));
+  const rows = await collectOpenCodeSessions(
+    { enabled: true, mode: "local" },
+    {
+      conventionalStateDir: "/tmp/opencode-data",
+      conventionalConfigDir: "/tmp/opencode-config",
+      readFile: async (filePath) => {
+        if (filePath.endsWith("opencode.jsonc") || filePath.endsWith("opencode.json")) {
+          return JSON.stringify({ provider: JOHN_PROVIDERS });
+        }
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      },
+      openDatabase: () =>
+        fakeDb({
+          queries,
+          tables: { session: columns },
+          rows: [session({ tokens_input: 75_000 })],
+        }),
+    }
+  );
+  assert.equal(rows[0].contextUsed, 75000);
+  assert.equal(rows[0].contextApprox, true);
+  assert.equal(
+    queries.some((sql) => /\btokens_input\b/i.test(sql) && /\bfrom\s+session\b/i.test(sql)),
+    true
+  );
+  assert.equal(queries.some((sql) => /message|part/i.test(sql)), false);
+});
+
+test("injected db that only exposes message is never queried", async () => {
+  const queries = [];
+  const rows = await collectOpenCodeSessions(
+    { enabled: true, mode: "state-dir", stateDir: "/tmp/opencode-data" },
+    {
+      conventionalConfigDir: "/tmp/opencode-config",
+      readFile: async (filePath) => {
+        if (filePath.endsWith("opencode.json")) {
+          return JSON.stringify({ provider: JOHN_PROVIDERS });
+        }
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      },
+      openDatabase: () =>
+        fakeDb({
+          queries,
+          tables: { session: [] },
+          rows: [{ id: "secret", body: "transcript" }],
+        }),
+    }
+  );
+  assert.deepEqual(rows, []);
+  assert.equal(queries.some((sql) => /message|part/i.test(sql)), false);
+  assert.equal(queries.some((sql) => /\bfrom\s+session\b/i.test(sql)), false);
+});
+
+test("missing db collects [] and diagnose is error", async () => {
+  const deps = {
+    conventionalStateDir: "/no/such/opencode",
+    conventionalConfigDir: "/no/such/opencode-config",
+    readFile: async () => {
+      const err = new Error("ENOENT");
+      err.code = "ENOENT";
+      throw err;
+    },
+    openDatabase: (dbPath) => {
+      const err = new Error(`ENOENT: ${dbPath}`);
+      err.code = "ENOENT";
+      throw err;
+    },
+  };
+  const collected = await collectOpenCodeSessions({ enabled: true, mode: "local" }, deps);
+  assert.deepEqual(collected, []);
+  const diagnosed = await diagnoseOpenCodeSessions({ enabled: true, mode: "local" }, deps);
+  assert.equal(diagnosed.status, "error");
+  assert.equal(diagnosed.found, 0);
+  assert.equal(diagnosed.mapped, 0);
+  assert.equal(typeof diagnosed.error, "string");
+  assert.ok(diagnosed.error);
+});
+
+test("URL mode maps helper JSON through stampAttachRows; fetch failure is [] / error", async () => {
+  const helperRows = [expectedRow({ id: "remote-1", handle: "laptop" })];
+  const mapped = await collectOpenCodeSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:8788/occupancy", id: "opencode" },
+    {
+      fetchJson: async (url, opts) => {
+        assert.equal(url, "http://127.0.0.1:8788/occupancy");
+        assert.equal(opts.token, "secret");
+        return helperRows;
+      },
+      token: "secret",
+    }
+  );
+  assert.equal(mapped.length, 1);
+  assert.equal(mapped[0].handle, "laptop");
+  assert.equal(mapped[0].id, "opencode:remote-1");
+  assert.equal(mapped[0].source, "opencode");
+
+  const envelope = await diagnoseOpenCodeSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:8788/occupancy", id: "opencode" },
+    {
+      fetchJson: async () => ({ found: 4, rows: helperRows }),
+    }
+  );
+  assert.equal(envelope.status, "ok");
+  assert.equal(envelope.found, 4);
+  assert.equal(envelope.mapped, 1);
+  assert.equal("handle" in envelope, false);
+
+  const failedCollect = await collectOpenCodeSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:8788/occupancy" },
+    {
+      fetchJson: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    }
+  );
+  assert.deepEqual(failedCollect, []);
+  const failedDiagnose = await diagnoseOpenCodeSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:8788/occupancy" },
+    {
+      fetchJson: async () => {
+        const err = new Error("connect");
+        err.code = "ECONNREFUSED";
+        throw err;
+      },
+    }
+  );
+  assert.equal(failedDiagnose.status, "error");
+  assert.equal(failedDiagnose.found, 0);
+});
+
+test("helper payload over 500 rows is skipped for collect and diagnose error", async () => {
+  const rows = Array.from({ length: 501 }, (_, i) => expectedRow({ id: `s${i}`, handle: `h${i}` }));
+  const collected = await collectOpenCodeSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:8788/occupancy" },
+    { fetchJson: async () => rows }
+  );
+  assert.deepEqual(collected, []);
+  const diagnosed = await diagnoseOpenCodeSessions(
+    { enabled: true, mode: "url", url: "http://127.0.0.1:8788/occupancy" },
+    { fetchJson: async () => rows }
+  );
+  assert.equal(diagnosed.status, "error");
+});
+
+test("module never queries message or part", () => {
+  const src = readFileSync(MODULE_PATH, "utf8");
+  assert.equal(/\bmessage\b|\bpart\b/.test(src), false);
+});

--- a/server/collectors/__tests__/occupancyPoller.test.js
+++ b/server/collectors/__tests__/occupancyPoller.test.js
@@ -1,0 +1,347 @@
+/**
+ * Dashboard occupancy poller (U5): collect once, project onto Sparks.
+ * Never throws. Does not read showcase/bench. Disabled sources skip I/O.
+ * Run: npm test
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createOccupancyLoop, pollOccupancy } from "../occupancyPoller.js";
+
+const MODULE_PATH = fileURLToPath(new URL("../occupancyPoller.js", import.meta.url));
+
+function spark(overrides = {}) {
+  return {
+    id: "spark-local",
+    lanIp: "127.0.0.1",
+    isLocal: true,
+    llmPorts: [8888],
+    role: "standalone",
+    ...overrides,
+  };
+}
+
+function row(overrides = {}) {
+  return {
+    source: "openclaw",
+    handle: "chat-a",
+    originHost: "127.0.0.1",
+    originPort: 8888,
+    midTurn: false,
+    ...overrides,
+  };
+}
+
+function sources({ openclaw = false, hermes = false } = {}) {
+  return {
+    openclaw: { enabled: openclaw, mode: "local", url: "", stateDir: "" },
+    hermes: { enabled: hermes, mode: "local", url: "", stateDir: "" },
+  };
+}
+
+test("occupancy poll iterates registry kinds, not a local openclaw/hermes pair", () => {
+  const src = readFileSync(MODULE_PATH, "utf8");
+  assert.match(src, /sessionSourceIds|sessionSourceKinds/);
+  assert.match(src, /sessionSourceRegistry/);
+  assert.match(src, /occupancyCollectors/);
+  assert.equal(/\[["']openclaw["']\s*,\s*["']hermes["']\]/.test(src), false);
+});
+
+test("occupancy adapters cover every registry kind", async () => {
+  const { occupancyCollectors, occupancyDiagnosers } = await import("../sessionSourceAdapters.js");
+  const { sessionSourceIds } = await import("../../sessionSourceRegistry.js");
+  assert.deepEqual(Object.keys(occupancyCollectors()).sort(), [...sessionSourceIds()].sort());
+  assert.deepEqual(Object.keys(occupancyDiagnosers()).sort(), [...sessionSourceIds()].sort());
+});
+
+test("enabled kinds not in the registry do not trigger occupancy I/O", async () => {
+  let called = 0;
+  const collect = async () => {
+    called += 1;
+    return [row()];
+  };
+  const result = await pollOccupancy({
+    sparks: [spark()],
+    sources: {
+      ...sources(),
+      omp: { enabled: true, mode: "local", url: "", stateDir: "" },
+    },
+    collectors: { openclaw: collect, hermes: collect },
+  });
+  assert.deepEqual(result, {});
+  assert.equal(called, 0);
+});
+
+test("AE4: empty sources skip collect and return {}", async () => {
+  let called = 0;
+  const collect = async () => {
+    called += 1;
+    throw new Error("should not collect");
+  };
+  const result = await pollOccupancy({
+    sparks: [spark()],
+    sources: sources(),
+    tokens: {},
+    collectors: { openclaw: collect, hermes: collect },
+  });
+  assert.deepEqual(result, {});
+  assert.equal(called, 0);
+});
+
+test("AE4: occupancy throw returns {} and does not throw", async () => {
+  const result = await pollOccupancy({
+    sparks: [spark()],
+    sources: sources({ openclaw: true }),
+    tokens: {},
+    collectors: {
+      openclaw: async () => {
+        throw new Error("gateway down");
+      },
+      hermes: async () => {
+        throw new Error("hermes down");
+      },
+    },
+  });
+  assert.deepEqual(result, {});
+});
+
+test("disabled sources: collect fns not called", async () => {
+  let openclaw = 0;
+  let hermes = 0;
+  const result = await pollOccupancy({
+    sparks: [spark()],
+    sources: sources({ openclaw: false, hermes: false }),
+    collectors: {
+      openclaw: async () => {
+        openclaw += 1;
+        return [row()];
+      },
+      hermes: async () => {
+        hermes += 1;
+        return [row({ source: "hermes", handle: "ha" })];
+      },
+    },
+  });
+  assert.deepEqual(result, {});
+  assert.equal(openclaw, 0);
+  assert.equal(hermes, 0);
+});
+
+test("AE6: occupancy poller does not read showcase or DecodeBench state", async () => {
+  const src = readFileSync(MODULE_PATH, "utf8");
+  assert.equal(/ShowcaseManager/.test(src), false);
+  assert.equal(/DecodeBench/.test(src), false);
+  const result = await pollOccupancy({
+    sparks: [spark()],
+    sources: sources({ openclaw: true }),
+    tokens: {},
+    collectors: {
+      openclaw: async () => [
+        row({ handle: "stalled-chat", midTurn: false }),
+        row({ handle: "unknown-chat", midTurn: "unknown" }),
+      ],
+      hermes: async () => [],
+    },
+  });
+  const list = result["spark-local"];
+  assert.ok(Array.isArray(list));
+  const byHandle = Object.fromEntries(list.map((r) => [r.handle, r]));
+  assert.equal(byHandle["stalled-chat"].badge, "stalled");
+  assert.equal(byHandle["unknown-chat"].badge, "unknown");
+});
+
+test("projector throw returns {} and does not throw", async () => {
+  const result = await pollOccupancy({
+    sparks: [spark()],
+    sources: sources({ openclaw: true }),
+    collectors: {
+      openclaw: async () => [row({ midTurn: true })],
+      hermes: async () => [],
+    },
+    project: () => {
+      throw new Error("projector boom");
+    },
+  });
+  assert.deepEqual(result, {});
+});
+
+test("per-source catch: throwing source contributes [] and sibling still projects", async () => {
+  const result = await pollOccupancy({
+    sparks: [spark()],
+    sources: sources({ openclaw: true, hermes: true }),
+    collectors: {
+      openclaw: async () => {
+        throw new Error("openclaw boom");
+      },
+      hermes: async () => [
+        row({ source: "hermes", handle: "agent-1", midTurn: "unknown" }),
+      ],
+    },
+  });
+  assert.deepEqual(result["spark-local"], [
+    { id: "hermes:8888:agent-1", source: "hermes", handle: "agent-1", badge: "unknown", port: 8888 },
+  ]);
+});
+
+test("collects every enabled attach of the same product", async () => {
+  const seen = [];
+  const result = await pollOccupancy({
+    sparks: [spark()],
+    sources: {
+      openclaw: { enabled: false, mode: "local", url: "", stateDir: "" },
+      hermes: [
+        { id: "hermes", enabled: true, mode: "url", url: "http://127.0.0.1:8787", stateDir: "" },
+        { id: "hermes-2", enabled: true, mode: "url", url: "http://10.0.0.2:9119", stateDir: "" },
+      ],
+    },
+    tokens: { hermes: "a", "hermes-2": "b" },
+    collectors: {
+      openclaw: async () => [],
+      hermes: async (attach, deps) => {
+        seen.push({ id: attach.id, token: deps.token, url: attach.url });
+        return [
+          row({
+            source: "hermes",
+            handle: attach.id,
+            midTurn: "unknown",
+          }),
+        ];
+      },
+    },
+  });
+  assert.equal(seen.length, 2);
+  assert.deepEqual(seen, [
+    { id: "hermes", token: "a", url: "http://127.0.0.1:8787" },
+    { id: "hermes-2", token: "b", url: "http://10.0.0.2:9119" },
+  ]);
+  assert.deepEqual(
+    result["spark-local"].map((r) => r.handle).sort(),
+    ["hermes", "hermes-2"]
+  );
+});
+
+test("collects every enabled OpenCode attach into one row list", async () => {
+  const seen = [];
+  const result = await pollOccupancy({
+    sparks: [spark()],
+    sources: {
+      ...sources(),
+      opencode: [
+        { id: "opencode", enabled: true, mode: "url", url: "http://127.0.0.1:8788", stateDir: "" },
+        { id: "opencode-2", enabled: true, mode: "url", url: "http://127.0.0.1:8789", stateDir: "" },
+      ],
+    },
+    collectors: {
+      openclaw: async () => [],
+      hermes: async () => [],
+      opencode: async (attach) => {
+        seen.push(attach.id);
+        return [
+          row({
+            source: "opencode",
+            handle: attach.id,
+            originHost: "127.0.0.1",
+            originPort: 8888,
+            midTurn: "unknown",
+          }),
+        ];
+      },
+    },
+  });
+  assert.deepEqual(seen, ["opencode", "opencode-2"]);
+  assert.deepEqual(
+    result["spark-local"].map((r) => r.handle).sort(),
+    ["opencode", "opencode-2"]
+  );
+});
+
+function loopHarness(overrides = {}) {
+  const applied = [];
+  const sparks = [spark()];
+  let currentSources = sources({ openclaw: true });
+  const loop = createOccupancyLoop({
+    intervalMs: 60_000,
+    getSparks: () => sparks,
+    getSources: () => currentSources,
+    getTokens: () => ({}),
+    apply: (bySpark) => applied.push(bySpark),
+    poll: async () => ({ "spark-local": [{ source: "openclaw", handle: "chat-a", badge: "generating", port: 8888 }] }),
+    ...overrides,
+  });
+  return {
+    loop,
+    applied,
+    setSources(next) {
+      currentSources = next;
+    },
+  };
+}
+
+test("occupancy loop: disabled sources apply {} without polling", async () => {
+  let polls = 0;
+  const { loop, applied } = loopHarness({
+    getSources: () => sources(),
+    poll: async () => {
+      polls += 1;
+      return { "spark-local": [] };
+    },
+  });
+  await loop.tick();
+  assert.equal(polls, 0);
+  assert.deepEqual(applied, [{}]);
+});
+
+test("occupancy loop: skip a second tick while a poll is in flight", async () => {
+  let polls = 0;
+  let release;
+  const hanging = new Promise((resolve) => {
+    release = resolve;
+  });
+  const { loop, applied } = loopHarness({
+    poll: async () => {
+      polls += 1;
+      await hanging;
+      return { "spark-local": [{ source: "openclaw", handle: "chat-a", badge: "generating", port: 8888 }] };
+    },
+  });
+  const first = loop.tick();
+  await loop.tick();
+  release();
+  await first;
+  assert.equal(polls, 1);
+  assert.equal(applied.length, 1);
+});
+
+test("occupancy loop: disable during poll applies {} not the hung result", async () => {
+  const { loop, applied, setSources } = loopHarness({
+    poll: async () => {
+      setSources(sources());
+      return { "spark-local": [{ source: "openclaw", handle: "chat-a", badge: "generating", port: 8888 }] };
+    },
+  });
+  await loop.tick();
+  assert.deepEqual(applied, [{}]);
+});
+
+test("occupancy loop: source URL change during poll discards the stale result", async () => {
+  const { loop, applied, setSources } = loopHarness({
+    poll: async () => {
+      setSources({
+        openclaw: { enabled: true, mode: "url", url: "http://127.0.0.1:9", stateDir: "" },
+        hermes: { enabled: false, mode: "local", url: "", stateDir: "" },
+      });
+      return { "spark-local": [{ source: "openclaw", handle: "stale", badge: "generating", port: 8888 }] };
+    },
+  });
+  await loop.tick();
+  assert.deepEqual(applied, []);
+});
+
+test("occupancy loop: stop clears the timer so later ticks are caller-driven only", async () => {
+  const { loop } = loopHarness();
+  loop.start();
+  loop.stop();
+  loop.start();
+  loop.stop();
+});

--- a/server/collectors/__tests__/openclawGateway.test.js
+++ b/server/collectors/__tests__/openclawGateway.test.js
@@ -1,0 +1,84 @@
+/**
+ * OpenClaw gateway WS RPC (sessions.list + config.get).
+ * Injected identity — does not persist secrets. Loopback mock only.
+ * Run: node --test server/collectors/__tests__/openclawGateway.test.js
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import crypto from "node:crypto";
+import { WebSocketServer } from "ws";
+import { defaultOpenClawGatewayRpc, gatewayWsUrl } from "../openclawGateway.js";
+
+test("gatewayWsUrl maps http(s) origin without path", () => {
+  assert.equal(gatewayWsUrl("http://127.0.0.1:18789/"), "ws://127.0.0.1:18789");
+  assert.equal(gatewayWsUrl("https://example.com:8443/ui"), "wss://example.com:8443");
+});
+
+test("defaultOpenClawGatewayRpc lists sessions and providers over WebSocket", async () => {
+  const { privateKey } = crypto.generateKeyPairSync("ed25519");
+  const identity = {
+    deviceId: "a".repeat(64),
+    publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+  };
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  const port = await new Promise((resolve) => {
+    server.on("listening", () => resolve(server.address().port));
+  });
+  server.on("connection", (socket) => {
+    socket.send(
+      JSON.stringify({ type: "event", event: "connect.challenge", payload: { nonce: "n1", ts: 1 } })
+    );
+    socket.on("message", (raw) => {
+      const msg = JSON.parse(String(raw));
+      if (msg.method === "connect") {
+        assert.equal(msg.params?.client?.id, "cli");
+        assert.ok(msg.params?.device?.signature);
+        socket.send(
+          JSON.stringify({ type: "res", id: msg.id, ok: true, payload: { type: "hello-ok", protocol: 4 } })
+        );
+      }
+      if (msg.method === "sessions.list") {
+        socket.send(
+          JSON.stringify({
+            type: "res",
+            id: msg.id,
+            ok: true,
+            payload: {
+              sessions: [
+                {
+                  key: "agent:main:telegram:topic:1",
+                  label: "World Cup",
+                  modelProvider: "spark",
+                  hasActiveRun: false,
+                },
+              ],
+            },
+          })
+        );
+      }
+      if (msg.method === "config.get") {
+        socket.send(
+          JSON.stringify({
+            type: "res",
+            id: msg.id,
+            ok: true,
+            payload: {
+              config: { models: { providers: { spark: { baseUrl: "http://127.0.0.1:4000/v1" } } } },
+            },
+          })
+        );
+      }
+    });
+  });
+  try {
+    const result = await defaultOpenClawGatewayRpc(`http://127.0.0.1:${port}`, "tok", {
+      deviceIdentity: identity,
+      timeoutMs: 2000,
+    });
+    assert.equal(result.sessions[0].label, "World Cup");
+    assert.equal(result.providers.spark.baseUrl, "http://127.0.0.1:4000/v1");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/server/collectors/__tests__/sessionIo.test.js
+++ b/server/collectors/__tests__/sessionIo.test.js
@@ -1,0 +1,173 @@
+/**
+ * Shared session I/O helpers: host-root remap, URL fetch guards.
+ * Run: node --test server/collectors/__tests__/sessionIo.test.js
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  expandTilde,
+  remapHostRoot,
+  resolveStateDir,
+  defaultFetchJson,
+  sanitizeProbeError,
+  parseSessionTime,
+  sessionLastUsedAt,
+  sessionAgent,
+  sessionContextSize,
+  profileFromStateDir,
+} from "../sessionIo.js";
+
+test("expandTilde maps ~ and ~/path against injected home", () => {
+  assert.equal(expandTilde("~", "/home/op"), "/home/op");
+  assert.equal(expandTilde("~/.openclaw", "/home/op"), "/home/op/.openclaw");
+  assert.equal(expandTilde("/abs/openclaw", "/home/op"), "/abs/openclaw");
+});
+
+test("remapHostRoot returns expanded when already readable", () => {
+  const readable = new Set(["/home/op/.openclaw"]);
+  const mapped = remapHostRoot("/home/op/.openclaw", {
+    hostRoot: "/host/root",
+    isReadable: (p) => readable.has(p),
+  });
+  assert.equal(mapped, "/home/op/.openclaw");
+});
+
+test("remapHostRoot joins HOST_ROOT when expanded is unreadable", () => {
+  const readable = new Set(["/host/root", "/host/root/home/op/.openclaw"]);
+  const mapped = remapHostRoot("/home/op/.openclaw", {
+    hostRoot: "/host/root",
+    isReadable: (p) => readable.has(p),
+  });
+  assert.equal(mapped, "/host/root/home/op/.openclaw");
+});
+
+test("remapHostRoot keeps expanded when remap target is also unreadable", () => {
+  const mapped = remapHostRoot("/home/op/.openclaw", {
+    hostRoot: "/host/root",
+    isReadable: () => false,
+  });
+  assert.equal(mapped, "/home/op/.openclaw");
+});
+
+test("resolveStateDir remaps state-dir paths the same as local conventional paths", () => {
+  const readable = new Set(["/host/root", "/host/root/opt/openclaw"]);
+  const deps = {
+    homedir: "/home/op",
+    hostRoot: "/host/root",
+    isReadable: (p) => readable.has(p),
+  };
+  const fromStateDir = resolveStateDir(
+    { mode: "state-dir", stateDir: "/opt/openclaw" },
+    deps,
+    "~/.openclaw"
+  );
+  const fromLocal = resolveStateDir({ mode: "local" }, deps, "/opt/openclaw");
+  assert.equal(fromStateDir, "/host/root/opt/openclaw");
+  assert.equal(fromLocal, "/host/root/opt/openclaw");
+});
+
+test("resolveStateDir does not fall back to conventional when state-dir is blank", () => {
+  const deps = { homedir: "/home/op", hostRoot: "", isReadable: () => true };
+  assert.equal(resolveStateDir({ mode: "state-dir", stateDir: "" }, deps, "~/.openclaw"), "");
+  assert.equal(resolveStateDir({ mode: "state-dir" }, deps, "/opt/openclaw"), "");
+});
+
+test("defaultFetchJson rejects file: protocol, userinfo, and disallowed IPs before fetch", async () => {
+  await assert.rejects(
+    () => defaultFetchJson("file:///etc/passwd"),
+    /protocol/i
+  );
+  const userinfoUrl = new URL("http://127.0.0.1:18789/");
+  userinfoUrl.username = "review-user";
+  userinfoUrl.password = "review-pass";
+  await assert.rejects(
+    () => defaultFetchJson(userinfoUrl.toString()),
+    /userinfo/i
+  );
+  await assert.rejects(
+    () => defaultFetchJson("http://169.254.169.254/latest/meta-data/"),
+    /disallowed host/i
+  );
+});
+
+test("sanitizeProbeError strips paths and maps auth / connect codes", () => {
+  const missing = new Error("ENOENT: no such file or directory, open '/secret/path/sessions.json'");
+  missing.code = "ENOENT";
+  assert.equal(sanitizeProbeError(missing), "State files not found");
+  assert.equal(String(sanitizeProbeError(missing)).includes("/secret/"), false);
+
+  const auth = new Error("HTTP 401");
+  auth.status = 401;
+  assert.equal(sanitizeProbeError(auth), "HTTP 401 (auth failed)");
+
+  const refused = new Error("connect ECONNREFUSED 127.0.0.1:8787");
+  refused.code = "ECONNREFUSED";
+  assert.equal(sanitizeProbeError(refused), "Connection refused");
+
+  const html = new Error("Unexpected token '<', \"<!doctype \"... is not valid JSON");
+  assert.equal(sanitizeProbeError(html), "Not a JSON session list");
+
+  const pairing = new Error("pairing required: device is not approved yet");
+  assert.equal(sanitizeProbeError(pairing), "Pairing required — approve this device in OpenClaw");
+  const missingScope = new Error("missing scope: operator.read");
+  assert.equal(sanitizeProbeError(missingScope), "Missing operator.read scope");
+
+  const denied = new Error("EACCES: permission denied, open '/home/op/.hermes/sessions.json'");
+  denied.code = "EACCES";
+  assert.equal(sanitizeProbeError(denied), "Permission denied");
+  assert.equal(String(sanitizeProbeError(denied)).includes("/home/op"), false);
+
+  const mystery = new Error("ENOENT-looking path /secret/layout in a generic failure");
+  assert.equal(sanitizeProbeError(mystery), "Request failed");
+  assert.equal(String(sanitizeProbeError(mystery)).includes("/secret/"), false);
+});
+
+test("parseSessionTime accepts ms, seconds, and ISO strings", () => {
+  assert.equal(parseSessionTime(1_700_000_000_000), 1_700_000_000_000);
+  assert.equal(parseSessionTime(1_700_000_000), 1_700_000_000_000);
+  assert.equal(parseSessionTime("2024-01-15T12:00:00.000Z"), Date.parse("2024-01-15T12:00:00.000Z"));
+  assert.equal(parseSessionTime(""), null);
+  assert.equal(parseSessionTime(0), null);
+  assert.equal(sessionLastUsedAt({ updatedAt: 1_700_000_000_000, createdAt: 1 }), 1_700_000_000_000);
+  assert.equal(sessionLastUsedAt({ created_at: "2024-01-15T12:00:00.000Z" }), Date.parse("2024-01-15T12:00:00.000Z"));
+  assert.equal(sessionLastUsedAt({ preview: "secret" }), null);
+});
+
+test("sessionAgent prefers explicit fields, then fallback, then agent: key", () => {
+  assert.equal(sessionAgent({ agentId: "work", key: "agent:main:telegram:t:1" }), "work");
+  assert.equal(sessionAgent({ profile: "unleashed" }), "unleashed");
+  assert.equal(sessionAgent({ active_profile: "planner" }), "planner");
+  assert.equal(sessionAgent({ key: "agent:niemand:telegram:t:1" }), "niemand");
+  assert.equal(sessionAgent({ session_key: "agent:main:telegram:t:1" }, "unleashed"), "unleashed");
+  assert.equal(sessionAgent({ key: "sess-a" }, "main"), "main");
+  assert.equal(profileFromStateDir("/home/op/.hermes/profiles/unleashed"), "unleashed");
+  assert.equal(profileFromStateDir("/home/op/.hermes"), "");
+});
+
+test("sessionContextSize reads OpenClaw totalTokens and contextTokens", () => {
+  assert.deepEqual(sessionContextSize({ totalTokens: 12_345, contextTokens: 128_000 }), {
+    used: 12345,
+    window: 128000,
+  });
+});
+
+test("sessionContextSize prefers last_prompt_tokens over cumulative input_tokens", () => {
+  assert.deepEqual(
+    sessionContextSize({ last_prompt_tokens: 42_000, input_tokens: 900_000 }),
+    { used: 42000 }
+  );
+});
+
+test("sessionContextSize omits zero, negative, and missing counts", () => {
+  assert.equal(sessionContextSize({ totalTokens: 0, last_prompt_tokens: -1 }), null);
+  assert.equal(sessionContextSize({ label: "chat" }), null);
+  assert.equal(sessionContextSize(null), null);
+});
+
+test("sessionContextSize marks stale OpenClaw totals as approx", () => {
+  assert.deepEqual(sessionContextSize({ totalTokens: 180_000, contextTokens: 200_000, totalTokensFresh: false }), {
+    used: 180000,
+    window: 200000,
+    approx: true,
+  });
+});

--- a/server/collectors/__tests__/sessionProjector.test.js
+++ b/server/collectors/__tests__/sessionProjector.test.js
@@ -1,0 +1,413 @@
+/**
+ * Origin projector (U2): source session rows → per-Spark conversation lists.
+ *
+ * Pure function — no HTTP, no clocks, no engine /slots joins.
+ * Run: npm test
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { projectConversations, localInterfaceHosts, withOccupancyHosts, parseFibLocalIpv4, hostListenIps } from "../sessionProjector.js";
+
+function spark(overrides = {}) {
+  return {
+    id: "spark-local",
+    lanIp: "192.168.4.51",
+    isLocal: true,
+    llmPorts: [8888],
+    role: "standalone",
+    ...overrides,
+  };
+}
+
+function row(overrides = {}) {
+  return {
+    source: "openclaw",
+    handle: "topic-a",
+    originHost: "192.168.4.51",
+    originPort: 8888,
+    midTurn: true,
+    ...overrides,
+  };
+}
+
+function rowsFor(result, sparkId) {
+  assert.equal(sparkId in result, true, `expected key ${sparkId}`);
+  return result[sparkId];
+}
+
+test("unknown rows sort by lastUsedAt descending", () => {
+  const list = rowsFor(
+    projectConversations(
+      [
+        row({ handle: "old", midTurn: "unknown", lastUsedAt: 100 }),
+        row({ handle: "new", midTurn: "unknown", lastUsedAt: 300 }),
+        row({ handle: "mid", midTurn: "unknown", lastUsedAt: 200 }),
+      ],
+      [spark()]
+    ),
+    "spark-local"
+  );
+  assert.deepEqual(list.map((r) => r.handle), ["new", "mid", "old"]);
+});
+
+test("agent is projected when present and omitted when empty", () => {
+  const withAgent = rowsFor(
+    projectConversations([row({ agent: "niemand" })], [spark()]),
+    "spark-local"
+  );
+  assert.equal(withAgent[0].agent, "niemand");
+  const without = rowsFor(projectConversations([row()], [spark()]), "spark-local");
+  assert.equal("agent" in without[0], false);
+});
+
+test("gateway is projected when present and omitted when empty", () => {
+  const withGateway = rowsFor(
+    projectConversations([row({ gateway: "theshop", agent: "niemand" })], [spark()]),
+    "spark-local"
+  );
+  assert.equal(withGateway[0].gateway, "theshop");
+  const without = rowsFor(projectConversations([row()], [spark()]), "spark-local");
+  assert.equal("gateway" in without[0], false);
+});
+
+test("contextUsed and contextWindow are projected when present and omitted when empty", () => {
+  const withCtx = rowsFor(
+    projectConversations(
+      [row({ contextUsed: 12345, contextWindow: 128000, contextApprox: true })],
+      [spark()]
+    ),
+    "spark-local"
+  );
+  assert.equal(withCtx[0].contextUsed, 12345);
+  assert.equal(withCtx[0].contextWindow, 128000);
+  assert.equal(withCtx[0].contextApprox, true);
+  const without = rowsFor(projectConversations([row()], [spark()]), "spark-local");
+  assert.equal("contextUsed" in without[0], false);
+  assert.equal("contextWindow" in without[0], false);
+  assert.equal("contextApprox" in without[0], false);
+});
+
+test("AE1: mid-turn + origin match is generating; midTurn false is stalled", () => {
+  const sparks = [spark()];
+  const generating = projectConversations([row({ handle: "chat-a", midTurn: true })], sparks);
+  assert.deepEqual(rowsFor(generating, "spark-local"), [
+    { id: "openclaw:8888:chat-a", source: "openclaw", handle: "chat-a", badge: "generating", port: 8888 },
+  ]);
+
+  const stalled = projectConversations([row({ handle: "chat-a", midTurn: false })], sparks);
+  assert.deepEqual(rowsFor(stalled, "spark-local"), [
+    { id: "openclaw:8888:chat-a", source: "openclaw", handle: "chat-a", badge: "stalled", port: 8888 },
+  ]);
+});
+
+test("AE2: one mid-turn sibling generating, the other stalled", () => {
+  const result = projectConversations(
+    [
+      row({ handle: "chat-a", midTurn: true }),
+      row({ handle: "chat-b", midTurn: false }),
+    ],
+    [spark()]
+  );
+  const list = rowsFor(result, "spark-local");
+  const byHandle = Object.fromEntries(list.map((r) => [r.handle, r]));
+  assert.equal(byHandle["chat-a"].badge, "generating");
+  assert.equal(byHandle["chat-b"].badge, "stalled");
+  assert.equal(list.length, 2);
+});
+
+test("AE3: midTurn unknown is unknown, never generating", () => {
+  const result = projectConversations(
+    [row({ handle: "chat-u", midTurn: "unknown" })],
+    [spark()]
+  );
+  assert.deepEqual(rowsFor(result, "spark-local"), [
+    { id: "openclaw:8888:chat-u", source: "openclaw", handle: "chat-u", badge: "unknown", port: 8888 },
+  ]);
+});
+
+test("cloud api.openai.com origin matches no Spark", () => {
+  const result = projectConversations(
+    [
+      row({
+        handle: "cloud-chat",
+        originHost: "api.openai.com",
+        originPort: 443,
+        midTurn: true,
+      }),
+    ],
+    [spark(), spark({ id: "spark-b", lanIp: "192.168.4.52", isLocal: false, llmPorts: [8888] })]
+  );
+  assert.deepEqual(result, {});
+});
+
+test("two Sparks, same model id, different ports: row only on matching port", () => {
+  const sparks = [
+    spark({ id: "spark-a", lanIp: "192.168.4.51", isLocal: false, llmPorts: [4000], modelId: "same-model" }),
+    spark({ id: "spark-b", lanIp: "192.168.4.52", isLocal: false, llmPorts: [4001], modelId: "same-model" }),
+  ];
+  const result = projectConversations(
+    [
+      row({
+        handle: "shared-model-chat",
+        originHost: "192.168.4.52",
+        originPort: 4001,
+        midTurn: true,
+      }),
+    ],
+    sparks
+  );
+  assert.equal("spark-a" in result, false);
+  assert.deepEqual(rowsFor(result, "spark-b"), [
+    { id: "openclaw:4001:shared-model-chat", source: "openclaw", handle: "shared-model-chat", badge: "generating", port: 4001 },
+  ]);
+});
+
+test("local Spark matches loopback origin; non-local Spark with other lanIp does not", () => {
+  const localSpark = spark({
+    id: "spark-local",
+    lanIp: "192.168.4.51",
+    isLocal: true,
+    llmPorts: [8888],
+  });
+  const remoteSpark = spark({
+    id: "spark-remote",
+    lanIp: "192.168.4.99",
+    isLocal: false,
+    llmPorts: [8888],
+  });
+  const result = projectConversations(
+    [row({ handle: "loopback-chat", originHost: "127.0.0.1", originPort: 8888, midTurn: true })],
+    [localSpark, remoteSpark]
+  );
+  assert.deepEqual(rowsFor(result, "spark-local"), [
+    { id: "openclaw:8888:loopback-chat", source: "openclaw", handle: "loopback-chat", badge: "generating", port: 8888 },
+  ]);
+  assert.equal("spark-remote" in result, false);
+});
+
+test("recency-only is_active does not mint generating", () => {
+  const result = projectConversations(
+    [
+      row({
+        handle: "recent-chat",
+        midTurn: "unknown",
+        is_active: true,
+        isActive: true,
+      }),
+      row({
+        source: "hermes",
+        handle: "recency-only",
+        midTurn: undefined,
+        is_active: true,
+        isActive: true,
+      }),
+    ],
+    [spark()]
+  );
+  const list = rowsFor(result, "spark-local");
+  for (const conversation of list) {
+    assert.equal(conversation.badge, "unknown");
+    assert.notEqual(conversation.badge, "generating");
+  }
+  assert.equal(list.length, 2);
+});
+
+test("projected JSON is stable and does not inject Date.now()", () => {
+  const rows = [
+    row({ handle: "chat-a", midTurn: true, lastUsedAt: 1_700_000_000_000 }),
+    row({ source: "hermes", handle: "chat-b", midTurn: false, lastUsedAt: 1_700_000_100_000 }),
+  ];
+  const sparks = [spark()];
+  const first = projectConversations(rows, sparks);
+  const second = projectConversations(rows, sparks);
+  const json1 = JSON.stringify(first);
+  const json2 = JSON.stringify(second);
+  assert.equal(json1, json2);
+  for (const conversation of first["spark-local"]) {
+    assert.equal("lastUsedAt" in conversation, true);
+    assert.deepEqual(
+      Object.keys(conversation).sort(),
+      ["badge", "handle", "id", "lastUsedAt", "port", "source"]
+    );
+  }
+});
+
+test("localhost and bracketed ::1 match an isLocal Spark", () => {
+  const local = spark({ id: "spark-local", isLocal: true, llmPorts: [8888] });
+  const localhostHit = projectConversations(
+    [row({ handle: "lh", originHost: "localhost", originPort: 8888 })],
+    [local]
+  );
+  const v6Hit = projectConversations(
+    [row({ handle: "v6", originHost: "[::1]", originPort: 8888 })],
+    [local]
+  );
+  assert.equal(rowsFor(localhostHit, "spark-local")[0].handle, "lh");
+  assert.equal(rowsFor(v6Hit, "spark-local")[0].handle, "v6");
+});
+
+test("worker with empty llmPorts gets no rows even when lanIp matches", () => {
+  const worker = spark({
+    id: "spark-worker",
+    lanIp: "192.168.4.51",
+    isLocal: false,
+    llmPorts: [],
+    role: "worker",
+    workerNode: true,
+  });
+  const result = projectConversations([row({ midTurn: true })], [worker]);
+  assert.deepEqual(result, {});
+});
+
+test("list is capped at 20; generating and most-recent lastUsedAt survive", () => {
+  const rows = [];
+  for (let i = 0; i < 21; i++) {
+    const n = String(20 - i).padStart(2, "0");
+    rows.push(
+      row({
+        source: "hermes",
+        handle: `h-${n}`,
+        midTurn: false,
+        lastUsedAt: 1_700_000_000_000 + i * 1000,
+      })
+    );
+  }
+  rows.push(row({ source: "openclaw", handle: "z-last", originPort: 8888, midTurn: true, lastUsedAt: 1 }));
+  const list = rowsFor(projectConversations(rows, [spark()]), "spark-local");
+  assert.equal(list.length, 20);
+  assert.equal(list[0].badge, "generating");
+  assert.equal(list[0].handle, "z-last");
+  assert.equal(list[1].handle, "h-00");
+  assert.equal(list[list.length - 1].handle, "h-18");
+});
+
+test("duplicate handles keep distinct ids from native session identity", () => {
+  const result = projectConversations(
+    [
+      row({ id: "sess-a", handle: "World Cup", midTurn: true }),
+      row({ id: "sess-b", handle: "World Cup", midTurn: false }),
+    ],
+    [spark()]
+  );
+  const list = rowsFor(result, "spark-local");
+  assert.deepEqual(
+    list.map((r) => r.id).sort(),
+    ["sess-a", "sess-b"]
+  );
+  assert.equal(list.every((r) => r.handle === "World Cup"), true);
+});
+
+test("origin hostname matching the Spark name binds even when lanIp differs", () => {
+  const named = spark({
+    id: "spark-john",
+    name: "john",
+    lanIp: "100.120.26.16",
+    isLocal: true,
+    llmPorts: [8888],
+  });
+  const result = projectConversations(
+    [row({ source: "hermes", handle: "cli-chat", originHost: "john", originPort: 8888, midTurn: "unknown" })],
+    [named]
+  );
+  assert.deepEqual(rowsFor(result, "spark-john"), [
+    { id: "hermes:8888:cli-chat", source: "hermes", handle: "cli-chat", badge: "unknown", port: 8888 },
+  ]);
+});
+
+test("duplicate Spark names do not bind origin hostnames", () => {
+  const sparks = [
+    spark({ id: "a", name: "john", lanIp: "10.0.0.1", isLocal: false, llmPorts: [8888] }),
+    spark({ id: "b", name: "john", lanIp: "10.0.0.2", isLocal: false, llmPorts: [8888] }),
+  ];
+  const result = projectConversations(
+    [row({ source: "hermes", handle: "cli-chat", originHost: "john", originPort: 8888 })],
+    sparks
+  );
+  assert.equal("a" in result, false);
+  assert.equal("b" in result, false);
+});
+
+test("a Spark name that matches another Spark ssh.host does not steal that origin", () => {
+  const sparks = [
+    spark({ id: "named", name: "john", lanIp: "10.0.0.1", isLocal: false, llmPorts: [8888] }),
+    spark({
+      id: "sshed",
+      name: "ofus",
+      lanIp: "10.0.0.2",
+      isLocal: false,
+      llmPorts: [8888],
+      ssh: { host: "john" },
+    }),
+  ];
+  const result = projectConversations(
+    [row({ source: "hermes", handle: "cli-chat", originHost: "john", originPort: 8888 })],
+    sparks
+  );
+  assert.equal("named" in result, false);
+  assert.equal(rowsFor(result, "sshed")[0].handle, "cli-chat");
+});
+
+test("cx7Ip and occupancyHosts bind the same port as lanIp", () => {
+  const box = spark({
+    id: "spark-box",
+    lanIp: "100.10.0.2",
+    cx7Ip: "192.168.100.10",
+    occupancyHosts: ["192.168.4.50"],
+    isLocal: true,
+    llmPorts: [8888],
+  });
+  const cx7 = projectConversations(
+    [row({ handle: "cx7-chat", originHost: "192.168.100.10", originPort: 8888 })],
+    [box]
+  );
+  const wifi = projectConversations(
+    [row({ handle: "wifi-chat", originHost: "192.168.4.50", originPort: 8888 })],
+    [box]
+  );
+  assert.equal(rowsFor(cx7, "spark-box")[0].handle, "cx7-chat");
+  assert.equal(rowsFor(wifi, "spark-box")[0].handle, "wifi-chat");
+});
+
+test("withOccupancyHosts only annotates isLocal sparks", () => {
+  const local = spark({ id: "local", isLocal: true, lanIp: "10.0.0.1" });
+  const remote = spark({ id: "remote", isLocal: false, lanIp: "10.0.0.2" });
+  const [nextLocal, nextRemote] = withOccupancyHosts([local, remote], ["192.168.4.50"]);
+  assert.deepEqual(nextLocal.occupancyHosts, ["192.168.4.50"]);
+  assert.equal("occupancyHosts" in nextRemote, false);
+});
+
+test("localInterfaceHosts skips loopback, link-local, and bridge ifaces", () => {
+  const hosts = localInterfaceHosts({
+    lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+    docker0: [{ address: "172.17.0.1", family: "IPv4", internal: false }],
+    "br-abc": [{ address: "172.18.0.1", family: "IPv4", internal: false }],
+    wl0: [{ address: "192.168.4.50", family: "IPv4", internal: false }],
+    eth0: [{ address: "169.254.1.1", family: "IPv4", internal: false }],
+    tailscale0: [{ address: "100.10.0.2", family: "IPv4", internal: false }],
+  });
+  assert.deepEqual(hosts.sort(), ["100.10.0.2", "192.168.4.50"]);
+});
+
+test("parseFibLocalIpv4 keeps host LOCAL /32s and hostListenIps drops docker", () => {
+  const fib = `
+           |-- 192.168.4.117
+              /32 host LOCAL
+        |-- 172.17.0.1
+           /32 host LOCAL
+           |-- 100.10.0.2
+              /32 host LOCAL
+           |-- 127.0.0.1
+              /32 host LOCAL
+`;
+  assert.deepEqual(parseFibLocalIpv4(fib).sort(), [
+    "100.10.0.2",
+    "127.0.0.1",
+    "172.17.0.1",
+    "192.168.4.117",
+  ]);
+  const hosts = hostListenIps({
+    readFileSync: () => fib,
+    procPath: "/host/proc",
+  });
+  assert.deepEqual(hosts.sort(), ["100.10.0.2", "192.168.4.117"]);
+});

--- a/server/collectors/__tests__/sessionSourceHealth.test.js
+++ b/server/collectors/__tests__/sessionSourceHealth.test.js
@@ -1,0 +1,170 @@
+/**
+ * Session source Settings probe: counts only, no transcripts.
+ * Run: node --test server/collectors/__tests__/sessionSourceHealth.test.js
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { testSessionSources } from "../sessionSourceHealth.js";
+
+const MODULE_PATH = fileURLToPath(new URL("../sessionSourceHealth.js", import.meta.url));
+
+test("health probe iterates registry kinds, not a local SOURCE_IDS pair", () => {
+  const src = readFileSync(MODULE_PATH, "utf8");
+  assert.match(src, /sessionSourceIds|sessionSourceKinds/);
+  assert.match(src, /sessionSourceRegistry/);
+  assert.match(src, /occupancyDiagnosers/);
+  assert.equal(/\[["']openclaw["']\s*,\s*["']hermes["']\]/.test(src), false);
+});
+
+test("disabled sources return disabled without requiring a live attach", async () => {
+  const result = await testSessionSources(
+    { openclaw: { enabled: false }, hermes: { enabled: false } },
+    {
+      loadSessionSources: () => ({
+        openclaw: { enabled: false, mode: "local", url: "", stateDir: "" },
+        hermes: { enabled: false, mode: "local", url: "", stateDir: "" },
+      }),
+      loadSessionSourceTokens: () => ({ openclaw: "", hermes: "" }),
+      getSparks: () => [],
+    }
+  );
+  assert.deepEqual(result.openclaw, [
+    { id: "openclaw", status: "disabled", found: 0, mapped: 0, error: null },
+  ]);
+  assert.deepEqual(result.hermes, [
+    { id: "hermes", status: "disabled", found: 0, mapped: 0, error: null },
+  ]);
+});
+
+test("health returns found/mapped per registry kind without handles", async () => {
+  const { sessionSourceIds } = await import("../../sessionSourceRegistry.js");
+  const result = await testSessionSources(
+    { openclaw: { enabled: false }, hermes: { enabled: false } },
+    {
+      loadSessionSources: () => ({
+        openclaw: { enabled: false, mode: "local", url: "", stateDir: "" },
+        hermes: { enabled: false, mode: "local", url: "", stateDir: "" },
+      }),
+      loadSessionSourceTokens: () => ({ openclaw: "", hermes: "" }),
+      getSparks: () => [],
+    }
+  );
+  assert.deepEqual(Object.keys(result).sort(), [...sessionSourceIds()].sort());
+  for (const kind of sessionSourceIds()) {
+    assert.ok(Array.isArray(result[kind]));
+    for (const row of result[kind]) {
+      assert.equal("found" in row, true);
+      assert.equal("mapped" in row, true);
+      assert.equal("handle" in row, false);
+      assert.equal(JSON.stringify(row).includes("token"), false);
+    }
+  }
+});
+
+test("blank enabled URL is an error, not a conventional fallback", async () => {
+  const result = await testSessionSources(
+    { hermes: { enabled: true, mode: "url", url: "  " } },
+    {
+      loadSessionSources: () => ({
+        openclaw: { enabled: false, mode: "local", url: "", stateDir: "" },
+        hermes: { enabled: false, mode: "local", url: "", stateDir: "" },
+      }),
+      loadSessionSourceTokens: () => ({ openclaw: "", hermes: "" }),
+      getSparks: () => [],
+    }
+  );
+  assert.equal(result.hermes[0].status, "error");
+  assert.equal(result.hermes[0].error, "URL is required");
+  assert.equal(JSON.stringify(result).includes("token"), false);
+});
+
+const DISABLED = { enabled: false, mode: "local", url: "", stateDir: "" };
+const HERMES_SAVED = {
+  enabled: true,
+  mode: "url",
+  url: "http://127.0.0.1:8787",
+  stateDir: "",
+};
+
+test("stored token is not reused after the probed URL origin changes", async () => {
+  let seenToken = "unset";
+  await testSessionSources(
+    { hermes: { enabled: true, mode: "url", url: "http://10.0.0.2:8787" } },
+    {
+      loadSessionSources: () => ({ openclaw: DISABLED, hermes: HERMES_SAVED }),
+      loadSessionSourceTokens: () => ({ openclaw: "", hermes: "old-password" }),
+      getSparks: () => [],
+      fetchJson: async (_url, opts = {}) => {
+        seenToken = opts.token ?? "";
+        return { sessions: [] };
+      },
+    }
+  );
+  assert.equal(seenToken, "");
+});
+
+test("stored token is reused when the probed URL origin is unchanged", async () => {
+  let seenToken = "unset";
+  await testSessionSources(
+    { hermes: { enabled: true, mode: "url", url: "http://127.0.0.1:8787" } },
+    {
+      loadSessionSources: () => ({ openclaw: DISABLED, hermes: HERMES_SAVED }),
+      loadSessionSourceTokens: () => ({ openclaw: "", hermes: "old-password" }),
+      getSparks: () => [],
+      fetchJson: async (_url, opts = {}) => {
+        seenToken = opts.token ?? "";
+        return { sessions: [] };
+      },
+    }
+  );
+  assert.equal(seenToken, "old-password");
+});
+
+test("health probe reads the source once", async () => {
+  let sessionCalls = 0;
+  await testSessionSources(
+    { hermes: { enabled: true, mode: "url", url: "http://127.0.0.1:8787" } },
+    {
+      loadSessionSources: () => ({ openclaw: DISABLED, hermes: HERMES_SAVED }),
+      loadSessionSourceTokens: () => ({ openclaw: "", hermes: "" }),
+      getSparks: () => [],
+      fetchJson: async (url) => {
+        if (String(url).includes("/api/sessions")) sessionCalls += 1;
+        if (String(url).includes("/api/sessions")) return { sessions: [] };
+        const err = new Error("HTTP 404");
+        err.status = 404;
+        throw err;
+      },
+    }
+  );
+  assert.equal(sessionCalls, 1);
+});
+
+test("health probe returns one result per OpenClaw attach", async () => {
+  const result = await testSessionSources(
+    {
+      openclaw: [
+        { id: "openclaw", enabled: false },
+        { id: "openclaw-2", enabled: true, mode: "url", url: "  " },
+      ],
+    },
+    {
+      loadSessionSources: () => ({
+        openclaw: [
+          { id: "openclaw", enabled: false, mode: "local", url: "", stateDir: "" },
+          { id: "openclaw-2", enabled: false, mode: "url", url: "", stateDir: "" },
+        ],
+        hermes: DISABLED,
+      }),
+      loadSessionSourceTokens: () => ({}),
+      getSparks: () => [],
+    }
+  );
+  assert.equal(result.openclaw.length, 2);
+  assert.equal(result.openclaw[0].status, "disabled");
+  assert.equal(result.openclaw[1].id, "openclaw-2");
+  assert.equal(result.openclaw[1].status, "error");
+  assert.equal(result.openclaw[1].error, "URL is required");
+});

--- a/server/collectors/hermesAuth.js
+++ b/server/collectors/hermesAuth.js
@@ -1,0 +1,127 @@
+/**
+ * Hermes dashboard/WebUI login for URL attaches.
+ * Cookie cache is process-local. Never transcripts.
+ */
+
+const cookieCache = new Map();
+
+export function resetHermesAuthCache() {
+  cookieCache.clear();
+}
+
+export async function hermesAuthedGetter(origin, token, fetchResponse, username) {
+  if (!token) {
+    return async function getJson(url) {
+      const res = await fetchResponse(url);
+      return res.json();
+    };
+  }
+  let cookie = "";
+  try {
+    cookie = await cookieFor(origin, token, fetchResponse, username);
+  } catch (err) {
+    if (!isMissingLoginEndpoint(err)) throw err;
+  }
+  if (!cookie) {
+    return async function getJson(url) {
+      const res = await fetchResponse(url, { token });
+      return res.json();
+    };
+  }
+  return async function getJson(url) {
+    try {
+      const res = await fetchResponse(url, { cookie });
+      return res.json();
+    } catch (err) {
+      if (Number(err?.status) !== 401) throw err;
+      cookieCache.delete(cookieCacheKey(origin, token, username));
+      cookie = await cookieFor(origin, token, fetchResponse, username);
+      const res = await fetchResponse(url, { cookie });
+      return res.json();
+    }
+  };
+}
+
+function cookieCacheKey(origin, token, username) {
+  return `${origin}\0${token}\0${username || ""}`;
+}
+
+function isMissingLoginEndpoint(err) {
+  const status = Number(err?.status);
+  return status === 404 || status === 405;
+}
+
+function isBearerFallbackStatus(err) {
+  const status = Number(err?.status);
+  return isMissingLoginEndpoint(err) || status === 401 || status === 403;
+}
+
+async function cookieFor(origin, token, fetchResponse, username) {
+  const key = cookieCacheKey(origin, token, username);
+  const cached = cookieCache.get(key);
+  if (cached) return cached;
+  const cookie = await loginHermes(origin, token, fetchResponse, username);
+  if (cookie) cookieCache.set(key, cookie);
+  return cookie;
+}
+
+async function loginHermes(origin, token, fetchResponse, username) {
+  const provider = await discoverPasswordProvider(origin, fetchResponse);
+  if (provider) {
+    try {
+      const res = await fetchResponse(`${origin}/auth/password-login`, {
+        method: "POST",
+        extraHeaders: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider,
+          username: String(username || "").trim() || "admin",
+          password: token,
+        }),
+      });
+      return sessionCookieFromResponse(res);
+    } catch (err) {
+      if (isMissingLoginEndpoint(err)) return "";
+      throw err;
+    }
+  }
+  try {
+    const res = await fetchResponse(`${origin}/api/auth/login`, {
+      method: "POST",
+      extraHeaders: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password: token }),
+    });
+    return sessionCookieFromResponse(res);
+  } catch (err) {
+    if (isMissingLoginEndpoint(err)) return "";
+    throw err;
+  }
+}
+
+async function discoverPasswordProvider(origin, fetchResponse) {
+  try {
+    const res = await fetchResponse(`${origin}/api/auth/providers`);
+    const data = await res.json();
+    const list = Array.isArray(data?.providers) ? data.providers : [];
+    const found = list.find((item) => item && item.supports_password && item.name);
+    return found ? String(found.name) : "";
+  } catch (err) {
+    if (isBearerFallbackStatus(err)) return "";
+    throw err;
+  }
+}
+
+function sessionCookieFromResponse(res) {
+  const headers = res?.headers;
+  if (!headers) return "";
+  const rawList =
+    typeof headers.getSetCookie === "function"
+      ? headers.getSetCookie()
+      : [headers.get("set-cookie")].filter(Boolean);
+  const parts = [];
+  for (const raw of rawList) {
+    const first = String(raw).split(";", 1)[0].trim();
+    const name = first.split("=", 1)[0].toLowerCase();
+    if (name === "hermes_session" || name.startsWith("hermes_session_")) parts.push(first);
+  }
+  return parts.join("; ");
+}

--- a/server/collectors/occupancyPoller.js
+++ b/server/collectors/occupancyPoller.js
@@ -1,0 +1,162 @@
+/**
+ * Dashboard occupancy poll. Collect once per tick, then project onto Sparks.
+ * Never throws. Skip I/O when no registry kind is enabled.
+ * The process owner injects sparks/sources/tokens/apply; this module owns
+ * inflight, the LLM-cadence timer, and the disable-during-poll recheck.
+ */
+import { attachList } from "../sessionSources.js";
+import { sessionSourceIds } from "../sessionSourceRegistry.js";
+import { occupancyCollectors } from "./sessionSourceAdapters.js";
+import { projectConversations, withOccupancyHosts, hostListenIps } from "./sessionProjector.js";
+
+/**
+ * @param {object} opts
+ * @param {object[]} opts.sparks
+ * @param {Record<string, object|object[]>} opts.sources
+ * @param {Record<string, string>} [opts.tokens]
+ * @param {Record<string, Function>} [opts.collectors]
+ * @param {Function} [opts.project]
+ * @returns {Promise<Record<string, object[]>>}
+ */
+export async function pollOccupancy({
+  sparks,
+  sources,
+  tokens = {},
+  collectors,
+  project = projectConversations,
+} = {}) {
+  if (!sourcesEnabled(sources)) return {};
+  const collectByKind = {
+    ...occupancyCollectors(),
+    ...collectors,
+  };
+  const batches = await Promise.all(
+    sessionSourceIds().map((kind) => {
+      const collect = collectByKind[kind];
+      if (typeof collect !== "function") return [];
+      return collectKind(collect, sources?.[kind], tokens, kind);
+    })
+  );
+  try {
+    return project(batches.flat(), withOccupancyHosts(sparks, hostListenIps()));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * @param {object} opts
+ * @param {number} opts.intervalMs
+ * @param {() => object[]} opts.getSparks
+ * @param {() => object} opts.getSources
+ * @param {() => Record<string, string>} [opts.getTokens]
+ * @param {(bySpark: Record<string, object[]>) => void} opts.apply
+ * @param {typeof pollOccupancy} [opts.poll]
+ * @returns {{ start: () => void, stop: () => void, tick: () => Promise<void> }}
+ */
+export function createOccupancyLoop({
+  intervalMs,
+  getSparks,
+  getSources,
+  getTokens = () => ({}),
+  apply,
+  poll = pollOccupancy,
+} = {}) {
+  let inflight = false;
+  /** @type {ReturnType<typeof setInterval> | null} */
+  let timer = null;
+
+  async function tick() {
+    const sources = getSources();
+    const tokens = getTokens();
+    if (!sourcesEnabled(sources)) {
+      apply({});
+      return;
+    }
+    if (inflight) return;
+    inflight = true;
+    try {
+      const bySpark = await poll({
+        sparks: getSparks(),
+        sources,
+        tokens,
+      });
+      const currentSources = getSources();
+      const currentTokens = getTokens();
+      if (!sourcesEnabled(currentSources)) {
+        apply({});
+        return;
+      }
+      if (sourcesSnapshot(sources, tokens) !== sourcesSnapshot(currentSources, currentTokens)) {
+        return;
+      }
+      apply(bySpark);
+    } catch (err) {
+      console.error("[occupancy] poll error:", err.message);
+    } finally {
+      inflight = false;
+    }
+  }
+
+  function start() {
+    if (timer != null) return;
+    timer = setInterval(() => void tick(), intervalMs);
+    void tick();
+  }
+
+  function stop() {
+    if (timer == null) return;
+    clearInterval(timer);
+    timer = null;
+    inflight = false;
+  }
+
+  return { start, stop, tick };
+}
+
+export function sourcesEnabled(sources) {
+  return sessionSourceIds().some((kind) =>
+    attachList(sources?.[kind]).some((attach) => attach.enabled)
+  );
+}
+
+function collectKind(collect, attaches, tokens, kind) {
+  const jobs = attachList(attaches)
+    .filter((attach) => attach.enabled)
+    .map((attach) =>
+      collectSafe(collect, attach, { token: tokens[attach.id] ?? tokens[kind] ?? "" })
+    );
+  return Promise.all(jobs).then((batches) => batches.flat());
+}
+
+function attachSnapshot(attach, token) {
+  return {
+    id: attach?.id ?? "",
+    enabled: Boolean(attach?.enabled),
+    mode: attach?.mode ?? "",
+    url: attach?.url ?? "",
+    stateDir: attach?.stateDir ?? "",
+    label: attach?.label ?? "",
+    username: attach?.username ?? "",
+    token: token ?? "",
+  };
+}
+
+function sourcesSnapshot(sources, tokens = {}) {
+  const snapshot = {};
+  for (const kind of sessionSourceIds()) {
+    snapshot[kind] = attachList(sources?.[kind]).map((attach) =>
+      attachSnapshot(attach, tokens[attach.id] ?? tokens[kind])
+    );
+  }
+  return JSON.stringify(snapshot);
+}
+
+async function collectSafe(collect, attach, deps) {
+  try {
+    const rows = await collect(attach, deps);
+    return Array.isArray(rows) ? rows : [];
+  } catch {
+    return [];
+  }
+}

--- a/server/collectors/occupancyPoller.js
+++ b/server/collectors/occupancyPoller.js
@@ -16,6 +16,7 @@ import { projectConversations, withOccupancyHosts, hostListenIps } from "./sessi
  * @param {Record<string, string>} [opts.tokens]
  * @param {Record<string, Function>} [opts.collectors]
  * @param {Function} [opts.project]
+ * @param {number} [opts.maxAgeMs] - Hide sessions older than this (0 = show all)
  * @returns {Promise<Record<string, object[]>>}
  */
 export async function pollOccupancy({
@@ -24,6 +25,7 @@ export async function pollOccupancy({
   tokens = {},
   collectors,
   project = projectConversations,
+  maxAgeMs = 0,
 } = {}) {
   if (!sourcesEnabled(sources)) return {};
   const collectByKind = {
@@ -38,7 +40,7 @@ export async function pollOccupancy({
     })
   );
   try {
-    return project(batches.flat(), withOccupancyHosts(sparks, hostListenIps()));
+    return project(batches.flat(), withOccupancyHosts(sparks, hostListenIps()), { maxAgeMs });
   } catch {
     return {};
   }
@@ -59,6 +61,7 @@ export function createOccupancyLoop({
   getSparks,
   getSources,
   getTokens = () => ({}),
+  getMaxAgeMs = () => 0,
   apply,
   poll = pollOccupancy,
 } = {}) {
@@ -80,6 +83,7 @@ export function createOccupancyLoop({
         sparks: getSparks(),
         sources,
         tokens,
+        maxAgeMs: getMaxAgeMs(),
       });
       const currentSources = getSources();
       const currentTokens = getTokens();

--- a/server/collectors/openclawGateway.js
+++ b/server/collectors/openclawGateway.js
@@ -1,0 +1,233 @@
+/**
+ * OpenClaw URL attach: gateway WebSocket RPC (sessions.list + config.get).
+ * Control UI HTML at GET / is not a session list. Never transcripts.
+ */
+import crypto from "node:crypto";
+import WebSocket from "ws";
+import { LLM_PROBE_TIMEOUT_MS } from "../config.js";
+import { loadSessionSourceDevice, saveSessionSourceDevice } from "../secretsStore.js";
+import { assertAllowedFetchUrl } from "./sessionIo.js";
+
+const PROTOCOL_MIN = 3;
+const PROTOCOL_MAX = 4;
+const CLIENT = Object.freeze({
+  id: "cli",
+  version: "1.3.0",
+  platform: process.platform || "linux",
+  mode: "cli",
+});
+const SCOPES = Object.freeze(["operator.admin"]);
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+export function gatewayWsUrl(raw) {
+  const parsed = assertAllowedFetchUrl(raw);
+  const proto = parsed.protocol === "https:" ? "wss:" : "ws:";
+  return `${proto}//${parsed.host}`;
+}
+
+export function gatewayDeviceKey(url, attachId) {
+  const id = typeof attachId === "string" ? attachId.trim() : "";
+  if (id) return id;
+  try {
+    return `openclaw:${new URL(url).host}`;
+  } catch {
+    return "openclaw";
+  }
+}
+
+/**
+ * @param {string} url
+ * @param {string} [token]
+ * @param {{ deviceKey?: string, deviceIdentity?: object, timeoutMs?: number }} [opts]
+ * @returns {Promise<{ sessions: unknown, providers: Record<string, { baseUrl?: string }> }>}
+ */
+export async function defaultOpenClawGatewayRpc(url, token = "", opts = {}) {
+  const wsUrl = gatewayWsUrl(url);
+  const deviceKey = opts.deviceKey || gatewayDeviceKey(url);
+  const identity = opts.deviceIdentity ?? loadOrCreateDevice(deviceKey);
+  const timeoutMs = opts.timeoutMs ?? LLM_PROBE_TIMEOUT_MS;
+  return await withGateway(wsUrl, timeoutMs, identity, token);
+}
+
+function loadOrCreateDevice(id) {
+  const stored = loadSessionSourceDevice(id);
+  if (stored?.deviceId && stored?.publicKey && stored?.privateKeyPem) return stored;
+  const created = createIdentity();
+  try {
+    saveSessionSourceDevice(id, created);
+  } catch {
+    /* still connect; pairing will not stick across restarts */
+  }
+  return created;
+}
+
+function createIdentity() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const raw = publicKeyRaw(publicKey);
+  return {
+    deviceId: crypto.createHash("sha256").update(raw).digest("hex"),
+    publicKey: b64url(raw),
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+  };
+}
+
+function publicKeyRaw(publicKey) {
+  const spki = publicKey.export({ type: "spki", format: "der" });
+  if (
+    spki.length === ED25519_SPKI_PREFIX.length + 32 &&
+    spki.subarray(0, ED25519_SPKI_PREFIX.length).equals(ED25519_SPKI_PREFIX)
+  ) {
+    return spki.subarray(ED25519_SPKI_PREFIX.length);
+  }
+  return spki;
+}
+
+function b64url(buf) {
+  return Buffer.from(buf).toString("base64").replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "");
+}
+
+function normalizeMeta(value) {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.replace(/[A-Z]/g, (char) => String.fromCharCode(char.charCodeAt(0) + 32));
+}
+
+function buildConnectParams(nonce, identity, token) {
+  if (!nonce) throw new Error("gateway connect challenge missing nonce");
+  const signedAt = Date.now();
+  const payload = [
+    "v3",
+    identity.deviceId,
+    CLIENT.id,
+    CLIENT.mode,
+    "operator",
+    SCOPES.join(","),
+    String(signedAt),
+    token ?? "",
+    nonce,
+    normalizeMeta(CLIENT.platform),
+    "",
+  ].join("|");
+  const key = crypto.createPrivateKey(identity.privateKeyPem);
+  const signature = b64url(crypto.sign(null, Buffer.from(payload, "utf8"), key));
+  return {
+    minProtocol: PROTOCOL_MIN,
+    maxProtocol: PROTOCOL_MAX,
+    client: { ...CLIENT },
+    role: "operator",
+    scopes: [...SCOPES],
+    ...(token ? { auth: { token } } : {}),
+    device: {
+      id: identity.deviceId,
+      publicKey: identity.publicKey,
+      signature,
+      signedAt,
+      nonce,
+    },
+  };
+}
+
+function providersFromConfig(payload) {
+  const cfg = payload?.config ?? payload;
+  const providers = cfg?.models?.providers;
+  return providers && typeof providers === "object" && !Array.isArray(providers) ? providers : {};
+}
+
+function rpcError(parsed) {
+  return new Error(parsed?.error?.message || "Request failed");
+}
+
+function withGateway(wsUrl, timeoutMs, identity, token) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl, { handshakeTimeout: timeoutMs });
+    const pending = new Map();
+    let seq = 0;
+    let settled = false;
+    const timer = setTimeout(() => {
+      finish(Object.assign(new Error("Timed out"), { name: "TimeoutError" }));
+    }, timeoutMs);
+
+    function finish(err, value) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        ws.close();
+      } catch {
+        /* already closed */
+      }
+      if (err) reject(err);
+      else resolve(value);
+    }
+
+    function sendReq(method, params = {}) {
+      const id = `r${++seq}`;
+      return new Promise((res, rej) => {
+        pending.set(id, { res, rej });
+        ws.send(JSON.stringify({ type: "req", id, method, params }));
+      });
+    }
+
+    ws.on("error", (err) => finish(err instanceof Error ? err : new Error(String(err))));
+    ws.on("close", (code, reason) => {
+      if (settled) return;
+      const text = String(reason || "").trim();
+      finish(new Error(text || `WebSocket closed (${code})`));
+    });
+    ws.on("message", (data) => {
+      let parsed;
+      try {
+        parsed = JSON.parse(String(data));
+      } catch (err) {
+        finish(err);
+        return;
+      }
+      if (parsed.type === "event" && parsed.event === "connect.challenge") {
+        try {
+          ws.send(
+            JSON.stringify({
+              type: "req",
+              id: "connect",
+              method: "connect",
+              params: buildConnectParams(parsed.payload?.nonce, identity, token),
+            })
+          );
+        } catch (err) {
+          finish(err instanceof Error ? err : new Error(String(err)));
+        }
+        return;
+      }
+      if (parsed.type !== "res") return;
+      if (parsed.id === "connect") {
+        if (!parsed.ok) {
+          finish(rpcError(parsed));
+          return;
+        }
+        void (async () => {
+          try {
+            const listed = await sendReq("sessions.list", {});
+            let config = {};
+            try {
+              config = await sendReq("config.get", {});
+            } catch {
+              config = {};
+            }
+            finish(null, {
+              sessions: listed?.sessions ?? listed ?? [],
+              providers: providersFromConfig(config),
+            });
+          } catch (err) {
+            finish(err instanceof Error ? err : new Error(String(err)));
+          }
+        })();
+        return;
+      }
+      const waiter = pending.get(parsed.id);
+      if (!waiter) return;
+      pending.delete(parsed.id);
+      if (!parsed.ok) waiter.rej(rpcError(parsed));
+      else waiter.res(parsed.payload);
+    });
+  });
+}

--- a/server/collectors/sessionIo.js
+++ b/server/collectors/sessionIo.js
@@ -1,0 +1,350 @@
+/**
+ * Shared I/O helpers for OpenClaw / Hermes conversation readers.
+ * Collectors keep their own mapping and mid-turn rules.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { HOST_PATHS, LLM_PROBE_TIMEOUT_MS } from "../config.js";
+import { isAllowedTargetHost } from "../validate.js";
+import { conventionalConfigDir } from "../sessionSourceRegistry.js";
+
+/**
+ * @param {string} url
+ * @returns {{ host: string, port: number } | null}
+ */
+export function parseBaseUrl(url) {
+  if (!url || typeof url !== "string") return null;
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname;
+    if (!host) return null;
+    const port = parsed.port
+      ? Number(parsed.port)
+      : parsed.protocol === "https:"
+        ? 443
+        : 80;
+    if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+    return { host, port };
+  } catch {
+    return null;
+  }
+}
+
+export function expandTilde(raw, home) {
+  const value = String(raw || "");
+  if (value === "~") return home;
+  if (value.startsWith("~/")) return path.join(home, value.slice(2));
+  return value;
+}
+
+export function pathReadable(filePath) {
+  try {
+    fs.accessSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function remapHostRoot(expanded, deps = {}) {
+  const hostRoot = deps.hostRoot === undefined ? HOST_PATHS.ROOT : deps.hostRoot;
+  if (!hostRoot) return expanded;
+  const isReadable = deps.isReadable ?? pathReadable;
+  if (isReadable(expanded)) return expanded;
+  if (!expanded.startsWith("/") || !isReadable(hostRoot)) return expanded;
+  const mapped = path.join(hostRoot, expanded.slice(1));
+  return isReadable(mapped) ? mapped : expanded;
+}
+
+export function resolveStateDir(attach, deps, conventional) {
+  const home = deps.homedir ?? os.homedir();
+  if (attach.mode === "state-dir") {
+    if (!attach.stateDir) return "";
+    return remapHostRoot(expandTilde(attach.stateDir, home), deps);
+  }
+  return remapHostRoot(expandTilde(String(conventional || ""), home), deps);
+}
+
+/**
+ * Resolve a source kind's conventional config directory, with host-root remap.
+ * Empty when the kind has no config dir.
+ * @param {string} source - Source kind id
+ * @param {object} deps - { conventionalConfigDir?, homedir?, hostRoot?, isReadable? }
+ * @returns {string}
+ */
+export function resolveConfigDir(source, deps = {}) {
+  const conventional = deps.conventionalConfigDir ?? conventionalConfigDir(source);
+  if (!conventional) return "";
+  const home = deps.homedir ?? os.homedir();
+  return remapHostRoot(expandTilde(String(conventional), home), deps);
+}
+
+/**
+ * Read a file, returning null on any error (missing, unreadable, etc).
+ * @param {Function} readFile
+ * @param {string} filePath
+ * @returns {Promise<string | null>}
+ */
+export async function readOptional(readFile, filePath) {
+  try {
+    return await readFile(filePath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sanitize a projector row to an allowlisted shape.
+ * Copies only the listed keys; forces source and midTurn defaults.
+ * @param {object} row
+ * @param {string} source
+ * @param {string[]} keys
+ * @returns {object}
+ */
+export function sanitizeProjectorRow(row, source, keys) {
+  const out = { source, midTurn: "unknown" };
+  if (!row || typeof row !== "object") return out;
+  for (const key of keys) {
+    if (row[key] !== undefined) out[key] = row[key];
+  }
+  out.source = source;
+  if (out.midTurn == null) out.midTurn = "unknown";
+  return out;
+}
+
+export function defaultReadFile(filePath) {
+  return fs.promises.readFile(filePath, "utf8");
+}
+
+export function defaultReadDir(dirPath) {
+  return fs.promises.readdir(dirPath);
+}
+
+export function defaultStat(filePath) {
+  return fs.promises.stat(filePath);
+}
+
+export function assertAllowedFetchUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("Invalid URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Invalid URL protocol: ${parsed.protocol}`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("URL userinfo is not allowed");
+  }
+  if (!isAllowedTargetHost(parsed.hostname)) {
+    throw new Error(`Invalid or disallowed host: ${parsed.hostname}`);
+  }
+  return parsed;
+}
+
+export async function defaultFetchResponse(url, { token, cookie, method, body, extraHeaders } = {}) {
+  assertAllowedFetchUrl(url);
+  const headers = { Accept: "application/json", ...(extraHeaders ?? {}) };
+  if (cookie) headers.Cookie = cookie;
+  else if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(url, {
+    method: method ?? "GET",
+    headers,
+    body,
+    redirect: "error",
+    signal: AbortSignal.timeout(LLM_PROBE_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const err = new Error(`HTTP ${res.status}`);
+    err.status = res.status;
+    throw err;
+  }
+  return res;
+}
+
+export async function defaultFetchJson(url, opts = {}) {
+  const res = await defaultFetchResponse(url, opts);
+  return res.json();
+}
+
+export function normalizeSessionList(sessions) {
+  if (Array.isArray(sessions)) return sessions;
+  if (sessions && Array.isArray(sessions.sessions)) return sessions.sessions;
+  return null;
+}
+
+const LAST_USED_FIELDS = [
+  "updatedAt",
+  "updated_at",
+  "lastActivityAt",
+  "last_activity",
+  "last_activity_at",
+  "lastMessageAt",
+  "last_message_at",
+  "mtime",
+  "modifiedAt",
+  "timestamp",
+  "createdAt",
+  "created_at",
+];
+
+/** Epoch ms from a session timestamp field. Null when absent or unparseable. */
+export function parseSessionTime(value) {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value < 1e12 ? Math.round(value * 1000) : Math.round(value);
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && numeric > 0) return parseSessionTime(numeric);
+  }
+  return null;
+}
+
+/** Prefer updated/activity timestamps; createdAt is last-resort. Never Date.now(). */
+export function sessionLastUsedAt(session) {
+  if (!session || typeof session !== "object") return null;
+  for (const field of LAST_USED_FIELDS) {
+    const ms = parseSessionTime(session[field]);
+    if (ms != null) return ms;
+  }
+  return null;
+}
+
+const AGENT_FIELDS = ["agentId", "agent_id", "agent", "profile", "profile_name", "active_profile"];
+
+/** OpenClaw/Hermes key form `agent:<id>:…`. Empty when absent. */
+export function agentFromSessionKey(value) {
+  const match = String(value || "").match(/^agent:([^:]+):/);
+  return match ? match[1].trim() : "";
+}
+
+/** `…/profiles/<name>/…` → name. Empty when the path is not a profile home. */
+export function profileFromStateDir(dir) {
+  const parts = String(dir || "").split(/[/\\]/).filter(Boolean);
+  const index = parts.indexOf("profiles");
+  const name = index >= 0 ? parts[index + 1] : "";
+  if (!name || name === "." || name === "..") return "";
+  return name;
+}
+
+function trimmedAgent(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+const CONTEXT_USED_FIELDS = [
+  "totalTokens",
+  "last_prompt_tokens",
+  "lastPromptTokens",
+  "input_tokens",
+  "inputTokens",
+];
+const CONTEXT_WINDOW_FIELDS = [
+  "contextTokens",
+  "context_tokens",
+  "contextWindow",
+  "context_window",
+];
+
+function positiveTokens(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n);
+}
+
+function firstPositiveToken(session, fields) {
+  for (const field of fields) {
+    const n = positiveTokens(session[field]);
+    if (n != null) return n;
+  }
+  return null;
+}
+
+/**
+ * Current context fill and window from a session list row. Counts only.
+ * @returns {{ used?: number, window?: number, approx?: boolean } | null}
+ */
+export function sessionContextSize(session) {
+  if (!session || typeof session !== "object") return null;
+  const used = firstPositiveToken(session, CONTEXT_USED_FIELDS);
+  const window = firstPositiveToken(session, CONTEXT_WINDOW_FIELDS);
+  if (used == null && window == null) return null;
+  const size = {};
+  if (used != null) size.used = used;
+  if (window != null) size.window = window;
+  if (session.totalTokensFresh === false && used != null) size.approx = true;
+  return size;
+}
+
+/** Stamp contextUsed / contextWindow onto a projector row. */
+export function applySessionContext(mapped, session) {
+  const size = sessionContextSize(session);
+  if (!size) return mapped;
+  if (size.used != null) mapped.contextUsed = size.used;
+  if (size.window != null) mapped.contextWindow = size.window;
+  if (size.approx) mapped.contextApprox = true;
+  return mapped;
+}
+
+/** OpenClaw agent id or Hermes profile/agent. Never a transcript. */
+export function sessionAgent(session, fallback = "") {
+  if (session && typeof session === "object") {
+    for (const field of AGENT_FIELDS) {
+      const value = trimmedAgent(session[field]);
+      if (value) return value;
+    }
+  }
+  const fromFallback = trimmedAgent(fallback);
+  if (fromFallback) return fromFallback;
+  if (session && typeof session === "object") {
+    return agentFromSessionKey(session.key ?? session.session_key ?? session.sessionKey);
+  }
+  return "";
+}
+
+/**
+ * Stamp attach id onto row ids and an optional gateway label for grouping.
+ * @param {object[]} rows
+ * @param {{ id?: string, label?: string, url?: string }} [attach]
+ */
+export function stampAttachRows(rows, attach) {
+  const list = Array.isArray(rows) ? rows : [];
+  const attachId = typeof attach?.id === "string" ? attach.id.trim() : "";
+  if (!attachId) return list;
+  const label = typeof attach?.label === "string" ? attach.label.trim() : "";
+  const origin = parseBaseUrl(attach?.url);
+  const gateway = label || origin?.host || "";
+  return list.map((row) => {
+    const next = { ...row };
+    if (next.id != null) next.id = `${attachId}:${next.id}`;
+    if (gateway) next.gateway = gateway;
+    return next;
+  });
+}
+
+/** Short probe error for Settings. No paths, tokens, or payloads. */
+export function sanitizeProbeError(err) {
+  const code = err?.code;
+  if (code === "ENOENT") return "State files not found";
+  if (code === "EACCES" || code === "EPERM") return "Permission denied";
+  if (code === "ENOTFOUND") return "Host not found";
+  if (code === "ECONNREFUSED") return "Connection refused";
+  if (code === "ECONNRESET") return "Connection reset";
+  if (code === "ETIMEDOUT" || err?.name === "TimeoutError" || err?.name === "AbortError") {
+    return "Timed out";
+  }
+  const status = Number(err?.status);
+  if (status === 401 || status === 403) return `HTTP ${status} (auth failed)`;
+  if (Number.isInteger(status) && status >= 400) return `HTTP ${status}`;
+  const raw = err?.message ? String(err.message) : "Request failed";
+  if (/pairing required/i.test(raw)) return "Pairing required — approve this device in OpenClaw";
+  if (/missing scope/i.test(raw)) return "Missing operator.read scope";
+  if (/Unexpected token|^JSON|not valid JSON/i.test(raw)) return "Not a JSON session list";
+  if (/^HTTP 401\b/.test(raw) || /^HTTP 403\b/.test(raw)) return `${raw.split(/\s+/).slice(0, 2).join(" ")} (auth failed)`;
+  const http = raw.match(/^HTTP \d+/);
+  if (http) return http[0];
+  return "Request failed";
+}

--- a/server/collectors/sessionProjector.js
+++ b/server/collectors/sessionProjector.js
@@ -1,0 +1,231 @@
+/**
+ * Project source session rows onto Sparks by LLM listen origin (host+port).
+ * Occupancy badges are per-conversation mid-turn. List order is generating
+ * first, then lastUsedAt descending. Projector does not inject Date.now().
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { HOST_PATHS } from "../config.js";
+
+const LOOPBACK_HOSTS = ["127.0.0.1", "localhost", "::1"];
+const LIST_CAP = 20;
+const SKIP_IFACE = /^(lo\d*|docker|br-|veth|virbr|cni)/i;
+
+/**
+ * @param {object[]} rows
+ * @param {object[]} sparks
+ * @returns {Record<string, object[]>}
+ */
+export function projectConversations(rows, sparks) {
+  const list = Array.isArray(sparks) ? sparks : [];
+  const nameHosts = exclusiveNameHosts(list);
+  const bySpark = {};
+  for (const spark of list) {
+    if (!spark?.id) continue;
+    const projected = projectSpark(Array.isArray(rows) ? rows : [], spark, nameHosts);
+    if (projected.length > 0) bySpark[spark.id] = projected;
+  }
+  return bySpark;
+}
+
+function projectSpark(rows, spark, nameHosts) {
+  const ports = listenPorts(spark);
+  if (ports.size === 0) return [];
+  const hosts = listenHosts(spark, nameHosts);
+  const matched = [];
+  for (const row of rows) {
+    const port = Number(row?.originPort);
+    if (!ports.has(port)) continue;
+    if (!hosts.has(normalizeHost(row?.originHost))) continue;
+    matched.push(toConversationRow(row, port));
+  }
+  matched.sort(compareRows);
+  return uniquifyIds(matched).slice(0, LIST_CAP);
+}
+
+function listenPorts(spark) {
+  const ports = new Set();
+  for (const value of spark.llmPorts ?? []) {
+    const port = Number(value);
+    if (Number.isInteger(port) && port >= 1 && port <= 65535) ports.add(port);
+  }
+  return ports;
+}
+
+function listenHosts(spark, nameHosts) {
+  const hosts = new Set();
+  const lan = normalizeHost(spark.lanIp);
+  if (lan) hosts.add(lan);
+  const cx7 = normalizeHost(spark.cx7Ip);
+  if (cx7) hosts.add(cx7);
+  const named = normalizeHost(spark.name);
+  if (named && nameHosts.has(named)) hosts.add(named);
+  const sshHost = normalizeHost(spark.ssh?.host);
+  if (sshHost) hosts.add(sshHost);
+  if (spark.isLocal) {
+    for (const host of LOOPBACK_HOSTS) hosts.add(host);
+  }
+  for (const extra of spark.occupancyHosts ?? []) {
+    const host = normalizeHost(extra);
+    if (host) hosts.add(host);
+  }
+  return hosts;
+}
+
+/**
+ * IPv4 addresses on this host that an LLM URL might use.
+ * Skips loopback, link-local, and container/bridge ifaces.
+ * @param {NodeJS.Dict<os.NetworkInterfaceInfo[]>} [ifaces]
+ * @returns {string[]}
+ */
+export function localInterfaceHosts(ifaces = os.networkInterfaces()) {
+  const hosts = [];
+  for (const [name, addrs] of Object.entries(ifaces || {})) {
+    if (SKIP_IFACE.test(name)) continue;
+    for (const addr of addrs || []) {
+      if (!addr || addr.internal) continue;
+      const family = addr.family;
+      if (family !== "IPv4" && family !== 4) continue;
+      const ip = String(addr.address || "").trim();
+      if (isUsableListenIp(ip)) hosts.push(ip);
+    }
+  }
+  return [...new Set(hosts)];
+}
+
+/** `/32 host LOCAL` IPv4s from a fib_trie dump. */
+export function parseFibLocalIpv4(text) {
+  const hosts = [];
+  let prevIp = "";
+  for (const line of String(text || "").split("\n")) {
+    const ipMatch = line.match(/(\d{1,3}(?:\.\d{1,3}){3})\s*$/);
+    if (ipMatch) prevIp = ipMatch[1];
+    if (/\/32\s+host\s+LOCAL/.test(line) && prevIp) {
+      hosts.push(prevIp);
+      prevIp = "";
+    }
+  }
+  return hosts;
+}
+
+/**
+ * Listen IPs for the Spark that is this host. Prefer host PID 1's netns
+ * (`/host/proc/1/net/fib_trie` in Docker) so Wi-Fi/LAN addresses are visible
+ * inside the container.
+ * @param {{ procPath?: string, readFileSync?: Function, ifaces?: NodeJS.Dict<os.NetworkInterfaceInfo[]> }} [deps]
+ */
+export function hostListenIps(deps = {}) {
+  const proc = deps.procPath ?? HOST_PATHS.PROC;
+  const read = deps.readFileSync ?? fs.readFileSync;
+  try {
+    const text = read(path.join(proc, "1", "net", "fib_trie"), "utf8");
+    const parsed = parseFibLocalIpv4(text).filter(isUsableListenIp);
+    if (parsed.length > 0) return [...new Set(parsed)];
+  } catch {
+    /* fall through to the process netns */
+  }
+  return localInterfaceHosts(deps.ifaces);
+}
+
+function isUsableListenIp(ip) {
+  if (!ip || typeof ip !== "string") return false;
+  if (ip.startsWith("127.") || ip.startsWith("169.254.")) return false;
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n))) return false;
+  if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return false;
+  return true;
+}
+
+/** Copy isLocal sparks with this host's extra listen IPs. Projector stays pure. */
+export function withOccupancyHosts(sparks, hosts = localInterfaceHosts()) {
+  const extra = Array.isArray(hosts) ? hosts.filter(Boolean) : [];
+  const list = Array.isArray(sparks) ? sparks : [];
+  if (extra.length === 0) return list;
+  return list.map((spark) => (spark?.isLocal ? { ...spark, occupancyHosts: extra } : spark));
+}
+
+function exclusiveNameHosts(sparks) {
+  const names = new Map();
+  const identity = new Map();
+  for (const spark of sparks) {
+    if (!spark?.id) continue;
+    const name = normalizeHost(spark.name);
+    if (name) names.set(name, [...(names.get(name) || []), spark.id]);
+    for (const host of [normalizeHost(spark.lanIp), normalizeHost(spark.ssh?.host)]) {
+      if (!host) continue;
+      identity.set(host, [...(identity.get(host) || []), spark.id]);
+    }
+  }
+  const exclusive = new Set();
+  for (const [name, ids] of names) {
+    if (new Set(ids).size !== 1) continue;
+    const owner = ids[0];
+    const claimedByOther = (identity.get(name) || []).some((id) => id !== owner);
+    if (claimedByOther) continue;
+    exclusive.add(name);
+  }
+  return exclusive;
+}
+
+function normalizeHost(value) {
+  if (value == null) return "";
+  let host = String(value).trim().toLowerCase();
+  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
+  return host;
+}
+
+function toConversationRow(row, port) {
+  const handle = String(row.handle ?? "");
+  const source = row.source;
+  const nativeId = String(row.id ?? "").trim();
+  const lastUsedAt = Number.isFinite(row.lastUsedAt) ? row.lastUsedAt : null;
+  const agent = typeof row.agent === "string" && row.agent.trim() ? row.agent.trim() : "";
+  const projected = {
+    id: nativeId || `${source}:${port}:${handle}`,
+    source,
+    handle,
+    badge: badgeFromMidTurn(row.midTurn),
+    port,
+  };
+  if (lastUsedAt != null) projected.lastUsedAt = lastUsedAt;
+  if (agent) projected.agent = agent;
+  if (typeof row.gateway === "string" && row.gateway.trim()) projected.gateway = row.gateway.trim();
+  const used = Number(row.contextUsed);
+  if (Number.isFinite(used) && used > 0) projected.contextUsed = Math.round(used);
+  const window = Number(row.contextWindow);
+  if (Number.isFinite(window) && window > 0) projected.contextWindow = Math.round(window);
+  if (row.contextApprox === true) projected.contextApprox = true;
+  return projected;
+}
+
+function uniquifyIds(rows) {
+  const used = new Set();
+  return rows.map((row) => {
+    let { id } = row;
+    if (!used.has(id)) {
+      used.add(id);
+      return row;
+    }
+    let n = 2;
+    while (used.has(`${id}:${n}`)) n += 1;
+    id = `${id}:${n}`;
+    used.add(id);
+    return { ...row, id };
+  });
+}
+
+function badgeFromMidTurn(midTurn) {
+  if (midTurn === true) return "generating";
+  if (midTurn === false) return "stalled";
+  return "unknown";
+}
+
+function compareRows(a, b) {
+  const live = Number(b.badge === "generating") - Number(a.badge === "generating");
+  if (live) return live;
+  const tb = b.lastUsedAt ?? 0;
+  const ta = a.lastUsedAt ?? 0;
+  if (tb !== ta) return tb - ta;
+  return a.source.localeCompare(b.source) || (a.gateway ?? "").localeCompare(b.gateway ?? "") || a.handle.localeCompare(b.handle) || a.port - b.port || (a.agent ?? "").localeCompare(b.agent ?? "") || a.id.localeCompare(b.id);
+}

--- a/server/collectors/sessionProjector.js
+++ b/server/collectors/sessionProjector.js
@@ -15,18 +15,32 @@ const SKIP_IFACE = /^(lo\d*|docker|br-|veth|virbr|cni)/i;
 /**
  * @param {object[]} rows
  * @param {object[]} sparks
+ * @param {{ maxAgeMs?: number, now?: number }} [opts]
  * @returns {Record<string, object[]>}
  */
-export function projectConversations(rows, sparks) {
+export function projectConversations(rows, sparks, opts = {}) {
   const list = Array.isArray(sparks) ? sparks : [];
   const nameHosts = exclusiveNameHosts(list);
+  const maxAgeMs = opts.maxAgeMs ?? 0;
+  const now = opts.now ?? Date.now();
+  const filtered = maxAgeMs > 0 ? filterByAge(rows, maxAgeMs, now) : rows;
   const bySpark = {};
   for (const spark of list) {
     if (!spark?.id) continue;
-    const projected = projectSpark(Array.isArray(rows) ? rows : [], spark, nameHosts);
+    const projected = projectSpark(filtered, spark, nameHosts);
     if (projected.length > 0) bySpark[spark.id] = projected;
   }
   return bySpark;
+}
+
+/** Drop rows whose lastUsedAt is older than maxAgeMs. Keep rows with no timestamp. */
+function filterByAge(rows, maxAgeMs, now) {
+  const cutoff = now - maxAgeMs;
+  return rows.filter((row) => {
+    const ts = row?.lastUsedAt;
+    if (ts == null || !Number.isFinite(ts)) return true;
+    return ts >= cutoff;
+  });
 }
 
 function projectSpark(rows, spark, nameHosts) {

--- a/server/collectors/sessionSourceAdapters.js
+++ b/server/collectors/sessionSourceAdapters.js
@@ -1,0 +1,34 @@
+/**
+ * Runtime collect/diagnose adapters for occupancy kinds.
+ * Keep this out of sessionSourceRegistry so the registry stays metadata-only
+ * and never imports OpenClaw/Hermes/OpenCode (ESM cycle).
+ */
+import { collectOpenClawSessions, diagnoseOpenClawSessions } from "./OpenClawSessions.js";
+import { collectHermesSessions, diagnoseHermesSessions } from "./HermesSessions.js";
+import { collectOpenCodeSessions, diagnoseOpenCodeSessions } from "./OpenCodeSessions.js";
+import { collectOmpSessions, diagnoseOmpSessions } from "./OmpSessions.js";
+import { sessionSourceIds } from "../sessionSourceRegistry.js";
+
+const ADAPTERS = {
+  openclaw: { collect: collectOpenClawSessions, diagnose: diagnoseOpenClawSessions },
+  hermes: { collect: collectHermesSessions, diagnose: diagnoseHermesSessions },
+  opencode: { collect: collectOpenCodeSessions, diagnose: diagnoseOpenCodeSessions },
+  omp: { collect: collectOmpSessions, diagnose: diagnoseOmpSessions },
+};
+
+function byKind(field) {
+  const out = {};
+  for (const id of sessionSourceIds()) {
+    const fn = ADAPTERS[id]?.[field];
+    if (typeof fn === "function") out[id] = fn;
+  }
+  return out;
+}
+
+export function occupancyCollectors() {
+  return byKind("collect");
+}
+
+export function occupancyDiagnosers() {
+  return byKind("diagnose");
+}

--- a/server/collectors/sessionSourceHealth.js
+++ b/server/collectors/sessionSourceHealth.js
@@ -1,0 +1,121 @@
+/**
+ * Settings connectivity probe for session sources.
+ * Counts only. Never persists. Never returns handles, transcripts, or tokens.
+ */
+import { attachList, loadSessionSources, conventionalStateDir } from "../sessionSources.js";
+import { sessionSourceIds } from "../sessionSourceRegistry.js";
+import { loadSessionSourceTokens } from "../secretsStore.js";
+import { occupancyDiagnosers } from "./sessionSourceAdapters.js";
+import { parseBaseUrl } from "./sessionIo.js";
+import { projectConversations, withOccupancyHosts, hostListenIps } from "./sessionProjector.js";
+
+/**
+ * @param {object} [body]
+ * @param {{ getSparks?: () => object[], loadSessionSources?: Function, loadSessionSourceTokens?: Function, diagnoseByKind?: Record<string, Function> }} [deps]
+ * @returns {Promise<Record<string, object[]>>}
+ */
+export async function testSessionSources(body = {}, deps = {}) {
+  const saved = (deps.loadSessionSources ?? loadSessionSources)();
+  const storedTokens = (deps.loadSessionSourceTokens ?? loadSessionSourceTokens)();
+  const sparks = deps.getSparks?.() ?? [];
+  const patch = body && typeof body === "object" ? body : {};
+  const diagnoseByKind = { ...occupancyDiagnosers(), ...deps.diagnoseByKind };
+  const pairs = await Promise.all(
+    sessionSourceIds().map(async (kind) => {
+      const rows = await probeKind(
+        kind,
+        saved[kind],
+        storedTokens,
+        patch[kind],
+        sparks,
+        { ...deps, diagnose: diagnoseByKind[kind] }
+      );
+      return [kind, rows];
+    })
+  );
+  return Object.fromEntries(pairs);
+}
+
+function probePatches(savedList, patch) {
+  if (patch === undefined) return savedList.map(() => ({}));
+  const listed = attachList(patch);
+  return listed.length > 0 ? listed : [{}];
+}
+
+async function probeKind(kind, savedRaw, storedTokens, patch, sparks, deps) {
+  const savedList = attachList(savedRaw);
+  const patches = probePatches(savedList, patch);
+  const jobs = patches.map((item, index) => {
+    const saved = (item.id && savedList.find((a) => a.id === item.id)) || savedList[index] || savedList[0] || {};
+    const attach = attachForTest(saved, item);
+    const token = tokenForTest(storedTokens[attach.id] ?? storedTokens[kind], item, saved, attach);
+    const collectDeps = {
+      token,
+      conventionalStateDir: conventionalStateDir(kind),
+      countMapped: (rows) => countBound(rows, sparks),
+      listSessions: deps.listSessions,
+      fetchJson: deps.fetchJson,
+      fetchResponse: deps.fetchResponse,
+      gatewayRpc: deps.gatewayRpc,
+    };
+    const diagnose = deps.diagnose;
+    if (typeof diagnose !== "function") {
+      return Promise.resolve({
+        id: attach.id || kind,
+        status: "disabled",
+        found: 0,
+        mapped: 0,
+        error: null,
+      });
+    }
+    return diagnose(attach, collectDeps).then((result) => ({ id: attach.id || kind, ...result }));
+  });
+  return Promise.all(jobs);
+}
+
+function countBound(rows, sparks) {
+  if (!Array.isArray(sparks) || sparks.length === 0) return 0;
+  const bySpark = projectConversations(
+    Array.isArray(rows) ? rows : [],
+    withOccupancyHosts(sparks, hostListenIps())
+  );
+  return Object.values(bySpark).reduce((sum, list) => sum + (Array.isArray(list) ? list.length : 0), 0);
+}
+
+function attachForTest(saved, patch) {
+  const src = patch && typeof patch === "object" ? patch : {};
+  return {
+    id: typeof src.id === "string" && src.id.trim() ? src.id.trim() : saved?.id,
+    enabled: src.enabled !== undefined ? Boolean(src.enabled) : Boolean(saved?.enabled),
+    mode: typeof src.mode === "string" ? src.mode : saved?.mode ?? "local",
+    url: src.url !== undefined ? String(src.url).trim() : String(saved?.url ?? ""),
+    stateDir: src.stateDir !== undefined ? String(src.stateDir).trim() : String(saved?.stateDir ?? ""),
+    label: src.label !== undefined ? String(src.label).trim() : String(saved?.label ?? ""),
+    username: src.username !== undefined ? String(src.username).trim() : String(saved?.username ?? ""),
+  };
+}
+
+function tokenForTest(storedToken, patch, saved, attach) {
+  if (patch && typeof patch === "object" && Object.prototype.hasOwnProperty.call(patch, "token")) {
+    return patch.token == null ? "" : String(patch.token);
+  }
+  if (!sameProbeTarget(saved, attach)) return "";
+  return storedToken ?? "";
+}
+
+function sameProbeTarget(saved, attach) {
+  const savedMode = saved?.mode ?? "local";
+  if (attach.mode !== savedMode) return false;
+  if (attach.mode === "url") return sameOrigin(saved?.url, attach.url);
+  if (attach.mode === "state-dir") {
+    return String(saved?.stateDir ?? "").trim() === attach.stateDir;
+  }
+  return true;
+}
+
+function sameOrigin(left, right) {
+  const a = parseBaseUrl(String(left ?? "").trim());
+  const b = parseBaseUrl(String(right ?? "").trim());
+  if (!a || !b) return false;
+  return a.host.toLowerCase() === b.host.toLowerCase() && a.port === b.port;
+}

--- a/server/config.js
+++ b/server/config.js
@@ -15,6 +15,9 @@ const SPARKS_SECRETS_PATH =
 /** AES key file (auto-generated if SPARKDASH_SECRETS_KEY unset). */
 const SECRETS_KEY_PATH =
   process.env.SECRETS_KEY_PATH || path.join(ROOT, "config", ".secrets-key");
+/** Dashboard-level OpenClaw / Hermes Agent attach records (no tokens). */
+const SESSION_SOURCES_JSON_PATH =
+  process.env.SESSION_SOURCES_JSON_PATH || path.join(ROOT, "config", "session-sources.json");
 /** Daily LLM tok/s rollups (gitignored). */
 const LLM_DAILY_JSON_PATH =
   process.env.LLM_DAILY_JSON_PATH || path.join(ROOT, "config", "llm-daily.json");
@@ -94,6 +97,7 @@ export {
   GPU_MEMORY_JSON_PATH,
   SPARKS_SECRETS_PATH,
   SECRETS_KEY_PATH,
+  SESSION_SOURCES_JSON_PATH,
   LLM_DAILY_JSON_PATH,
   LLM_PROBE_TIMEOUT_MS,
   COMFY_PROBE_TIMEOUT_MS,

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,11 @@ import { sshExec, sshTest, llmTest, comfyTest } from "./collectors/ssh.js";
 import { comfyCancelJob } from "./collectors/comfyActions.js";
 import { validateSparkTarget, createRateLimiter } from "./validate.js";
 import { getSettings, updateSettings, loadSettings } from "./settings.js";
+import { getPublicSessionSources, loadSessionSources, updateSessionSources } from "./sessionSources.js";
+import { loadSessionSourceTokens } from "./secretsStore.js";
+import { testSessionSources } from "./collectors/sessionSourceHealth.js";
+import { createOccupancyLoop } from "./collectors/occupancyPoller.js";
+import { POLL_INTERVAL_LLM } from "./config.js";
 import { broadcastForLanIp, effectiveMac, normalizeMac, sendWol } from "./wol.js";
 import {
   decodeBenchManager,
@@ -129,6 +134,19 @@ function orderedSnapshots() {
     .filter(Boolean)
     .map((m) => m.snapshot());
 }
+
+// Occupancy is dashboard-level, on LLM cadence, never folded into _pollDomain("llm").
+const occupancyLoop = createOccupancyLoop({
+  intervalMs: POLL_INTERVAL_LLM,
+  getSparks: () => registry.sparks,
+  getSources: loadSessionSources,
+  getTokens: loadSessionSourceTokens,
+  apply(bySpark) {
+    for (const [id, monitor] of monitors) {
+      monitor.setConversations(bySpark[id] || []);
+    }
+  },
+});
 
 // ─── Express app ─────────────────────────────────────────
 const app = express();
@@ -296,6 +314,30 @@ app.put("/api/settings", (req, res) => {
       restartBroadcast();
     }
     res.json(newSettings);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Dashboard-level conversation sources (tokens never returned)
+app.get("/api/session-sources", (_req, res) => {
+  res.json(getPublicSessionSources());
+});
+
+app.patch("/api/session-sources", (req, res) => {
+  try {
+    res.json(updateSessionSources(req.body || {}));
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.post("/api/session-sources/test", async (req, res) => {
+  if (!allowTest(clientKey(req))) {
+    return res.status(429).json({ error: "Too many test requests; try again shortly" });
+  }
+  try {
+    res.json(await testSessionSources(req.body || {}, { getSparks: () => registry.sparks }));
   } catch (err) {
     res.status(400).json({ error: err.message });
   }
@@ -1385,6 +1427,7 @@ server.listen(PORT, BIND_HOST, () => {
     );
   }
   startAllMonitors();
+  occupancyLoop.start();
 });
 
 // ─── Graceful shutdown ─────────────────────────────────
@@ -1412,6 +1455,7 @@ function shutdown(signal) {
       clearInterval(broadcastTimer);
       broadcastTimer = null;
     }
+    occupancyLoop.stop();
     for (const m of monitors.values()) m.stop();
     monitors.clear();
   } catch (err) {

--- a/server/index.js
+++ b/server/index.js
@@ -141,6 +141,10 @@ const occupancyLoop = createOccupancyLoop({
   getSparks: () => registry.sparks,
   getSources: loadSessionSources,
   getTokens: loadSessionSourceTokens,
+  getMaxAgeMs: () => {
+    const hours = getSettings().occupancyMaxAgeHours;
+    return hours > 0 ? hours * 3600_000 : 0;
+  },
   apply(bySpark) {
     for (const [id, monitor] of monitors) {
       monitor.setConversations(bySpark[id] || []);

--- a/server/secretsStore.js
+++ b/server/secretsStore.js
@@ -1,19 +1,23 @@
 /**
- * Encrypted secrets store — survives process/Docker restarts.
+ * Encrypted secret store — survives process/Docker restarts.
  *
- * Secrets are NEVER written to sparks.json and NEVER returned by the API.
+ * SSH passwords, session-source tokens, and LLM API keys are NEVER written to
+ * sparks.json / session-sources.json and NEVER returned by GET APIs.
  * They live in:
  *   - memory (Maps) for SSH collectors / LLM probes
  *   - config/sparks-secrets.json (AES-256-GCM ciphertext, volume-mounted)
  *
- * File shape (v2):
+ * File shape (v2, backward compatible):
  *   {
  *     version: 2,
  *     secrets: { [sparkId]: "<encrypted ssh password>" },
- *     llmApiKeys: { [sparkId]: "<encrypted JSON { \"8000\": \"sk-…\" }>" }
+ *     llmApiKeys?: { [sparkId]: "<encrypted JSON { \"8000\": \"sk-…\" }>" },
+ *     sessionSourceTokens?: { [attachId]: "<encrypted token>" },
+ *     sessionSourceDevices?: { [attachId]: "<encrypted device identity JSON>" }
  *   }
  *
- * v1 files (secrets only) still load; rewritten as v2 on next save.
+ * v1 files (secrets + optional sessionSourceTokens/Devices) still load;
+ * rewritten as v2 on next save.
  *
  * Encryption key:
  *   - SPARKDASH_SECRETS_KEY env (passphrase or 64-char hex), or
@@ -29,9 +33,13 @@ const ALGO = "aes-256-gcm";
 const IV_LEN = 12;
 const TAG_LEN = 16;
 const KEY_LEN = 32;
-
 /** Cached key so we never regenerate mid-process. */
 let _cachedKey = null;
+
+/** Test helper: drop the in-process key cache. Does not rotate the key file. */
+export function resetSecretsKeyCache() {
+  _cachedKey = null;
+}
 
 function ensureDir(filePath) {
   const dir = path.dirname(filePath);
@@ -115,6 +123,82 @@ function decrypt(blobB64, key) {
   return Buffer.concat([decipher.update(data), decipher.final()]).toString("utf8");
 }
 
+function asBlobMap(value) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return {};
+  return value;
+}
+
+function readRawStore() {
+  const empty = { version: 2, secrets: {}, llmApiKeys: {}, sessionSourceTokens: {}, sessionSourceDevices: {} };
+  if (!fs.existsSync(SPARKS_SECRETS_PATH)) return empty;
+  const data = JSON.parse(fs.readFileSync(SPARKS_SECRETS_PATH, "utf8"));
+  return {
+    version: 2,
+    secrets: asBlobMap(data?.secrets),
+    llmApiKeys: asBlobMap(data?.llmApiKeys),
+    sessionSourceTokens: asBlobMap(data?.sessionSourceTokens),
+    sessionSourceDevices: asBlobMap(data?.sessionSourceDevices),
+  };
+}
+
+function nonEmptyBlobs(blobs) {
+  const out = {};
+  for (const [id, blob] of Object.entries(blobs || {})) {
+    if (id && typeof blob === "string" && blob) out[id] = blob;
+  }
+  return out;
+}
+
+function hasBlobMap(blobs) {
+  return Object.keys(nonEmptyBlobs(blobs)).length > 0;
+}
+
+function unlinkStoreFile() {
+  if (!fs.existsSync(SPARKS_SECRETS_PATH)) return;
+  try {
+    fs.accessSync(SPARKS_SECRETS_PATH, fs.constants.W_OK);
+    fs.unlinkSync(SPARKS_SECRETS_PATH);
+  } catch (err) {
+    throw new Error(
+      `Failed to clear secrets file (permission?): ${err.message}. ` +
+        `Run: sudo chown -R $(id -u):$(id -g) config/sparks-secrets.json`
+    );
+  }
+}
+
+function persistStore({ secrets: secretBlobs, llmApiKeys: llmKeyBlobs, sessionSourceTokens: tokenBlobs, sessionSourceDevices: deviceBlobs }) {
+  const secrets = asBlobMap(secretBlobs);
+  const llmApiKeys = nonEmptyBlobs(llmKeyBlobs);
+  const sessionSourceTokens = nonEmptyBlobs(tokenBlobs);
+  const sessionSourceDevices = nonEmptyBlobs(deviceBlobs);
+  const hasSecrets = Object.keys(secrets).length > 0;
+  if (!hasSecrets && !hasBlobMap(llmApiKeys) && !hasBlobMap(sessionSourceTokens) && !hasBlobMap(sessionSourceDevices)) {
+    unlinkStoreFile();
+    return;
+  }
+  const payload = { version: 2, secrets };
+  if (hasBlobMap(llmApiKeys)) payload.llmApiKeys = llmApiKeys;
+  if (hasBlobMap(sessionSourceTokens)) payload.sessionSourceTokens = sessionSourceTokens;
+  if (hasBlobMap(sessionSourceDevices)) payload.sessionSourceDevices = sessionSourceDevices;
+  atomicWrite(SPARKS_SECRETS_PATH, JSON.stringify(payload, null, 2) + "\n", 0o644);
+}
+
+function decryptEntries(entries, key, kind) {
+  const map = new Map();
+  let failed = 0;
+  for (const [id, blob] of Object.entries(entries)) {
+    if (!id || typeof blob !== "string") continue;
+    try {
+      const value = decrypt(blob, key);
+      if (value) map.set(id, value);
+    } catch {
+      failed += 1;
+      console.error(`[secretsStore] Failed to decrypt ${kind} for ${id} (wrong/missing key?)`);
+    }
+  }
+  return { map, failed };
+}
+
 /**
  * @returns {{
  *   passwords: Map<string, string>,
@@ -133,36 +217,21 @@ export function loadSecrets() {
 
   try {
     const key = resolveKey();
-    const raw = fs.readFileSync(SPARKS_SECRETS_PATH, "utf8");
-    const data = JSON.parse(raw);
-    const entries = data?.secrets || {};
-    if (typeof entries === "object" && entries !== null) {
-      let failed = 0;
-      for (const [id, blob] of Object.entries(entries)) {
-        if (!id || typeof blob !== "string") continue;
-        try {
-          const pw = decrypt(blob, key);
-          if (pw) passwords.set(id, pw);
-        } catch {
-          failed += 1;
-          console.error(
-            `[secretsStore] Failed to decrypt password for ${id} (wrong/missing key?)`
-          );
-        }
-      }
-      if (passwords.size > 0) {
-        console.log(`[secretsStore] Loaded ${passwords.size} SSH password(s) from encrypted store`);
-      }
-      if (failed > 0) {
-        console.warn(
-          `[secretsStore] ${failed} password(s) could not be decrypted — re-enter via Edit Spark`
-        );
-      }
+    const raw = readRawStore();
+    const { map: loaded, failed } = decryptEntries(raw.secrets, key, "password");
+    for (const [id, pw] of loaded) passwords.set(id, pw);
+    if (passwords.size > 0) {
+      console.log(`[secretsStore] Loaded ${passwords.size} SSH password(s) from encrypted store`);
+    }
+    if (failed > 0) {
+      console.warn(
+        `[secretsStore] ${failed} password(s) could not be decrypted — re-enter via Edit Spark`
+      );
     }
 
-    const keyEntries = data?.llmApiKeys || {};
+    const keyEntries = raw.llmApiKeys || {};
     if (typeof keyEntries === "object" && keyEntries !== null) {
-      let failed = 0;
+      let failedKeys = 0;
       let portCount = 0;
       for (const [id, blob] of Object.entries(keyEntries)) {
         if (!id || typeof blob !== "string") continue;
@@ -179,7 +248,7 @@ export function loadSecrets() {
           }
           if (Object.keys(ports).length > 0) llmApiKeys.set(id, ports);
         } catch {
-          failed += 1;
+          failedKeys += 1;
           console.error(
             `[secretsStore] Failed to decrypt LLM API keys for ${id} (wrong/missing key?)`
           );
@@ -188,9 +257,9 @@ export function loadSecrets() {
       if (portCount > 0) {
         console.log(`[secretsStore] Loaded ${portCount} LLM API key(s) from encrypted store`);
       }
-      if (failed > 0) {
+      if (failedKeys > 0) {
         console.warn(
-          `[secretsStore] ${failed} LLM API key bundle(s) could not be decrypted — re-enter via LLM Settings`
+          `[secretsStore] ${failedKeys} LLM API key bundle(s) could not be decrypted — re-enter via LLM Settings`
         );
       }
     }
@@ -202,13 +271,19 @@ export function loadSecrets() {
 }
 
 /**
- * Persist SSH passwords + per-port LLM API keys (encrypted).
- * Empty maps remove the file when both are empty.
+ * Persist SSH passwords + per-port LLM API keys (encrypted). Empty passwords
+ * remove those slots; the file is deleted only when passwords, LLM keys, AND
+ * session tokens/devices are all gone. Throws on failure so callers can
+ * surface errors to the UI.
+ *
+ * Encrypted file mode is 0o644 so bind-mounted volumes stay usable across
+ * root/non-root container users (contents are ciphertext, not plaintext).
  *
  * @param {Map<string, string>} passwords
  * @param {Map<string, Record<string, string>>} [llmApiKeys]
  */
 export function saveSecrets(passwords, llmApiKeys = new Map()) {
+  const raw = readRawStore();
   const hasPasswords = passwords && passwords.size > 0;
   let hasKeys = false;
   if (llmApiKeys) {
@@ -221,17 +296,7 @@ export function saveSecrets(passwords, llmApiKeys = new Map()) {
   }
 
   if (!hasPasswords && !hasKeys) {
-    if (fs.existsSync(SPARKS_SECRETS_PATH)) {
-      try {
-        fs.accessSync(SPARKS_SECRETS_PATH, fs.constants.W_OK);
-        fs.unlinkSync(SPARKS_SECRETS_PATH);
-      } catch (err) {
-        throw new Error(
-          `Failed to clear secrets file (permission?): ${err.message}. ` +
-            `Run: sudo chown -R $(id -u):$(id -g) config/sparks-secrets.json`
-        );
-      }
-    }
+    persistStore({ secrets: {}, llmApiKeys: raw.llmApiKeys, sessionSourceTokens: raw.sessionSourceTokens, sessionSourceDevices: raw.sessionSourceDevices });
     return;
   }
 
@@ -257,12 +322,94 @@ export function saveSecrets(passwords, llmApiKeys = new Map()) {
     }
   }
 
-  const payload =
-    JSON.stringify({ version: 2, secrets, llmApiKeys: llmOut }, null, 2) + "\n";
-  atomicWrite(SPARKS_SECRETS_PATH, payload, 0o644);
+  persistStore({ secrets, llmApiKeys: llmOut, sessionSourceTokens: raw.sessionSourceTokens, sessionSourceDevices: raw.sessionSourceDevices });
   const keyCount = Object.keys(llmOut).length;
   console.log(
     `[secretsStore] Saved ${Object.keys(secrets).length} SSH password(s)` +
       (keyCount ? `, ${keyCount} LLM API key bundle(s)` : "")
   );
+}
+
+function decryptTokenMap(blobs, key) {
+  const { map } = decryptEntries(blobs, key, "session source token");
+  /** @type {Record<string, string>} */
+  const out = {};
+  for (const [id, value] of map) {
+    if (value) out[id] = value;
+  }
+  return out;
+}
+
+/** @returns {Record<string, string>} plaintext tokens keyed by attach id */
+export function loadSessionSourceTokens() {
+  try {
+    const raw = readRawStore();
+    if (!hasBlobMap(raw.sessionSourceTokens)) return {};
+    return decryptTokenMap(raw.sessionSourceTokens, resolveKey());
+  } catch (err) {
+    console.error(`[secretsStore] Failed to load session source tokens: ${err.message}`);
+    return {};
+  }
+}
+
+/**
+ * Merge session-source token slots. Omitted keys leave the stored token;
+ * empty string clears that slot. Keys are attach ids.
+ * @param {Record<string, string>} patch
+ * @returns {Record<string, string>}
+ */
+export function patchSessionSourceTokens(patch) {
+  const raw = readRawStore();
+  const key = resolveKey();
+  const current = decryptTokenMap(raw.sessionSourceTokens, key);
+  const body = patch && typeof patch === "object" ? patch : {};
+  for (const id of Object.keys(body)) {
+    if (!id) continue;
+    const value = body[id];
+    if (value == null) continue;
+    if (value === "") delete current[id];
+    else current[id] = String(value);
+  }
+  /** @type {Record<string, string>} */
+  const tokenBlobs = {};
+  for (const [id, value] of Object.entries(current)) {
+    if (value) tokenBlobs[id] = encrypt(value, key);
+  }
+  persistStore({ secrets: raw.secrets, llmApiKeys: raw.llmApiKeys, sessionSourceTokens: tokenBlobs, sessionSourceDevices: raw.sessionSourceDevices });
+  return current;
+}
+
+/** @returns {{ deviceId: string, publicKey: string, privateKeyPem: string } | null} */
+export function loadSessionSourceDevice(id) {
+  if (!id) return null;
+  try {
+    const raw = readRawStore();
+    const blob = raw.sessionSourceDevices?.[id];
+    if (typeof blob !== "string" || !blob) return null;
+    const parsed = JSON.parse(decrypt(blob, resolveKey()));
+    if (parsed?.deviceId && parsed?.publicKey && parsed?.privateKeyPem) return parsed;
+  } catch (err) {
+    console.error(`[secretsStore] Failed to load session source device for ${id}: ${err.message}`);
+  }
+  return null;
+}
+
+/** Persist OpenClaw gateway device identity for one attach id. */
+export function saveSessionSourceDevice(id, identity) {
+  if (!id || !identity) return;
+  const raw = readRawStore();
+  const devices = { ...raw.sessionSourceDevices };
+  devices[id] = encrypt(JSON.stringify(identity), resolveKey());
+  persistStore({ secrets: raw.secrets, llmApiKeys: raw.llmApiKeys, sessionSourceTokens: raw.sessionSourceTokens, sessionSourceDevices: devices });
+}
+
+/** Drop device identities whose attach ids are no longer present. */
+export function dropSessionSourceDevices(keepIds) {
+  const keep = new Set(Array.isArray(keepIds) ? keepIds : []);
+  const raw = readRawStore();
+  const devices = {};
+  for (const [id, blob] of Object.entries(raw.sessionSourceDevices || {})) {
+    if (keep.has(id) && typeof blob === "string" && blob) devices[id] = blob;
+  }
+  persistStore({ secrets: raw.secrets, llmApiKeys: raw.llmApiKeys, sessionSourceTokens: raw.sessionSourceTokens, sessionSourceDevices: devices });
 }

--- a/server/sessionSourceRegistry.js
+++ b/server/sessionSourceRegistry.js
@@ -42,6 +42,7 @@ const KINDS = Object.freeze([
   Object.freeze({
     id: "omp",
     label: "oh-my-pi",
+    urlPlaceholder: "http://127.0.0.1:8789/occupancy",
     usesUsername: false,
     conventionalStateDir(env = process.env) {
       return trimmedEnv(env?.OMP_STATE_DIR, "~/.omp");

--- a/server/sessionSourceRegistry.js
+++ b/server/sessionSourceRegistry.js
@@ -1,0 +1,81 @@
+/**
+ * Session source kind registry (metadata only).
+ * Collect/diagnose stay in occupancyPoller and sessionSourceHealth so this
+ * module never imports OpenClawSessions or HermesSessions (ESM cycle).
+ */
+
+function trimmedEnv(value, fallback) {
+  return value && String(value).trim() ? String(value).trim() : fallback;
+}
+
+const KINDS = Object.freeze([
+  Object.freeze({
+    id: "openclaw",
+    label: "OpenClaw",
+    urlPlaceholder: "http://127.0.0.1:18789",
+    usesUsername: false,
+    conventionalStateDir(env = process.env) {
+      return trimmedEnv(env?.OPENCLAW_STATE_DIR, "~/.openclaw");
+    },
+  }),
+  Object.freeze({
+    id: "hermes",
+    label: "Hermes Agent",
+    urlPlaceholder: "http://127.0.0.1:8787",
+    usesUsername: true,
+    conventionalStateDir(env = process.env) {
+      return trimmedEnv(env?.HERMES_HOME, "~/.hermes");
+    },
+  }),
+  Object.freeze({
+    id: "opencode",
+    label: "OpenCode",
+    urlPlaceholder: "http://127.0.0.1:8788/occupancy",
+    usesUsername: false,
+    conventionalStateDir(env = process.env) {
+      return trimmedEnv(env?.OPENCODE_DATA_DIR, "~/.local/share/opencode");
+    },
+    conventionalConfigDir(env = process.env) {
+      return trimmedEnv(env?.OPENCODE_CONFIG_DIR, "~/.config/opencode");
+    },
+  }),
+  Object.freeze({
+    id: "omp",
+    label: "oh-my-pi",
+    usesUsername: false,
+    conventionalStateDir(env = process.env) {
+      return trimmedEnv(env?.OMP_STATE_DIR, "~/.omp");
+    },
+    conventionalConfigDir(env = process.env) {
+      return trimmedEnv(env?.OMP_CONFIG_DIR, "~/.omp/agent");
+    },
+  }),
+]);
+
+export function sessionSourceKinds() {
+  return KINDS.slice();
+}
+
+export function sessionSourceIds() {
+  return KINDS.map((kind) => kind.id);
+}
+
+export function kindById(id) {
+  const key = String(id ?? "");
+  return KINDS.find((kind) => kind.id === key) ?? null;
+}
+
+export function conventionalStateDir(id, env = process.env) {
+  const kind = kindById(id);
+  return kind ? kind.conventionalStateDir(env) : "";
+}
+
+export function conventionalConfigDir(id, env = process.env) {
+  const kind = kindById(id);
+  if (kind && typeof kind.conventionalConfigDir === "function") {
+    return kind.conventionalConfigDir(env);
+  }
+  return "";
+}
+
+export const SOURCE_IDS = Object.freeze(sessionSourceIds());

--- a/server/sessionSources.js
+++ b/server/sessionSources.js
@@ -1,0 +1,302 @@
+/**
+ * Dashboard-level conversation-source attach config.
+ * Tokens live in secretsStore, never in this JSON file.
+ * Each product is a list of attaches (legacy singleton objects migrate on load).
+ * Kind ids come from sessionSourceRegistry.
+ */
+import fs from "fs";
+import { SESSION_SOURCES_JSON_PATH } from "./config.js";
+import { atomicWrite } from "./util/atomicWrite.js";
+import { isAllowedTargetHost } from "./validate.js";
+import {
+  dropSessionSourceDevices,
+  loadSessionSourceTokens,
+  patchSessionSourceTokens,
+} from "./secretsStore.js";
+import {
+  SOURCE_IDS,
+  conventionalStateDir,
+  conventionalConfigDir,
+  sessionSourceIds,
+  kindById,
+} from "./sessionSourceRegistry.js";
+
+const MODES = new Set(["local", "url", "state-dir"]);
+const PUBLIC_ONLY = new Set([
+  "token",
+  "hasToken",
+  "conventionalStateDir",
+  "conventionalConfigDir",
+  "urlPlaceholder",
+  "usesUsername",
+  "kindLabel",
+]);
+const ATTACH_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
+
+const DEFAULT_ATTACH = Object.freeze({
+  enabled: false,
+  mode: "local",
+  url: "",
+  stateDir: "",
+  label: "",
+  username: "",
+});
+
+export { SOURCE_IDS, conventionalStateDir, conventionalConfigDir };
+
+export function attachList(source) {
+  if (Array.isArray(source)) return source.filter((item) => item && typeof item === "object");
+  if (source && typeof source === "object") return [source];
+  return [];
+}
+
+function nextAttachId(kind, used) {
+  if (!used.has(kind)) return kind;
+  let n = 2;
+  while (used.has(`${kind}-${n}`)) n += 1;
+  return `${kind}-${n}`;
+}
+
+function assignAttachId(rawId, kind, used) {
+  const id = typeof rawId === "string" ? rawId.trim() : "";
+  if (ATTACH_ID_RE.test(id) && !used.has(id)) return id;
+  return nextAttachId(kind, used);
+}
+
+function normalizeAttach(raw, kind, used) {
+  const extras = raw && typeof raw === "object" && !Array.isArray(raw) ? { ...raw } : {};
+  for (const key of PUBLIC_ONLY) delete extras[key];
+  const kindMeta = kindById(kind);
+  const supportsUrl = Boolean(kindMeta?.urlPlaceholder);
+  let mode = MODES.has(extras.mode) ? extras.mode : DEFAULT_ATTACH.mode;
+  if (mode === "url" && !supportsUrl) mode = DEFAULT_ATTACH.mode;
+  const id = assignAttachId(extras.id, kind, used);
+  return {
+    ...extras,
+    id,
+    enabled: Boolean(extras.enabled),
+    mode,
+    url: typeof extras.url === "string" ? extras.url.trim() : "",
+    stateDir: typeof extras.stateDir === "string" ? extras.stateDir.trim() : "",
+    label: typeof extras.label === "string" ? extras.label.trim() : "",
+    username: typeof extras.username === "string" ? extras.username.trim() : "",
+  };
+}
+
+function normalizeKindList(kind, raw) {
+  const used = new Set();
+  const list = attachList(raw).map((item) => {
+    const attach = normalizeAttach(item, kind, used);
+    used.add(attach.id);
+    return attach;
+  });
+  if (list.length === 0) {
+    const attach = normalizeAttach({ id: kind }, kind, used);
+    list.push(attach);
+  }
+  return list;
+}
+
+function normalizeConfig(raw) {
+  const base = raw && typeof raw === "object" && !Array.isArray(raw) ? { ...raw } : {};
+  const next = { ...base };
+  for (const kind of sessionSourceIds()) {
+    next[kind] = normalizeKindList(kind, base[kind]);
+  }
+  return next;
+}
+
+function hostFromUrl(url) {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "";
+  }
+}
+
+function originKey(url) {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return "";
+  }
+}
+
+function validateAttach(attach) {
+  if (attach.enabled && attach.mode === "state-dir" && !attach.stateDir) {
+    throw new Error("State dir is required");
+  }
+  if (attach.mode === "state-dir" && attach.stateDir && /[\0\r\n]/.test(attach.stateDir)) {
+    throw new Error("Invalid state dir");
+  }
+  if (attach.mode !== "url" || !attach.url) return;
+  let parsed;
+  try {
+    parsed = new URL(attach.url);
+  } catch {
+    throw new Error(`Invalid or disallowed host: ${attach.url}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Invalid URL protocol: ${parsed.protocol}`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("URL userinfo is not allowed");
+  }
+  const host = parsed.hostname || hostFromUrl(attach.url);
+  if (!host || !isAllowedTargetHost(host)) {
+    throw new Error(`Invalid or disallowed host: ${host || attach.url}`);
+  }
+}
+
+function persistableAttach(attach) {
+  const rest = { ...attach };
+  for (const key of PUBLIC_ONLY) delete rest[key];
+  return rest;
+}
+
+function saveSessionSources(config) {
+  /** @type {Record<string, object[]>} */
+  const payload = {};
+  for (const kind of sessionSourceIds()) {
+    payload[kind] = attachList(config[kind]).map(persistableAttach);
+  }
+  atomicWrite(SESSION_SOURCES_JSON_PATH, JSON.stringify(payload, null, 2) + "\n", 0o644);
+}
+
+export function loadSessionSources() {
+  try {
+    const raw = fs.readFileSync(SESSION_SOURCES_JSON_PATH, "utf8");
+    return normalizeConfig(JSON.parse(raw));
+  } catch (err) {
+    if (err.code === "ENOENT") return normalizeConfig({});
+    console.error("[sessionSources] Failed to load session-sources.json:", err.message);
+    return normalizeConfig({});
+  }
+}
+
+function publicAttach(kind, attach, tokens) {
+  const rest = persistableAttach(attach);
+  const meta = kindById(kind);
+  return {
+    ...rest,
+    hasToken: Boolean(tokens[attach.id] || tokens[kind]),
+    conventionalStateDir: conventionalStateDir(kind),
+    conventionalConfigDir: conventionalConfigDir(kind) || undefined,
+    urlPlaceholder: meta?.urlPlaceholder || undefined,
+    usesUsername: meta?.usesUsername || undefined,
+    kindLabel: meta?.label || undefined,
+  };
+}
+
+export function getPublicSessionSources() {
+  const config = loadSessionSources();
+  const tokens = loadSessionSourceTokens();
+  /** @type {Record<string, object[]>} */
+  const pub = {};
+  for (const kind of sessionSourceIds()) {
+    pub[kind] = attachList(config[kind]).map((attach) => publicAttach(kind, attach, tokens));
+  }
+  return pub;
+}
+
+function allAttachIds(config) {
+  return sessionSourceIds()
+    .flatMap((kind) => attachList(config[kind]))
+    .map((attach) => attach.id)
+    .filter(Boolean);
+}
+
+function patchKindList(kind, currentList, src) {
+  if (Array.isArray(src)) {
+    const used = new Set();
+    return src.map((item) => {
+      const prev = item?.id ? currentList.find((a) => a.id === item.id) : null;
+      const attachPatch = { ...(prev || {}), ...item };
+      for (const key of PUBLIC_ONLY) delete attachPatch[key];
+      const attach = normalizeAttach(attachPatch, kind, used);
+      used.add(attach.id);
+      validateAttach(attach);
+      return attach;
+    });
+  }
+  const attachPatch = { ...src };
+  for (const key of PUBLIC_ONLY) delete attachPatch[key];
+  const idx = src.id ? currentList.findIndex((a) => a.id === src.id) : 0;
+  const base = idx >= 0 ? currentList[idx] : currentList[0] || { id: kind };
+  const used = new Set(currentList.map((a) => a.id).filter((id) => id !== base.id));
+  const updated = normalizeAttach({ ...base, ...attachPatch }, kind, used);
+  validateAttach(updated);
+  if (idx >= 0 && currentList.length > 0) {
+    const next = [...currentList];
+    next[idx] = updated;
+    return next;
+  }
+  return [updated];
+}
+
+function tokenPatchFromBody(patch, previous, next) {
+  /** @type {Record<string, string>} */
+  const out = {};
+  for (const kind of sessionSourceIds()) {
+    const src = patch[kind];
+    if (src === undefined) continue;
+    const items = Array.isArray(src) ? src : [src];
+    const prevList = attachList(previous[kind]);
+    const nextList = attachList(next[kind]);
+    for (const item of items) {
+      if (!item || typeof item !== "object") continue;
+      const id = item.id || nextList[0]?.id || kind;
+      if (Object.prototype.hasOwnProperty.call(item, "token") && item.token != null) {
+        out[id] = String(item.token);
+        continue;
+      }
+      const prev = item.id ? prevList.find((a) => a.id === item.id) : prevList[0];
+      const curr = nextList.find((a) => a.id === id) || nextList[0];
+      if (!prev || !curr) continue;
+      if (originKey(prev.url) === originKey(curr.url)) continue;
+      out[id] = "";
+    }
+  }
+  const keep = new Set(allAttachIds(next));
+  const stored = loadSessionSourceTokens();
+  for (const id of Object.keys(stored)) {
+    if (!keep.has(id)) out[id] = "";
+  }
+  return out;
+}
+
+export function updateSessionSources(patch) {
+  const body = patch && typeof patch === "object" ? patch : {};
+  const current = loadSessionSources();
+  const next = { ...current };
+  for (const kind of sessionSourceIds()) {
+    const src = body[kind];
+    if (src === undefined) continue;
+    if (src !== null && typeof src !== "object") continue;
+    next[kind] = patchKindList(kind, attachList(current[kind]), src);
+  }
+  const tokens = tokenPatchFromBody(body, current, next);
+  const previousTokens = tokenSnapshot(current);
+  let tokensPatched = false;
+  try {
+    if (Object.keys(tokens).length > 0) {
+      patchSessionSourceTokens(tokens);
+      tokensPatched = true;
+    }
+    saveSessionSources(next);
+    dropSessionSourceDevices(allAttachIds(next));
+  } catch (err) {
+    if (tokensPatched) patchSessionSourceTokens(previousTokens);
+    throw err;
+  }
+  return getPublicSessionSources();
+}
+
+function tokenSnapshot(config) {
+  const current = loadSessionSourceTokens();
+  /** @type {Record<string, string>} */
+  const out = {};
+  for (const id of allAttachIds(config)) out[id] = current[id] ?? "";
+  return out;
+}

--- a/server/settings.js
+++ b/server/settings.js
@@ -19,6 +19,8 @@ const DEFAULTS = Object.freeze({
   benchDebugTraces: false,
   /** Layout density — compact (default) or comfortable. */
   density: "compact",
+  /** Hide occupancy sessions older than this many hours. 0 = show all. */
+  occupancyMaxAgeHours: 12,
 });
 
 /** @type {typeof DEFAULTS} */
@@ -45,6 +47,10 @@ function _clampSettings(settings) {
   // Ensure density is valid
   if (s.density !== "comfortable" && s.density !== "compact") {
     s.density = DEFAULTS.density;
+  }
+  // Ensure occupancyMaxAgeHours is a non-negative number
+  if (typeof s.occupancyMaxAgeHours !== "number" || s.occupancyMaxAgeHours < 0) {
+    s.occupancyMaxAgeHours = DEFAULTS.occupancyMaxAgeHours;
   }
   return s;
 }

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -25,6 +25,31 @@ import {
 
 const ONLINE_GRACE_MS = 10000;
 
+function sameConversationRows(a, b) {
+  if (a === b) return true;
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const left = a[i];
+    const right = b[i];
+    if (
+      left.id !== right.id ||
+      left.source !== right.source ||
+      left.handle !== right.handle ||
+      left.badge !== right.badge ||
+      left.port !== right.port ||
+      left.lastUsedAt !== right.lastUsedAt ||
+      left.agent !== right.agent ||
+      left.gateway !== right.gateway ||
+      left.contextUsed !== right.contextUsed ||
+      left.contextWindow !== right.contextWindow ||
+      left.contextApprox !== right.contextApprox
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * SparkMonitor — one per Spark. Owns collectors + rate state + poll loop.
  * Exposes snapshot() for WebSocket pushed payload.
@@ -128,6 +153,9 @@ export class SparkMonitor {
     this._running = false;
     /** @type {Record<string, boolean>} in-flight domain guards */
     this._inflight = {};
+
+    /** Bound conversation rows from the dashboard occupancy poller. */
+    this._conversations = [];
   }
 
   /** Hot-update config without tearing down poll loops / rate baselines. */
@@ -380,6 +408,21 @@ export class SparkMonitor {
     console.log(`[SparkMonitor] ${this.spark.id} stopped`);
   }
 
+  /** Store a copy of occupancy rows. Dashboard poller owns collection. */
+  setConversations(rows) {
+    const next = Array.isArray(rows) ? rows.map((row) => ({ ...row })) : [];
+    if (sameConversationRows(this._conversations, next)) return;
+    this._conversations = next;
+  }
+
+  /** Occupancy list for snapshot: omit when empty, disabled, or worker. */
+  _conversationSnapshot() {
+    if (!this._llmMonitoringEnabled()) return {};
+    const rows = this._conversations;
+    if (!Array.isArray(rows) || rows.length === 0) return {};
+    return { conversations: rows };
+  }
+
   /** Return a full snapshot of this Spark's metrics. */
   snapshot() {
     const ports = this._llmMonitoringEnabled() ? this._llmPorts() : [];
@@ -431,6 +474,7 @@ export class SparkMonitor {
         comfy: comfyOn ? this._metrics.comfy : null,
         tailscale: tailscaleOn ? this._metrics.tailscale : null,
       },
+      ...this._conversationSnapshot(),
     };
   }
 

--- a/server/sparks/__tests__/SparkMonitor.conversations.test.js
+++ b/server/sparks/__tests__/SparkMonitor.conversations.test.js
@@ -1,0 +1,104 @@
+/**
+ * SparkMonitor occupancy attach (U5).
+ * Conversations are top-level, omitted when empty/disabled/worker.
+ * No per-tick timestamp. Occupancy must not blank metrics.llm.
+ * Run: npm test
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { SparkMonitor } from "../SparkMonitor.js";
+
+function stubSpark(overrides = {}) {
+  return {
+    id: "spark-local",
+    name: "Local",
+    lanIp: "127.0.0.1",
+    isLocal: true,
+    llmPorts: [8888],
+    role: "standalone",
+    llmMonitoring: true,
+    disabledDevices: [],
+    disabledInterfaces: [],
+    ...overrides,
+  };
+}
+
+function llmMetrics() {
+  return [
+    {
+      available: true,
+      backend: "vllm",
+      modelId: "test-model",
+      modelPath: null,
+      contextLength: 8192,
+      gpuMemoryUtilization: 0.5,
+      slotsActive: 0,
+      slotsTotal: 0,
+      generationTps: 0,
+      prefillTps: 0,
+      totalOutputTokens: 0,
+      error: null,
+    },
+  ];
+}
+
+function conversation(overrides = {}) {
+  return {
+    source: "openclaw",
+    handle: "chat-a",
+    badge: "stalled",
+    port: 8888,
+    ...overrides,
+  };
+}
+
+function monitorWithLlm(spark = stubSpark()) {
+  const monitor = new SparkMonitor(spark);
+  monitor._metrics.llm = llmMetrics();
+  return monitor;
+}
+
+test("AE4: occupancy empty leaves metrics.llm and omits conversations", () => {
+  const monitor = monitorWithLlm();
+  monitor.setConversations([]);
+  const snap = monitor.snapshot();
+  assert.equal(snap.metrics.llm[0].available, true);
+  assert.equal(snap.metrics.llm[0].modelId, "test-model");
+  assert.equal("conversations" in snap, false);
+});
+
+test("worker spark omits conversations even after setConversations", () => {
+  const monitor = monitorWithLlm(stubSpark({ role: "worker", workerNode: true, llmMonitoring: false }));
+  monitor.setConversations([conversation()]);
+  const snap = monitor.snapshot();
+  assert.equal("conversations" in snap, false);
+});
+
+test("unchanged conversation list: two snapshot() JSON strings equal", () => {
+  const monitor = monitorWithLlm();
+  monitor.setConversations([conversation({ handle: "chat-a", badge: "generating" })]);
+  const a = JSON.stringify(monitor.snapshot());
+  const b = JSON.stringify(monitor.snapshot());
+  assert.equal(a, b);
+  assert.ok(!a.includes("Date"));
+  const snap = monitor.snapshot();
+  assert.equal(snap.conversations.length, 1);
+  assert.equal(snap.conversations[0].handle, "chat-a");
+  assert.equal("timestamp" in snap.metrics, false);
+});
+
+test("llmOn snapshot includes conversations when rows exist", () => {
+  const monitor = monitorWithLlm();
+  monitor.setConversations([conversation()]);
+  const snap = monitor.snapshot();
+  assert.deepEqual(snap.conversations, [conversation()]);
+  assert.equal(snap.metrics.llm[0].available, true);
+});
+
+test("setConversations stores a copy", () => {
+  const monitor = monitorWithLlm();
+  const rows = [conversation()];
+  monitor.setConversations(rows);
+  rows[0].handle = "mutated";
+  assert.equal(monitor.snapshot().conversations[0].handle, "chat-a");
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -5,6 +5,9 @@ import type {
   HermesUpdatesResponse,
   LlmMetrics,
   LlmDailyResponse,
+  SessionSources,
+  SessionSourcesHealth,
+  SessionSourcesPatch,
   Settings,
   ShowcaseListResponse,
   ShowcaseSessionState,
@@ -382,5 +385,23 @@ export function updateSettings(patch: Partial<Settings>): Promise<Settings> {
   return apiFetch("/api/settings", {
     method: "PUT",
     body: JSON.stringify(patch),
+  });
+}
+
+export function fetchSessionSources(): Promise<SessionSources> {
+  return apiFetch("/api/session-sources");
+}
+
+export function updateSessionSources(patch: SessionSourcesPatch): Promise<SessionSources> {
+  return apiFetch("/api/session-sources", {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+}
+
+export function testSessionSources(body: SessionSourcesPatch = {}): Promise<SessionSourcesHealth> {
+  return apiFetch("/api/session-sources/test", {
+    method: "POST",
+    body: JSON.stringify(body),
   });
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -550,6 +550,8 @@ export interface Settings {
   benchDebugTraces: boolean;
   /** Layout density — compact (default) or comfortable. */
   density: "comfortable" | "compact";
+  /** Hide occupancy sessions older than this many hours. 0 = show all. */
+  occupancyMaxAgeHours: number;
 }
 
 export type SessionSourceMode = "local" | "url" | "state-dir";

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -463,6 +463,31 @@ export interface SparkMetrics {
   tailscale?: TailscaleMetrics | null;
 }
 
+// ─── Occupancy conversations (not LlmMetrics) ────────────
+export type ConversationSource = string;
+export type ConversationBadge = "generating" | "stalled" | "unknown";
+
+/** Occupancy row: handle + badge only. `id` is list identity, not a transcript. */
+export interface ConversationRow {
+  id: string;
+  source: ConversationSource;
+  handle: string;
+  badge: ConversationBadge;
+  port: number;
+  /** Session last-used epoch ms from the source. Omit when unknown. */
+  lastUsedAt?: number;
+  /** OpenClaw agent id or Hermes profile/agent. Omit when unknown. */
+  agent?: string;
+  /** Attach label or gateway hostname when several of the same product are attached. */
+  gateway?: string;
+  /** Tokens currently in context. Omit when the source does not report it. */
+  contextUsed?: number;
+  /** Model context window in tokens. Omit when unknown. */
+  contextWindow?: number;
+  /** True when used tokens are a stale/approximate snapshot. */
+  contextApprox?: boolean;
+}
+
 // ─── Spark snapshot (server pushes this) ──────────────────
 export interface SparkSnapshot {
   id: string;
@@ -504,6 +529,8 @@ export interface SparkSnapshot {
   hermes?: HermesStatus;
   hardware: HardwareInfo;
   metrics: SparkMetrics;
+  /** Bound occupancy conversations. Omit when empty. */
+  conversations?: ConversationRow[];
 }
 
 // ─── WebSocket envelope ───────────────────────────────────
@@ -524,6 +551,61 @@ export interface Settings {
   /** Layout density — compact (default) or comfortable. */
   density: "comfortable" | "compact";
 }
+
+export type SessionSourceMode = "local" | "url" | "state-dir";
+
+/** Dashboard-level OpenClaw / Hermes Agent attach record. Token never returned. */
+export interface SessionSourceAttach {
+  id: string;
+  /** Optional operator label for this gateway. */
+  label?: string;
+  enabled: boolean;
+  mode: SessionSourceMode;
+  url: string;
+  stateDir: string;
+  /** Hermes dashboard username. Empty uses `admin`. Not a secret. */
+  username?: string;
+  hasToken: boolean;
+  /** Conventional local path (`~/.openclaw` / `~/.hermes` / `~/.local/share/opencode` / `~/.omp`, or env override). */
+  conventionalStateDir: string;
+  /** OpenCode provider-config dir (`~/.config/opencode`). Empty for other kinds. */
+  conventionalConfigDir?: string;
+  /** Occupancy lane / Settings title from the source registry. */
+  kindLabel?: string;
+  /** URL-mode input placeholder from the source registry. */
+  urlPlaceholder?: string;
+  /** Hermes dashboard username field. Omit when the kind has no username. */
+  usesUsername?: boolean;
+}
+
+export type SessionSources = Record<string, SessionSourceAttach[]>;
+
+export interface SessionSourcePatch {
+  id?: string;
+  label?: string;
+  enabled?: boolean;
+  mode?: SessionSourceMode;
+  url?: string;
+  stateDir?: string;
+  username?: string;
+  /** Omit to leave stored token; empty string clears. Never returned on GET. */
+  token?: string;
+}
+
+export type SessionSourcesPatch = Record<string, SessionSourcePatch | SessionSourcePatch[]>;
+
+export type SessionSourceHealthStatus = "disabled" | "ok" | "error";
+
+/** Counts only. Never handles, titles, or transcripts. */
+export interface SessionSourceHealth {
+  id?: string;
+  status: SessionSourceHealthStatus;
+  found: number;
+  mapped: number;
+  error: string | null;
+}
+
+export type SessionSourcesHealth = Record<string, SessionSourceHealth[]>;
 
 export interface SparksListResponse {
   sparks: SparkConfig[];

--- a/src/components/SessionSourceFields.tsx
+++ b/src/components/SessionSourceFields.tsx
@@ -1,0 +1,221 @@
+import type { SessionSourceAttach, SessionSourceHealth, SessionSourceMode } from "../api/types";
+
+const MODE_OPTIONS: { value: SessionSourceMode; label: string }[] = [
+  { value: "local", label: "Local" },
+  { value: "url", label: "URL" },
+  { value: "state-dir", label: "State dir" },
+];
+
+function tokenPlaceholder(source: SessionSourceAttach): string {
+  if (source.hasToken) return "Token stored — leave blank to keep";
+  if (source.mode === "url" && urlRequiresToken(source.url)) return "Token required";
+  return "Optional token";
+}
+
+function urlRequiresToken(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host !== "127.0.0.1" && host !== "localhost" && host !== "::1";
+  } catch {
+    return false;
+  }
+}
+
+const fieldClass =
+  "w-full rounded border border-border bg-surface-elevated px-3 py-1.5 text-xs text-text outline-none focus:border-accent";
+
+export function Toggle({ on, onClick }: { on: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      onClick={onClick}
+      className={`toggle-track relative mt-0.5 inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+        on ? "is-on" : ""
+      }`}
+    >
+      <span
+        className={`toggle-dot inline-block h-4 w-4 transform rounded-full shadow transition-transform ${
+          on ? "translate-x-4" : "translate-x-0"
+        }`}
+      />
+    </button>
+  );
+}
+
+export type HealthTone = "muted" | "ok" | "danger";
+
+export interface HealthView {
+  label: string;
+  tone: HealthTone;
+  found?: number;
+  mapped?: number;
+  detail?: string;
+}
+
+export function healthView(
+  health: SessionSourceHealth | undefined,
+  checking: boolean
+): HealthView | null {
+  if (checking) return { label: "Checking", tone: "muted" };
+  if (!health) return null;
+  if (health.status === "disabled") return { label: "Off", tone: "muted" };
+  if (health.status === "error") {
+    return { label: "Unreachable", tone: "danger", detail: health.error || undefined };
+  }
+  return { label: "Connected", tone: "ok", found: health.found, mapped: health.mapped };
+}
+
+export function SessionSourceFields({
+  kind,
+  source,
+  tokenDraft,
+  health,
+  checking,
+  canRemove,
+  onSource,
+  onToken,
+  onClearToken,
+  onCheck,
+  onRemove,
+}: {
+  kind: string;
+  source: SessionSourceAttach;
+  tokenDraft: string;
+  health?: SessionSourceHealth;
+  checking: boolean;
+  canRemove: boolean;
+  onSource: (patch: Partial<SessionSourceAttach>) => void;
+  onToken: (value: string) => void;
+  onClearToken: () => void;
+  onCheck: () => void;
+  onRemove: () => void;
+}) {
+  const status = healthView(health, checking);
+  const title = source.kindLabel || kind;
+  return (
+    <div className="space-y-2 rounded border border-border px-3 py-2">
+      <div className="flex items-center gap-3">
+        <label className="flex min-w-0 flex-1 items-center gap-3 text-xs text-muted">
+          <Toggle on={source.enabled} onClick={() => onSource({ enabled: !source.enabled })} />
+          <span className="truncate text-text">{title}</span>
+        </label>
+        {canRemove && (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="shrink-0 rounded border border-border bg-surface-elevated px-2 py-1 text-[10px] text-muted hover:bg-surface-hover"
+          >
+            Remove
+          </button>
+        )}
+      </div>
+      <input
+        type="text"
+        value={source.label ?? ""}
+        onChange={(e) => onSource({ label: e.target.value })}
+        placeholder="Optional label"
+        className={fieldClass}
+        aria-label={`${title} label`}
+      />
+      <select
+        value={source.mode}
+        onChange={(e) => onSource({ mode: e.target.value as SessionSourceMode })}
+        className={fieldClass}
+        aria-label={`${title} mode`}
+      >
+        {MODE_OPTIONS.filter((opt) => opt.value !== "url" || source.urlPlaceholder).map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {source.mode === "local" && (
+        <p className="text-[10px] leading-snug text-muted">
+          {source.conventionalConfigDir
+            ? `Sessions ${source.conventionalStateDir}; providers ${source.conventionalConfigDir}`
+            : `Uses ${source.conventionalStateDir}`}
+        </p>
+      )}
+      {source.mode === "url" && (
+        <input
+          type="text"
+          value={source.url}
+          onChange={(e) => onSource({ url: e.target.value })}
+          placeholder={source.urlPlaceholder}
+          className={fieldClass}
+          aria-label={`${title} URL`}
+        />
+      )}
+      {source.usesUsername && source.mode === "url" && (
+        <input
+          type="text"
+          value={source.username ?? ""}
+          onChange={(e) => onSource({ username: e.target.value })}
+          placeholder="Username (default admin)"
+          className={fieldClass}
+          aria-label={`${title} username`}
+        />
+      )}
+      {source.mode === "state-dir" && (
+        <input
+          type="text"
+          value={source.stateDir}
+          onChange={(e) => onSource({ stateDir: e.target.value })}
+          placeholder="State directory"
+          className={fieldClass}
+          aria-label={`${title} state directory`}
+        />
+      )}
+      <div className="flex gap-2">
+        <input
+          type="password"
+          autoComplete="new-password"
+          value={tokenDraft}
+          onChange={(e) => onToken(e.target.value)}
+          placeholder={tokenPlaceholder(source)}
+          className={fieldClass}
+          aria-label={`${title} token`}
+        />
+        {source.hasToken && !tokenDraft && (
+          <button
+            type="button"
+            onClick={onClearToken}
+            className="shrink-0 rounded border border-border bg-surface-elevated px-2 py-1.5 text-[10px] text-muted hover:bg-surface-hover"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+      <div className="session-health">
+        <button
+          type="button"
+          onClick={onCheck}
+          disabled={checking}
+          className="shrink-0 rounded border border-border bg-surface-elevated px-2 py-1.5 text-[10px] text-muted hover:bg-surface-hover disabled:opacity-50"
+        >
+          {checking ? "Checking…" : "Check"}
+        </button>
+        {status && (
+          <div className="session-health-body">
+            <span className={`session-health-pill is-${status.tone}`}>{status.label}</span>
+            {status.found != null && (
+              <span className="session-health-metric">
+                <span className="session-health-k">found</span>
+                <span className="session-health-v">{status.found}</span>
+              </span>
+            )}
+            {status.mapped != null && (
+              <span className="session-health-metric">
+                <span className="session-health-k">on Sparks</span>
+                <span className="session-health-v">{status.mapped}</span>
+              </span>
+            )}
+            {status.detail && <p className="session-health-detail">{status.detail}</p>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SessionSourcesPanel.tsx
+++ b/src/components/SessionSourcesPanel.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import type { SessionSourceAttach, SessionSources, SessionSourcesHealth } from "../api/types";
+import { SessionSourceFields } from "./SessionSourceFields";
+
+export function sourceKinds(sources: SessionSources): string[] {
+  return Object.keys(sources).filter((key) => Array.isArray(sources[key]));
+}
+
+function healthFor(health: SessionSourcesHealth | null, kind: string, id: string) {
+  const list = health?.[kind];
+  if (!Array.isArray(list)) return undefined;
+  return list.find((row) => row.id === id) ?? list.find((row) => !row.id);
+}
+
+export function nextAttachId(kind: string, existing: SessionSourceAttach[]) {
+  const used = new Set(existing.map((row) => row.id));
+  if (!used.has(kind)) return kind;
+  let n = 2;
+  while (used.has(`${kind}-${n}`)) n += 1;
+  return `${kind}-${n}`;
+}
+
+const HELPER_COMMAND = `BIND="$(tailscale ip -4 2>/dev/null || ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')"
+TOKEN="$(openssl rand -hex 32)"
+printf 'URL:   http://%s:8788/occupancy\\nToken: %s\\n' "$BIND" "$TOKEN"
+OPENCODE_OCCUPANCY_BIND="$BIND" OPENCODE_OCCUPANCY_TOKEN="$TOKEN" node scripts/opencode-occupancy-helper/index.js`;
+
+export function SessionSourcesPanel({
+  sources,
+  tokenDrafts,
+  health,
+  checkingId,
+  onPatch,
+  onToken,
+  onClearToken,
+  onCheck,
+  onAdd,
+  onRemove,
+}: {
+  sources: SessionSources;
+  tokenDrafts: Record<string, string>;
+  health: SessionSourcesHealth | null;
+  checkingId: string | null;
+  onPatch: (kind: string, id: string, patch: Partial<SessionSourceAttach>) => void;
+  onToken: (id: string, value: string) => void;
+  onClearToken: (kind: string, id: string) => void;
+  onCheck: (id: string) => void;
+  onAdd: (kind: string) => void;
+  onRemove: (kind: string, id: string) => void;
+}) {
+  return (
+    <div className="space-y-3 border-t border-border pt-4">
+      <h3 className="text-xs font-medium text-text">Occupancy sources</h3>
+      <p className="text-[10px] leading-snug text-muted">
+        Dashboard-wide — set this once on any LLM card. Sessions land on the Spark whose
+        host:port they hit. Local = this dashboard host; URL = another machine.
+      </p>
+      <OpenCodeHelperSetup />
+      {sourceKinds(sources).map((kind) => {
+        const kindLabel = sources[kind][0]?.kindLabel || kind;
+        return (
+          <div key={kind} className="space-y-2">
+            {sources[kind].map((src) => (
+              <SessionSourceFields
+                key={src.id}
+                kind={kind}
+                source={src}
+                tokenDraft={tokenDrafts[src.id] ?? ""}
+                health={healthFor(health, kind, src.id)}
+                checking={checkingId === "*" || checkingId === src.id}
+                canRemove={sources[kind].length > 1}
+                onSource={(patch) => onPatch(kind, src.id, patch)}
+                onToken={(value) => onToken(src.id, value)}
+                onClearToken={() => onClearToken(kind, src.id)}
+                onCheck={() => onCheck(src.id)}
+                onRemove={() => onRemove(kind, src.id)}
+              />
+            ))}
+            <button
+              type="button"
+              onClick={() => onAdd(kind)}
+              className="rounded border border-border bg-surface-elevated px-2 py-1.5 text-[10px] text-muted hover:bg-surface-hover"
+            >
+              Add {kindLabel}
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function OpenCodeHelperSetup() {
+  const [copied, setCopied] = useState(false);
+  return (
+    <details className="rounded border border-border bg-surface-elevated px-3 py-2">
+      <summary className="cursor-pointer text-[10px] font-medium text-text">
+        How to attach OpenCode from another computer
+      </summary>
+      <p className="mt-2 text-[10px] leading-snug text-muted">
+        OpenCode has no occupancy HTTP API. Run this helper on the OpenCode machine, then paste
+        the printed URL and token into OpenCode below (mode URL). Same-host OpenCode: use Local,
+        no helper. Do not bind 0.0.0.0.
+      </p>
+      <ol className="mt-2 list-decimal space-y-1.5 pl-4 text-[10px] leading-snug text-muted">
+        <li>On that machine: Node 22+, from a sparkDash checkout.</li>
+      </ol>
+      <div className="mt-2 flex items-start gap-2">
+        <pre className="min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap rounded bg-surface px-2 py-1.5 font-mono text-[10px] text-text">
+          {HELPER_COMMAND}
+        </pre>
+        <button
+          type="button"
+          onClick={() => {
+            void navigator.clipboard.writeText(HELPER_COMMAND).then(() => {
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            });
+          }}
+          className="shrink-0 rounded border border-border px-2 py-1 text-[10px] text-muted hover:bg-surface-hover"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <ol className="mt-2 list-decimal space-y-1.5 pl-4 text-[10px] leading-snug text-muted" start={2}>
+        <li>The command prints the URL and token. Leave the helper running.</li>
+        <li>
+          Here: OpenCode → URL, paste both, Check, then{" "}
+          <span className="font-medium text-text">Save occupancy</span> (separate from Save port
+          above).
+        </li>
+        <li>
+          macOS 503: set <code className="text-text">OPENCODE_DATA_DIR</code> to the folder that
+          contains <code className="text-text">opencode.db</code> (often{" "}
+          <code className="text-text">~/Library/Application Support/opencode</code>).
+        </li>
+      </ol>
+    </details>
+  );
+}

--- a/src/components/SessionSourcesSettings.tsx
+++ b/src/components/SessionSourcesSettings.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useState } from "react";
+import { fetchSessionSources, testSessionSources, updateSessionSources } from "../api/client";
+import type {
+  SessionSourceAttach,
+  SessionSources,
+  SessionSourcesHealth,
+  SessionSourcesPatch,
+} from "../api/types";
+import { SessionSourcesPanel, nextAttachId, sourceKinds } from "./SessionSourcesPanel";
+
+function attachPatch(
+  src: SessionSourceAttach,
+  tokenDrafts: Record<string, string>,
+  clearTokens: Record<string, boolean>
+) {
+  const draft = tokenDrafts[src.id] ?? "";
+  return {
+    id: src.id,
+    label: src.label ?? "",
+    enabled: src.enabled,
+    mode: src.mode,
+    url: src.url,
+    stateDir: src.stateDir,
+    username: src.username ?? "",
+    ...(clearTokens[src.id] && !draft ? { token: "" } : draft ? { token: draft } : {}),
+  };
+}
+
+function testBody(
+  sources: SessionSources,
+  tokenDrafts: Record<string, string>,
+  clearTokens: Record<string, boolean>
+): SessionSourcesPatch {
+  return Object.fromEntries(
+    sourceKinds(sources).map((kind) => [
+      kind,
+      sources[kind].map((src) => attachPatch(src, tokenDrafts, clearTokens)),
+    ])
+  );
+}
+
+/**
+ * Dashboard occupancy attaches. Shown on LLM settings (not global Settings).
+ * Saves independently of the Spark LLM port.
+ */
+export function SessionSourcesSettings() {
+  const [sessionSources, setSessionSources] = useState<SessionSources | null>(null);
+  const [tokenDrafts, setTokenDrafts] = useState<Record<string, string>>({});
+  const [clearTokens, setClearTokens] = useState<Record<string, boolean>>({});
+  const [sourceHealth, setSourceHealth] = useState<SessionSourcesHealth | null>(null);
+  const [checkingId, setCheckingId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchSessionSources()
+      .then((sources) => {
+        if (cancelled) return;
+        setSessionSources(sources);
+        setCheckingId("*");
+        return testSessionSources(testBody(sources, {}, {})).then((result) => {
+          if (!cancelled) setSourceHealth(result);
+        });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setCheckingId(null);
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const patchSource = (kind: string, id: string, patch: Partial<SessionSourceAttach>) => {
+    setSessionSources((prev) =>
+      prev
+        ? {
+            ...prev,
+            [kind]: (prev[kind] ?? []).map((row) => (row.id === id ? { ...row, ...patch } : row)),
+          }
+        : prev
+    );
+    setDirty(true);
+  };
+
+  const addSource = (kind: string) => {
+    setSessionSources((prev) => {
+      if (!prev) return prev;
+      const id = nextAttachId(kind, prev[kind] ?? []);
+      const template = prev[kind]?.[0];
+      const blank: SessionSourceAttach = {
+        id,
+        label: "",
+        enabled: true,
+        mode: template?.urlPlaceholder ? "url" : "local",
+        url: "",
+        stateDir: "",
+        username: "",
+        hasToken: false,
+        conventionalStateDir: template?.conventionalStateDir ?? "",
+        conventionalConfigDir: template?.conventionalConfigDir,
+        urlPlaceholder: template?.urlPlaceholder,
+        usesUsername: template?.usesUsername,
+        kindLabel: template?.kindLabel,
+      };
+      return { ...prev, [kind]: [...(prev[kind] ?? []), blank] };
+    });
+    setDirty(true);
+  };
+
+  const removeSource = (kind: string, id: string) => {
+    setSessionSources((prev) =>
+      prev ? { ...prev, [kind]: (prev[kind] ?? []).filter((row) => row.id !== id) } : prev
+    );
+    setTokenDrafts((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    setClearTokens((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    setDirty(true);
+  };
+
+  const runCheck = async (sources: SessionSources, attachId?: string) => {
+    setCheckingId(attachId ?? "*");
+    setError(null);
+    try {
+      setSourceHealth(await testSessionSources(testBody(sources, tokenDrafts, clearTokens)));
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCheckingId(null);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!sessionSources) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const saved = await updateSessionSources(testBody(sessionSources, tokenDrafts, clearTokens));
+      setSessionSources(saved);
+      setTokenDrafts({});
+      setClearTokens({});
+      setDirty(false);
+      await runCheck(saved);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <p className="text-[10px] text-muted">Loading occupancy sources…</p>;
+  }
+  if (!sessionSources) {
+    return error ? <p className="text-[10px] text-danger">{error}</p> : null;
+  }
+
+  return (
+    <div className="space-y-3">
+      <SessionSourcesPanel
+        sources={sessionSources}
+        tokenDrafts={tokenDrafts}
+        health={sourceHealth}
+        checkingId={checkingId}
+        onPatch={patchSource}
+        onToken={(id, value) => {
+          setTokenDrafts((prev) => ({ ...prev, [id]: value }));
+          if (value) setClearTokens((prev) => ({ ...prev, [id]: false }));
+          setDirty(true);
+        }}
+        onClearToken={(kind, id) => {
+          setTokenDrafts((prev) => ({ ...prev, [id]: "" }));
+          setClearTokens((prev) => ({ ...prev, [id]: true }));
+          patchSource(kind, id, { hasToken: false });
+        }}
+        onCheck={(id) => void runCheck(sessionSources, id)}
+        onAdd={addSource}
+        onRemove={removeSource}
+      />
+      {error && <p className="text-[10px] text-danger">{error}</p>}
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={saving || !dirty}
+          className="rounded bg-accent px-2 py-1 text-[10px] font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Save occupancy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -215,6 +215,22 @@ export function SettingsDialog({ open, onClose, onSaved }: SettingsDialogProps) 
                 </span>
               </label>
             </div>
+
+            <div>
+              <label className="block text-xs text-text">Occupancy session age limit</label>
+              <span className="mt-0.5 block text-[10px] leading-snug text-muted">
+                Hide occupancy sessions older than this many hours. 0 shows all.
+              </span>
+              <input
+                type="number"
+                min={0}
+                max={168}
+                value={settings.occupancyMaxAgeHours}
+                onChange={(e) => update({ occupancyMaxAgeHours: Number(e.target.value) || 0 })}
+                className="mt-1 w-20 rounded border border-border bg-surface-elevated px-2 py-1 text-xs text-text outline-none focus:border-accent"
+              />
+              <span className="ml-1 text-[10px] text-muted">hours</span>
+            </div>
           </div>
         )}
 

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { fetchSettings, updateSettings } from "../api/client";
 import type { Settings } from "../api/types";
+import { Toggle } from "./SessionSourceFields";
 import { useModalPresence } from "../hooks/useModalPresence";
 import packageJson from "../../package.json";
 
@@ -95,14 +96,13 @@ export function SettingsDialog({ open, onClose, onSaved }: SettingsDialogProps) 
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="settings-panel w-full max-w-sm p-6">
+      <div className="settings-panel w-full max-w-md max-h-[90vh] overflow-y-auto p-6">
         <h2 className="mb-4 text-sm font-semibold text-text-strong">Settings</h2>
 
         {loading && <p className="text-xs text-muted">Loading…</p>}
 
         {settings && !loading && (
           <div className="space-y-4">
-            {/* Poll interval */}
             <div>
               <label className="mb-2 block text-xs text-muted">Poll interval</label>
               <div className="flex gap-2">
@@ -123,7 +123,6 @@ export function SettingsDialog({ open, onClose, onSaved }: SettingsDialogProps) 
               </div>
             </div>
 
-            {/* Default LLM port */}
             <div>
               <label className="mb-1 block text-xs text-muted">Default LLM port</label>
               <input
@@ -142,48 +141,24 @@ export function SettingsDialog({ open, onClose, onSaved }: SettingsDialogProps) 
               </p>
             </div>
 
-            {/* Auto-hide offline */}
             <div>
               <label className="flex items-center gap-3 text-xs text-muted">
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={settings.autoHideOffline}
+                <Toggle
+                  on={settings.autoHideOffline}
                   onClick={() => update({ autoHideOffline: !settings.autoHideOffline })}
-                  className={`toggle-track relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
-                    settings.autoHideOffline ? "is-on" : ""
-                  }`}
-                >
-                  <span
-                    className={`toggle-dot inline-block h-4 w-4 transform rounded-full shadow transition-transform ${
-                      settings.autoHideOffline ? "translate-x-4" : "translate-x-0"
-                    }`}
-                  />
-                </button>
+                />
                 Auto-hide offline Sparks on Overview
               </label>
             </div>
 
-            {/* Benchmark debug traces */}
             <div>
               <label className="flex items-start gap-3 text-xs text-muted">
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={Boolean(settings.benchDebugTraces)}
+                <Toggle
+                  on={Boolean(settings.benchDebugTraces)}
                   onClick={() =>
                     update({ benchDebugTraces: !settings.benchDebugTraces })
                   }
-                  className={`toggle-track relative mt-0.5 inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
-                    settings.benchDebugTraces ? "is-on" : ""
-                  }`}
-                >
-                  <span
-                    className={`toggle-dot inline-block h-4 w-4 transform rounded-full shadow transition-transform ${
-                      settings.benchDebugTraces ? "translate-x-4" : "translate-x-0"
-                    }`}
-                  />
-                </button>
+                />
                 <span>
                   <span className="block text-text">Enable debug traces for Benchmark runs</span>
                   <span className="mt-0.5 block text-[10px] leading-snug text-muted">
@@ -194,7 +169,6 @@ export function SettingsDialog({ open, onClose, onSaved }: SettingsDialogProps) 
               </label>
             </div>
 
-            {/* Temperature unit */}
             <div>
               <label className="text-xs text-muted">Temperature unit</label>
               <div className="mt-1.5 flex gap-2">
@@ -223,28 +197,16 @@ export function SettingsDialog({ open, onClose, onSaved }: SettingsDialogProps) 
               </div>
             </div>
 
-            {/* Density */}
             <div>
               <label className="flex items-start gap-3 text-xs text-muted">
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={settings.density === "compact"}
+                <Toggle
+                  on={settings.density === "compact"}
                   onClick={() =>
                     update({
                       density: settings.density === "compact" ? "comfortable" : "compact",
                     })
                   }
-                  className={`toggle-track relative mt-0.5 inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
-                    settings.density === "compact" ? "is-on" : ""
-                  }`}
-                >
-                  <span
-                    className={`toggle-dot inline-block h-4 w-4 transform rounded-full shadow transition-transform ${
-                      settings.density === "compact" ? "translate-x-4" : "translate-x-0"
-                    }`}
-                  />
-                </button>
+                />
                 <span>
                   <span className="block text-text">Compact UI</span>
                   <span className="mt-0.5 block text-[10px] leading-snug text-muted">
@@ -256,7 +218,6 @@ export function SettingsDialog({ open, onClose, onSaved }: SettingsDialogProps) 
           </div>
         )}
 
-        {/* Links */}
         <div className="mt-5 flex items-center gap-3 border-t border-border pt-3">
           <span className="text-[10px] text-muted">sparkDash v{packageJson.version}</span>
           <span className="text-border-strong text-[10px]">·</span>
@@ -293,7 +254,7 @@ export function SettingsDialog({ open, onClose, onSaved }: SettingsDialogProps) 
           </button>
           <button
             type="button"
-            onClick={handleSave}
+            onClick={() => void handleSave()}
             disabled={saving || !settings || !dirty}
             className="rounded bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
           >

--- a/src/components/SparkPage/ConversationList.tsx
+++ b/src/components/SparkPage/ConversationList.tsx
@@ -1,0 +1,147 @@
+import type { ConversationRow } from "../../api/types";
+import { PlusIcon } from "../ui/icons";
+
+const SOURCE_LABEL: Record<string, string> = {
+  openclaw: "OpenClaw",
+  hermes: "Hermes",
+  opencode: "OpenCode",
+  omp: "oh-my-pi",
+};
+
+interface ConversationListProps {
+  conversations: ConversationRow[];
+  onAddHarness?: () => void;
+}
+
+function formatSessionAge(lastUsedAt: number | undefined, now: number): string {
+  if (lastUsedAt == null || !Number.isFinite(lastUsedAt)) return "—";
+  const delta = Math.max(0, now - lastUsedAt);
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (delta < minute) return "now";
+  if (delta < hour) return `${Math.floor(delta / minute)}m`;
+  if (delta < day) return `${Math.floor(delta / hour)}h`;
+  if (delta < 7 * day) return `${Math.floor(delta / day)}d`;
+  return new Date(lastUsedAt).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function occupancyTone(row: ConversationRow, now: number): "generating" | "recent" | "warm" | "idle" {
+  if (row.badge === "generating") return "generating";
+  if (row.lastUsedAt == null || !Number.isFinite(row.lastUsedAt)) return "idle";
+  const age = now - row.lastUsedAt;
+  if (age < 5 * 60_000) return "recent";
+  if (age < 60 * 60_000) return "warm";
+  return "idle";
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`;
+  if (n >= 10_000) return `${Math.round(n / 1000)}k`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+function contextLabel(row: ConversationRow): string {
+  if (row.contextUsed == null) return "";
+  const used = `${row.contextApprox ? "~" : ""}${formatTokens(row.contextUsed)}`;
+  if (row.contextWindow == null) return used;
+  return `${used}/${formatTokens(row.contextWindow)}`;
+}
+
+function contextTitle(row: ConversationRow): string {
+  const used = row.contextUsed?.toLocaleString();
+  const window = row.contextWindow?.toLocaleString();
+  if (used && window) return `${row.contextApprox ? "~" : ""}${used} / ${window} tokens`;
+  if (used) return `${row.contextApprox ? "~" : ""}${used} tokens`;
+  if (window) return `${window} token window`;
+  return "";
+}
+
+function stateLabel(row: ConversationRow, now: number): string {
+  if (row.badge === "generating") return "Generating";
+  return formatSessionAge(row.lastUsedAt, now);
+}
+
+function laneLabel(source: string, agent?: string, gateway?: string): string {
+  const parts = [SOURCE_LABEL[source] ?? source];
+  if (gateway) parts.push(gateway);
+  if (agent) parts.push(agent);
+  return parts.join(" · ");
+}
+
+function groupConversations(rows: ConversationRow[]) {
+  const groups: { key: string; label: string; rows: ConversationRow[] }[] = [];
+  const index = new Map<string, number>();
+  for (const row of rows) {
+    const key = `${row.source}\0${row.gateway ?? ""}\0${row.agent ?? ""}`;
+    const existing = index.get(key);
+    if (existing != null) {
+      groups[existing].rows.push(row);
+      continue;
+    }
+    index.set(key, groups.length);
+    groups.push({ key, label: laneLabel(row.source, row.agent, row.gateway), rows: [row] });
+  }
+  return groups;
+}
+
+export function ConversationList({ conversations, onAddHarness }: ConversationListProps) {
+  const now = Date.now();
+  const groups = groupConversations(conversations);
+
+  return (
+    <div className="occupancy">
+      <div className="occupancy-head">
+        <span className="occupancy-head-count">{conversations.length}</span>
+        <span className="occupancy-head-title">Sessions</span>
+        {onAddHarness && (
+          <button
+            type="button"
+            title="Add harness"
+            aria-label="Add harness"
+            onClick={onAddHarness}
+            className="occupancy-head-add"
+          >
+            <PlusIcon className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+      {conversations.length === 0 ? (
+        <div className="occupancy-empty">
+          <p>No sessions on this LLM. Attach OpenClaw, Hermes, OpenCode, or oh-my-pi.</p>
+          {onAddHarness && (
+            <button type="button" onClick={onAddHarness} className="occupancy-add-harness">
+              + Harness
+            </button>
+          )}
+        </div>
+      ) : (
+        <div className="occupancy-list" aria-label="Occupancy on this LLM">
+          {groups.map((group) => (
+            <section key={group.key} className="occupancy-lane">
+              <h3 className="occupancy-lane-label">{group.label}</h3>
+              <ul className="occupancy-lane-list" aria-label={group.label}>
+                {group.rows.map((row) => {
+                  const ctx = contextLabel(row);
+                  return (
+                    <li key={row.id} className={`occupancy-row is-${occupancyTone(row, now)}`}>
+                      <span className="occupancy-dot" aria-hidden="true" />
+                      <span className="occupancy-handle" title={row.handle}>
+                        {row.handle}
+                      </span>
+                      <span className="occupancy-ctx" title={ctx ? contextTitle(row) : undefined}>
+                        {ctx}
+                      </span>
+                      <span className="occupancy-state">{stateLabel(row, now)}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SparkPage/GpuPanel.tsx
+++ b/src/components/SparkPage/GpuPanel.tsx
@@ -1,4 +1,4 @@
-import type { GpuMetrics } from "../../api/types";
+import type { GpuMetrics, ConversationRow } from "../../api/types";
 import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
 import { ActivityIcon } from "../ui/icons";
@@ -10,6 +10,8 @@ interface GpuPanelProps {
   sparkId: string;
   temperatureUnit: "celsius" | "fahrenheit";
   className?: string;
+  llmPort?: number;
+  conversations?: ConversationRow[];
 }
 
 function celsiusToFahrenheit(c: number): number {

--- a/src/components/SparkPage/LlmPanel.tsx
+++ b/src/components/SparkPage/LlmPanel.tsx
@@ -1,17 +1,20 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import type { LlmMetrics } from "../../api/types";
+import { useState, useEffect, useRef, useCallback, type ReactNode } from "react";
+import type { ConversationRow, LlmMetrics } from "../../api/types";
 import { setLlmApiKey, updateLlmPort, updateLlmPorts } from "../../api/client";
 import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
 import { BotIcon, GearIcon, InfoIcon } from "../ui/icons";
 import { useMetricsHistoryTail } from "../../hooks/metricsStore";
 import { BenchmarkDialog } from "./BenchmarkDialog";
+import { ConversationList } from "./ConversationList";
+import { SessionSourcesSettings } from "../SessionSourcesSettings";
 import { LlmDailyChart } from "./LlmDailyChart";
 
 interface LlmPanelProps {
   llm: LlmMetrics | null;
   sparkId: string;
   llmPort: number;
+  conversations?: ConversationRow[];
   llmPorts?: number[];
   hasApiKey?: boolean;
   onRemovePort?: (port: number) => void;
@@ -53,6 +56,23 @@ function BackendBadge({ backend }: { backend: string | null }) {
       <span className="h-1.5 w-1.5 rounded-full bg-accent" />
       {labels[backend] || backend}
     </span>
+  );
+}
+
+function LlmOperate({
+  conversations,
+  onAddHarness,
+  children,
+}: {
+  conversations: ConversationRow[];
+  onAddHarness?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="llm-operate">
+      <div className="llm-operate-metrics space-y-3">{children}</div>
+      <ConversationList conversations={conversations} onAddHarness={onAddHarness} />
+    </div>
   );
 }
 
@@ -150,6 +170,7 @@ export function LlmPanel({
   llm,
   sparkId,
   llmPort,
+  conversations = [],
   llmPorts,
   hasApiKey = false,
   onRemovePort,
@@ -161,6 +182,8 @@ export function LlmPanel({
   const cachedPrefillHistory = useMetricsHistoryTail(sparkId, `llm:${llmPort}.prefillCached`);
   const uncachedPrefillHistory = useMetricsHistoryTail(sparkId, `llm:${llmPort}.prefillUncached`);
   const [showSettings, setShowSettings] = useState(false);
+  const [focusOccupancy, setFocusOccupancy] = useState(false);
+  const occupancySettingsRef = useRef<HTMLDivElement>(null);
   const [portDraft, setPortDraft] = useState(String(llmPort));
   const [apiKeyDraft, setApiKeyDraft] = useState("");
   const [clearApiKey, setClearApiKey] = useState(false);
@@ -210,6 +233,17 @@ export function LlmPanel({
   const portInvalid = portDraft.trim() !== "" && parsedPort === null;
   const apiKeyDirty = apiKeyDraft.trim() !== "" || clearApiKey;
   const settingsDirty = portDirty || apiKeyDirty;
+
+  const openHarnessSettings = useCallback(() => {
+    setFocusOccupancy(true);
+    setShowSettings(true);
+  }, []);
+
+  useEffect(() => {
+    if (!showSettings || !focusOccupancy) return;
+    occupancySettingsRef.current?.scrollIntoView({ block: "nearest" });
+    setFocusOccupancy(false);
+  }, [showSettings, focusOccupancy]);
 
   const handleSaveSettings = async () => {
     if (parsedPort === null) {
@@ -298,9 +332,10 @@ export function LlmPanel({
       }
     >
       {showSettings ? (
-        <div className="space-y-3">
+        <div className="max-h-[70vh] space-y-3 overflow-y-auto pr-1">
           <p className="text-[10px] text-muted">
-            HTTP port of the LLM server on this Spark (vLLM / llama.cpp / sglang / ds4 / OpenAI-compatible gateway).
+            HTTP port of the LLM server on this Spark (vLLM / llama.cpp / sglang / ds4 / OpenAI-compatible gateway). Occupancy
+            sources below are dashboard-wide and save separately.
           </p>
           <label className="block space-y-1">
             <span className="text-xs text-muted">Port</span>
@@ -386,47 +421,52 @@ export function LlmPanel({
               disabled={saving || portInvalid || !settingsDirty}
               className="rounded bg-accent px-2 py-1 text-[10px] font-medium text-white hover:bg-accent-hover disabled:opacity-50"
             >
-              {saving ? "Saving…" : "Save"}
+              {saving ? "Saving…" : "Save port"}
             </button>
+          </div>
+          <div ref={occupancySettingsRef}>
+            <SessionSourcesSettings />
           </div>
         </div>
       ) : !available ? (
-        <div className="space-y-3">
-          <div className="flex flex-wrap items-center gap-2 py-1">
-            {llm?.posture ? (
-              <PostureBadge posture={llm.posture} />
-            ) : (
-              <span className="h-1.5 w-1.5 rounded-full bg-muted" />
-            )}
-            <p className="text-xs text-muted">
-              {llm?.posture?.auth === "protected"
-                ? `${llm.posture.label} on :${llmPort}`
-                : `No model loaded on :${llmPort}`}
-            </p>
+        <LlmOperate conversations={conversations} onAddHarness={openHarnessSettings}>
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2 py-1">
+              {llm?.posture ? (
+                <PostureBadge posture={llm.posture} />
+              ) : (
+                <span className="h-1.5 w-1.5 rounded-full bg-muted" />
+              )}
+              <p className="text-xs text-muted">
+                {llm?.posture?.auth === "protected"
+                  ? `${llm.posture.label} on :${llmPort}`
+                  : `No model loaded on :${llmPort}`}
+              </p>
+            </div>
+            <div className="border-t border-border pt-3 space-y-2">
+              <button
+                type="button"
+                onClick={() => {
+                  const params = new URLSearchParams();
+                  if (llmPort) params.set("port", String(llmPort));
+                  const q = params.toString() ? `?${params.toString()}` : "";
+                  window.open(
+                    `/showcase/${encodeURIComponent(sparkId)}${q}`,
+                    "_blank",
+                    "noopener,noreferrer"
+                  );
+                }}
+                className="w-full rounded border border-border bg-surface-elevated px-3 py-1.5 text-xs font-medium text-text transition-colors hover:border-accent hover:bg-accent-soft"
+                title="Open prompt showcase (works offline to view history or prepare a run)"
+              >
+                Showcase
+              </button>
+              <LlmDailyChart sparkId={sparkId} llmPort={llmPort} />
+            </div>
           </div>
-          <div className="border-t border-border pt-3 space-y-2">
-            <button
-              type="button"
-              onClick={() => {
-                const params = new URLSearchParams();
-                if (llmPort) params.set("port", String(llmPort));
-                const q = params.toString() ? `?${params.toString()}` : "";
-                window.open(
-                  `/showcase/${encodeURIComponent(sparkId)}${q}`,
-                  "_blank",
-                  "noopener,noreferrer"
-                );
-              }}
-              className="w-full rounded border border-border bg-surface-elevated px-3 py-1.5 text-xs font-medium text-text transition-colors hover:border-accent hover:bg-accent-soft"
-              title="Open prompt showcase (works offline to view history or prepare a run)"
-            >
-              Showcase
-            </button>
-            <LlmDailyChart sparkId={sparkId} llmPort={llmPort} />
-          </div>
-        </div>
+        </LlmOperate>
       ) : (
-        <div className="space-y-3">
+        <LlmOperate conversations={conversations} onAddHarness={openHarnessSettings}>
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <BackendBadge backend={llm?.backend ?? null} />
             {llm?.posture && <PostureBadge posture={llm.posture} />}
@@ -732,7 +772,7 @@ export function LlmPanel({
               Showcase
             </button>
           </div>
-        </div>
+        </LlmOperate>
       )}
 
       <BenchmarkDialog

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, type CSSProperties } from "react";
-import type { SparkSnapshot } from "../../api/types";
+import { useState, useEffect, useCallback, useMemo, type CSSProperties } from "react";
+import type { ConversationRow, SparkSnapshot } from "../../api/types";
 import { isLlmMonitoringEnabled } from "../../api/sparkRole";
 import { updateSpark, refreshSparkMetric, addLlmPort, removeLlmPort } from "../../api/client";
 import { SparkHeader } from "./SparkHeader";
@@ -18,6 +18,8 @@ interface SparkPageProps {
   temperatureUnit: "celsius" | "fahrenheit";
   onEdit?: () => void;
 }
+
+const EMPTY_CONVERSATIONS: ConversationRow[] = [];
 
 const SECTION_OPEN_KEYS = {
   resources: "sparkdash.ui.section.resources",
@@ -111,6 +113,16 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
     });
   }, []);
 
+  const conversationsByPort = useMemo(() => {
+    const byPort = new Map<number, ConversationRow[]>();
+    for (const row of spark.conversations ?? []) {
+      const list = byPort.get(row.port);
+      if (list) list.push(row);
+      else byPort.set(row.port, [row]);
+    }
+    return byPort;
+  }, [spark.conversations]);
+
   // Sync when spark data changes (WS push)
   useEffect(() => {
     setDisabledDevices(spark.disabledDevices || []);
@@ -203,6 +215,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
         llm={llmMetrics}
         sparkId={spark.id}
         llmPort={port}
+        conversations={conversationsByPort.get(port) ?? EMPTY_CONVERSATIONS}
         llmPorts={llmPorts}
         hasApiKey={Boolean(spark.llmApiKeyPorts?.includes(port))}
         onRemovePort={canRemove ? handleRemovePort : undefined}
@@ -235,6 +248,8 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
                 <GpuPanel
                   gpu={metrics.gpu}
                   sparkId={spark.id}
+                  llmPort={primaryPort}
+                  conversations={conversationsByPort.get(primaryPort) ?? EMPTY_CONVERSATIONS}
                   temperatureUnit={temperatureUnit}
                   className={tailscaleOn ? "md:row-span-4" : "md:row-span-3"}
                 />

--- a/src/index.css
+++ b/src/index.css
@@ -1011,6 +1011,8 @@ input[type="checkbox"] {
   margin: 0;
   font-size: 11px;
   line-height: 1.4;
+  color: var(--color-muted);
+}
 
 /* Endpoint exposure / auth posture (#17) */
 .llm-posture {

--- a/src/index.css
+++ b/src/index.css
@@ -741,6 +741,277 @@ input[type="checkbox"] {
   color: var(--color-accent);
 }
 
+
+/* ─── Occupancy (bound chats on an LLM port) ───────────── */
+.llm-operate {
+  display: grid;
+  gap: 16px;
+}
+@media (min-width: 768px) {
+  .llm-operate:has(.occupancy) {
+    grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+    gap: 28px;
+    align-items: start;
+  }
+}
+.occupancy {
+  min-width: 0;
+}
+.occupancy-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 8px;
+}
+.occupancy-head-count {
+  font-size: 18px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+  line-height: 1;
+}
+.occupancy-head-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-muted-strong);
+}
+.occupancy-head-add {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  color: var(--color-muted);
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.occupancy-head-add:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-accent);
+}
+.occupancy-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.occupancy-empty p {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--color-muted);
+}
+.occupancy-add-harness {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px dashed var(--color-border);
+  background: transparent;
+  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--color-muted);
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.occupancy-add-harness:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+.occupancy-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: min(28rem, 58vh);
+  overflow: auto;
+  scrollbar-color: var(--color-border-strong) transparent;
+}
+.occupancy-lane {
+  min-width: 0;
+}
+.occupancy-lane-label {
+  margin: 0 0 4px;
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  color: var(--color-muted);
+}
+.occupancy-lane-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.occupancy-row {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 10px 12px;
+  min-height: 32px;
+  padding: 4px 4px 4px 0;
+  border-radius: 8px;
+}
+.occupancy-row:hover {
+  background: var(--color-surface-hover);
+}
+.occupancy-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-muted);
+}
+.occupancy-row.is-generating .occupancy-dot {
+  background: var(--color-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 22%, transparent);
+  animation: occupancy-live 1.8s ease-out infinite;
+}
+.occupancy-row.is-recent .occupancy-dot {
+  background: var(--color-success);
+}
+.occupancy-row.is-warm .occupancy-dot {
+  background: var(--color-accent);
+}
+.occupancy-row.is-idle .occupancy-dot {
+  background: var(--color-muted);
+}
+.occupancy-handle {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 550;
+  color: var(--color-text);
+}
+.occupancy-ctx {
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-muted);
+  white-space: nowrap;
+  justify-self: end;
+}
+.occupancy-state {
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-muted-strong);
+  white-space: nowrap;
+  justify-self: end;
+}
+.occupancy-row.is-generating .occupancy-state {
+  color: var(--color-success);
+}
+.occupancy-row.is-recent .occupancy-state {
+  color: var(--color-success);
+}
+.occupancy-row.is-warm .occupancy-state {
+  color: var(--color-accent);
+}
+.occupancy-row.is-idle .occupancy-state {
+  color: var(--color-muted);
+}
+
+@keyframes occupancy-live {
+  0%,
+  100% {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 22%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 5px color-mix(in srgb, var(--color-success) 8%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .occupancy-row.is-generating .occupancy-dot {
+    animation: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .occupancy-list {
+    max-height: min(32rem, 64vh);
+  }
+  .occupancy-row {
+    min-height: 36px;
+    padding: 6px 8px 6px 4px;
+  }
+  .occupancy-handle {
+    font-size: 14px;
+  }
+}
+
+[data-density="compact"] .occupancy-head-count {
+  font-size: 15px;
+}
+[data-density="compact"] .occupancy-row {
+  min-height: 26px;
+  gap: 8px;
+  padding: 2px 4px 2px 0;
+}
+[data-density="compact"] .occupancy-handle {
+  font-size: 12px;
+}
+
+.session-health {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+.session-health-body {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 12px;
+}
+.session-health-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 50px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--color-surface-elevated);
+  color: var(--color-muted-strong);
+  border: 1px solid var(--color-border);
+}
+.session-health-pill.is-ok {
+  color: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success) 35%, var(--color-border));
+}
+.session-health-pill.is-danger {
+  color: var(--color-danger);
+  border-color: color-mix(in srgb, var(--color-danger) 35%, var(--color-border));
+}
+.session-health-metric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.session-health-k {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+.session-health-v {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+.session-health-detail {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.4;
+
 /* Endpoint exposure / auth posture (#17) */
 .llm-posture {
   display: inline-flex;
@@ -768,6 +1039,7 @@ input[type="checkbox"] {
 }
 .llm-posture--danger {
   background: color-mix(in srgb, var(--color-danger) 16%, transparent);
+
   color: var(--color-danger);
 }
 


### PR DESCRIPTION
## Summary

- Add `OCCUPANCY.md` — full setup guide for the session occupancy system covering all four sources (OpenClaw, Hermes, OpenCode, oh-my-pi), local/URL/state-dir modes, helper setup for remote machines, the session age filter setting, origin matching, and LiteLLM notes
- Add `scripts/omp-occupancy-helper/README.md` — env vars, security rules, and response shape for the omp helper (mirrors the OpenCode helper README)
- Update `README.md` — features table and occupancy section now include oh-my-pi, the age filter, and the omp helper quick-start

#### Test plan

- [x] `npm run build` passes
- [x] Internal links in OCCUPANCY.md resolve to repo-relative paths
- [x] README.md links to OCCUPANCY.md and both helper READMEs

Generated with [Devin](https://devin.ai)