### PR TITLE
feat: collect CPU temperature from DGX Sparks

### DIFF
--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -1001,28 +1001,28 @@ export class SystemCollector {
     }
   }
 
-  async _getRemoteCpu() {
-    try {
-      const cmd = [
-        "cat /proc/stat | head -1",
-        "echo '---'",
-        "cat /proc/cpuinfo | grep -E 'CPU architecture|aarch64' | head -1",
-        ...(this.spark.kind === "host"
-          ? [
-              "echo '---'",
-              // Same hwmon-then-thermal priority as local `_getCPUTemperature()`.
-              // GB10 also exposes nvme/mlx5 sensors; the name allowlist keeps those out.
-              'for h in /sys/class/hwmon/*; do n=$(cat "$h/name" 2>/dev/null); case "$n" in coretemp|k10temp|zenpower|acpitz) for t in "$h"/temp*_input; do cat "$t" 2>/dev/null; break; done;; esac; done',
-              "cat /sys/class/thermal/thermal_zone*/temp 2>/dev/null",
-            ]
-          : []),
-      ].join("; ");
+  _buildRemoteCpuCommand() {
+    return [
+      "cat /proc/stat | head -1",
+      "echo '---'",
+      "cat /proc/cpuinfo | grep -E 'CPU architecture|aarch64' | head -1",
+      "echo '---'",
+      // Same hwmon-then-thermal priority as local `_getCPUTemperature()`.
+      // GB10 also exposes nvme/mlx5 sensors; the name allowlist keeps those out.
+      'for h in /sys/class/hwmon/*; do n=$(cat "$h/name" 2>/dev/null); case "$n" in coretemp|k10temp|zenpower|acpitz) for t in "$h"/temp*_input; do cat "$t" 2>/dev/null; break; done;; esac; done',
+      "cat /sys/class/thermal/thermal_zone*/temp 2>/dev/null",
+    ].join("; ");
+  }
 
-      const output = await sshExec(this.spark, cmd);
+  async _getRemoteCpu(sshExecutor = sshExec) {
+    try {
+      const cmd = this._buildRemoteCpuCommand();
+
+      const output = await sshExecutor(this.spark, cmd);
       const sections = output.split("---");
       const statOut = sections[0]?.trim() || "";
       const cpuinfoOut = sections[1]?.trim() || "";
-      const tempOut = this.spark.kind === "host" ? sections[2] || "" : "";
+      const tempOut = sections[2] || "";
 
       const cpuStat = this._parseCPUUsage(statOut);
       const totalDiff = cpuStat.total - (this.lastCpuStat?.total || cpuStat.total);
@@ -1038,7 +1038,7 @@ export class SystemCollector {
 
       return {
         usage,
-        temperature: this.spark.kind === "host" ? this._parseSensorTemp(tempOut) : 0,
+        temperature: this._parseSensorTemp(tempOut),
         draw: Math.round(draw * 10) / 10,
         tdp: Math.round(tdp),
       };

--- a/server/collectors/__tests__/SystemCollector.cpuTemp.test.js
+++ b/server/collectors/__tests__/SystemCollector.cpuTemp.test.js
@@ -5,6 +5,25 @@ import { SystemCollector } from "../SystemCollector.js";
 const c = Object.create(SystemCollector.prototype);
 const parse = (raw) => c._parseSensorTemp(raw);
 
+test("remote CPU collection returns temperature for DGX Spark nodes", async () => {
+  const collector = new SystemCollector({ id: "spark-test", kind: "spark" });
+  const result = await collector._getRemoteCpu(async (spark, command) => {
+    assert.equal(spark.id, "spark-test");
+    assert.match(command, /coretemp\|k10temp\|zenpower\|acpitz/);
+    assert.match(command, /thermal_zone\*\/temp/);
+    assert.equal((command.match(/echo '---'/g) || []).length, 2);
+    return [
+      "cpu  100 0 40 860 0 0 0 0",
+      "---",
+      "CPU architecture: 8",
+      "---",
+      "70900",
+    ].join("\n");
+  });
+
+  assert.equal(result.temperature, 70.9);
+});
+
 test("converts millidegrees to Celsius", () => {
   assert.equal(parse("70900"), 70.9);
   assert.equal(parse("69200"), 69.2);


### PR DESCRIPTION
## Summary

DGX Spark nodes now report CPU temperature through the existing remote CPU metric instead of always returning `0`. The collector reuses the host sensor allowlist and priority order, while filtering unrelated NVMe and network-card sensors.

Related: #34

## Validation

- `node --test server/collectors/__tests__/SystemCollector.cpuTemp.test.js` - 8 passed, including the full remote DGX Spark parse path
- `npm run typecheck` - passed
- `npm run build` - passed
- Code review completed with no remaining actionable findings.

## Post-Deploy Monitoring & Validation

- Search logs for `Remote CPU error` during the first 15 minutes.
- Compare the API CPU temperature with the first allowed hwmon or `acpitz` sensor on one DGX Spark.
- Healthy signal: a plausible non-zero Celsius value updates with each normal CPU poll.
- Failure signal: CPU polling fails, temperature exceeds the accepted sensor range, or the value comes from an NVMe/CX7 sensor. Roll back this PR if observed.
- Validation window and owner: first 15 minutes after deployment; sparkDash maintainer/operator.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
