### PR TITLE
fix: include showcase fixture in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/package-lock.json ./package-lock.json
 COPY --from=builder /app/server ./server
 COPY --from=builder /app/src/shared ./src/shared
+COPY --from=builder /app/src/components/ShowcasePage/showcasePrompts.ts ./src/components/ShowcasePage/showcasePrompts.ts
 COPY --from=builder /app/config ./config
 
 # Volume for persistent sparks.json


### PR DESCRIPTION
## Summary

The production image now contains the shared Showcase prompt catalog required by the Node test suite. This makes the image's own tests exercise the same source tree as local development instead of failing on a missing `src/components/ShowcasePage/showcasePrompts.ts` import.

## Validation

- A clean production candidate image completed all 248 image-local tests after this copy-list correction.
- No runtime bundle or API behavior changes.
- Code review completed with no remaining actionable findings.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This changes only the production image test fixture set and does not alter runtime behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
