### PR TITLE
Align copied results values to those shown in dialog (closes #57)

### DIFF
--- a/src/components/SparkPage/BenchmarkDialog.tsx
+++ b/src/components/SparkPage/BenchmarkDialog.tsx
@@ -89,7 +89,7 @@ function buildShareText(job: DecodeBenchJob, modelId: string | null): string {
     .map((r) => {
       if (r.totalDecodeTokens > 0 || r.totalCompletionTokens > 0) {
         const agg = r.aggregateDecodeTps > 0 ? r.aggregateDecodeTps : r.meanDecodeTps;
-        return `×${r.concurrency}  ${agg.toFixed(0)} agg  ${r.meanDecodeTps.toFixed(0)}/str  · TTFT ${formatTtft(r.medianTtftMs)}`;
+        return `×${r.concurrency}  ${agg.toFixed(1)} agg  ${r.meanDecodeTps.toFixed(1)}/str  · TTFT ${formatTtft(r.medianTtftMs)}`;
       }
       return `×${r.concurrency}  failed${r.error ? ` — ${r.error}` : ""}`;
     });
@@ -104,7 +104,7 @@ function ResultRow({ r }: { r: DecodeBenchJob["results"][number] }) {
         <span className="bench-result-row__badge">×{r.concurrency}</span>
         <div className="bench-result-row__facts">
           <span>
-            TTFT <strong>{formatTtft(r.meanTtftMs)}</strong>
+            TTFT <strong>{formatTtft(r.medianTtftMs)}</strong>
           </span>
           <span className="bench-result-row__sep" aria-hidden>
             ·


### PR DESCRIPTION
Also show the median TTFT in the dialog as aligned to the copied results. Median is preferrable as it is robust to outliers.