### PR TITLE
fix(llm): SGLang Engine tile and live tok/s under load

### DIFF
--- a/server/collectors/LlmProbe.js
+++ b/server/collectors/LlmProbe.js
@@ -416,7 +416,13 @@ export class LlmProbe {
         if (sgRes.ok) {
           this.backendType = "sglang";
           const sgData = await sgRes.json();
+          // Load before last_gen_throughput so inflight can keep a steady rate live.
+          await this._probeSglangLoad();
           this._applySglangServerInfo(sgData, dtSec);
+          // Engine tile: Active vs Sleeping. SGLang has no live sleep gauge
+          // (sleep_on_idle is a launch flag, not current state). A reachable
+          // server with weights resident is Active / ready.
+          if (this.gpuMemoryUtilization == null) this.gpuMemoryUtilization = 1;
         }
       } catch {}
     }
@@ -688,19 +694,103 @@ export class LlmProbe {
       }
     }
 
-    // No cumulative counters — sticky last_gen_throughput only while it moves
+    // No cumulative counters — sticky last_gen_throughput only while it moves,
+    // unless /v1/loads (or /get_load) says requests are in flight.
     const lastGen = LlmProbe._sglangLastGenThroughput(sgData);
-    this.generationTps = this._sglangStickyThroughput(lastGen);
+    this.generationTps = this._sglangStickyThroughput(lastGen, this._sglangInflight());
+  }
+
+  /** True when SGLang load probe reported running or waiting requests. */
+  _sglangInflight() {
+    return (
+      this.slotsActive > 0 ||
+      (this.requestsRunning != null && this.requestsRunning > 0) ||
+      (this.requestsWaiting != null && this.requestsWaiting > 0)
+    );
+  }
+
+  /**
+   * Prefer /v1/loads (num_running_reqs). Fall back to /get_load, where
+   * num_reqs is running + waiting.
+   */
+  async _probeSglangLoad() {
+    for (const path of ["/v1/loads", "/get_load"]) {
+      try {
+        const res = await this._fetch(`${this.baseUrl}${path}`);
+        if (!res.ok) continue;
+        const data = await res.json().catch(() => null);
+        if (this._applySglangLoad(data)) return;
+      } catch {
+        /* try next */
+      }
+    }
+  }
+
+  /**
+   * Apply SGLang /v1/loads or /get_load. Returns true when a row was applied.
+   * @param {unknown} payload
+   * @returns {boolean}
+   */
+  _applySglangLoad(payload) {
+    const rows = LlmProbe._sglangLoadRows(payload);
+    if (!rows.length) return false;
+    let running = 0;
+    let waiting = 0;
+    let saw = false;
+    for (const row of rows) {
+      const wait = Number(row.num_waiting_reqs);
+      const runDirect = Number(row.num_running_reqs);
+      const total = Number(row.num_reqs);
+      if (Number.isFinite(wait) && wait >= 0) {
+        waiting += wait;
+        saw = true;
+      }
+      if (Number.isFinite(runDirect) && runDirect >= 0) {
+        running += runDirect;
+        saw = true;
+      } else if (Number.isFinite(total) && total >= 0) {
+        const waitPart = Number.isFinite(wait) && wait >= 0 ? wait : 0;
+        running += Math.max(0, total - waitPart);
+        saw = true;
+      }
+    }
+    if (!saw) return false;
+    this.requestsRunning = running;
+    this.requestsWaiting = waiting;
+    this.slotsActive = Math.round(running);
+    return true;
+  }
+
+  /**
+   * @param {unknown} payload
+   * @returns {Array<Record<string, unknown>>}
+   */
+  static _sglangLoadRows(payload) {
+    if (payload == null) return [];
+    if (Array.isArray(payload)) {
+      return payload.filter((row) => row && typeof row === "object");
+    }
+    if (typeof payload !== "object") return [];
+    if (Array.isArray(payload.loads)) {
+      return payload.loads.filter((row) => row && typeof row === "object");
+    }
+    if (payload.num_reqs != null || payload.num_running_reqs != null) {
+      return [payload];
+    }
+    return [];
   }
 
   /**
    * Map SGLang's sticky last_gen_throughput gauge to a live panel rate.
    * Returns 0 until the value changes between polls (avoids showing a stale
    * leftover after idle); stays live for a short window after each change.
+   * When `inflight` is true (independent load signal), keep a positive rate
+   * even if the gauge is not moving — a busy decode can report a constant value.
    * @param {number | null} raw
+   * @param {boolean} [inflight]
    * @returns {number}
    */
-  _sglangStickyThroughput(raw) {
+  _sglangStickyThroughput(raw, inflight = false) {
     if (raw == null || !Number.isFinite(raw) || raw < 0) {
       this._sglangStickyTps = null;
       return 0;
@@ -710,9 +800,12 @@ export class LlmProbe {
     const prev = this._sglangStickyTps;
 
     if (!prev) {
-      // First sample after reset/start — seed only; do not display stale gauge
-      this._sglangStickyTps = { value: rounded, liveUntil: 0 };
-      return 0;
+      // First sample after reset/start — seed only unless load says we are busy
+      this._sglangStickyTps = {
+        value: rounded,
+        liveUntil: inflight && rounded > 0 ? now + SGLANG_STICKY_TPS_LIVE_MS : 0,
+      };
+      return inflight && rounded > 0 ? rounded : 0;
     }
 
     if (rounded !== prev.value) {
@@ -724,6 +817,9 @@ export class LlmProbe {
     }
 
     if (prev.liveUntil > now) {
+      return rounded;
+    }
+    if (inflight && rounded > 0) {
       return rounded;
     }
     return 0;

--- a/server/collectors/__tests__/LlmProbe.sglang.test.js
+++ b/server/collectors/__tests__/LlmProbe.sglang.test.js
@@ -291,6 +291,135 @@ test("probe: modern sglang without totals still reports last_gen tok/s", async (
   assert.equal(snap.available, true);
 });
 
+test("_applySglangLoad: /v1/loads uses num_running_reqs", () => {
+  const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 30000);
+  assert.equal(
+    probe._applySglangLoad({
+      loads: [{ num_running_reqs: 8, num_waiting_reqs: 26 }],
+    }),
+    true
+  );
+  assert.equal(probe.slotsActive, 8);
+  assert.equal(probe.requestsRunning, 8);
+  assert.equal(probe.requestsWaiting, 26);
+});
+
+test("_applySglangLoad: /get_load num_reqs is running + waiting", () => {
+  const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 30000);
+  assert.equal(
+    probe._applySglangLoad([{ num_reqs: 34, num_waiting_reqs: 26 }]),
+    true
+  );
+  assert.equal(probe.slotsActive, 8);
+  assert.equal(probe.requestsRunning, 8);
+  assert.equal(probe.requestsWaiting, 26);
+});
+
+test("_applySglangLoad: empty / unknown payload is a no-op", () => {
+  const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 30000);
+  assert.equal(probe._applySglangLoad(null), false);
+  assert.equal(probe._applySglangLoad({}), false);
+  assert.equal(probe.slotsActive, 0);
+});
+
+test("_sglangStickyThroughput: inflight keeps a steady rate after the live window", () => {
+  const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 30000);
+  assert.equal(probe._sglangStickyThroughput(40, true), 40);
+  probe._sglangStickyTps.liveUntil = Date.now() - 1;
+  assert.equal(probe._sglangStickyThroughput(40, true), 40);
+  assert.equal(probe._sglangStickyThroughput(40, false), 0);
+});
+
+test("probe: reachable SGLang without sleep metric is Active, not Sleeping", async () => {
+  const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 30000);
+  probe.serverIsOpenAI = true;
+  probe.backendType = "sglang";
+  probe.authOpen = true;
+  probe._lastDetectAt = Date.now();
+  probe.lastProbeTime = Date.now() - 2000;
+  probe._fetch = async (url) => {
+    const u = String(url);
+    if (u.endsWith("/v1/models")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{ id: "org/model", owned_by: "sglang", max_model_len: 8192 }],
+        }),
+      };
+    }
+    if (u.endsWith("/get_server_info")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          model_path: "org/model",
+          context_length: 8192,
+          sleep_on_idle: true,
+          internal_states: [{ last_gen_throughput: 0 }],
+        }),
+      };
+    }
+    if (u.endsWith("/v1/loads")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ loads: [{ num_running_reqs: 0, num_waiting_reqs: 0 }] }),
+      };
+    }
+    return { ok: false, status: 404, json: async () => ({}), text: async () => "" };
+  };
+  const snap = await probe.probe();
+  assert.equal(snap.available, true);
+  assert.equal(snap.backend, "sglang");
+  assert.equal(snap.gpuMemoryUtilization, 1);
+  assert.equal(snap.totalOutputTokens, 0);
+});
+
+test("probe: /v1/loads inflight keeps last_gen on the first sample", async () => {
+  const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 30000);
+  probe.serverIsOpenAI = true;
+  probe.backendType = "sglang";
+  probe.authOpen = true;
+  probe._lastDetectAt = Date.now();
+  probe.lastProbeTime = Date.now() - 2000;
+  probe._fetch = async (url) => {
+    const u = String(url);
+    if (u.endsWith("/v1/models")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{ id: "org/model", owned_by: "sglang", max_model_len: 8192 }],
+        }),
+      };
+    }
+    if (u.endsWith("/get_server_info")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          model_path: "org/model",
+          context_length: 8192,
+          internal_states: [{ last_gen_throughput: 55.5 }],
+        }),
+      };
+    }
+    if (u.endsWith("/v1/loads")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ loads: [{ num_running_reqs: 3, num_waiting_reqs: 1 }] }),
+      };
+    }
+    return { ok: false, status: 404, json: async () => ({}), text: async () => "" };
+  };
+  const snap = await probe.probe();
+  assert.equal(snap.generationTps, 55.5);
+  assert.equal(snap.slotsActive, 3);
+  assert.equal(snap.requestsWaiting, 1);
+});
+
 test("_applySglangMetrics: cached_tokens_total vs prompt_tokens_total", () => {
   const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 30000);
   probe._applySglangMetrics(


### PR DESCRIPTION
## Bug Description

On a live SGLang server the LLM panel already shows the backend badge and model id, but **Engine** stays `—` and **Generation tok/s** often drops to `0` while requests are still running.

This is not a detection bug. sparkDash already classifies SGLang (`owned_by`, `/get_server_info`) and switches to the SGLang probe path. The gap is that path never reads SGLang load, and it treats a *steady* `last_gen_throughput` as an idle leftover.

## Root Cause

- **Engine** is driven by `gpuMemoryUtilization`. That field is only filled from vLLM’s `engine_sleep_state`. SGLang has no equivalent live sleep gauge. `sleep_on_idle` is a *launch flag* (park the scheduler when the queue is empty). It is not “GPU memory freed”, so mapping it to Sleeping would be wrong.
- Modern SGLang often omits `total_input_tokens` / `total_output_tokens` and ships with Prometheus off (`/metrics` 404). The panel then falls back to sticky `last_gen_throughput`. A busy decode can report the same rate for many polls; after ~6s the sticky window expires and the UI shows `0` even though `/v1/loads` still has running requests.
- **Total Generated** needs a real lifetime counter. SGLang does not expose one without `--enable-metrics` or the older server-info totals. This PR does **not** invent a total from a rate gauge.

## Fix

SGLang-only. No vLLM / llama.cpp / ds4 behaviour change.

- Probe `/v1/loads` (preferred: `num_running_reqs` / `num_waiting_reqs`), fall back to `/get_load` (where `num_reqs` is running + waiting).
- Fill slots / running / waiting from that load payload.
- A reachable SGLang process is **Active** (weights resident, ready). Sleeping is reserved for engines that actually unload GPU memory.
- While load says requests are in flight, keep a positive `last_gen_throughput` even if the gauge is not moving.
- Idle leftover behaviour is unchanged when load is empty.

## How to Verify

Works on any Linux host with a reachable SGLang HTTP port. No special hardware.

1. Point a Spark at an SGLang server (default OpenAI port is fine).
2. Confirm the panel badge is `sgLang` and the model id appears (existing detection).
3. Idle: Engine shows **Active**, tok/s is `0`, slots `0 / N`.
4. Send traffic: slots / running / waiting update; Generation tok/s stays non-zero for the whole run, not only the first few seconds.
5. Optional: start SGLang with `--enable-metrics` if you want **Total Generated**. Without it that tile stays `—` on purpose.

## Test Plan

- [x] Unit tests for `/v1/loads` vs `/get_load` parsing
- [x] Sticky throughput stays live when inflight, expires when idle
- [x] `sleep_on_idle: true` in server-info does **not** mark the engine Sleeping
- [x] Existing SGLang / ds4 / llama.cpp / vLLM probe tests still pass
- [ ] Manual check against a local SGLang (`curl :PORT/v1/loads`)

## Risk Assessment

Low — only the SGLang branch of `LlmProbe` changes. Extra HTTP is `/v1/loads` then `/get_load` on 404, same probe timeout as the rest of the LLM poll. vLLM and llama.cpp paths are untouched.

## Notes for reviewers

This is intentionally small and generic. It does not start or stop engines, does not add a manual backend toggle, and does not treat unknown OpenAI servers as vLLM. Detection was already correct; this only fills the SGLang numbers after that guess.