### PR TITLE
feat: add fleet energy telemetry endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ config/bench-history.json
 config/bench-active.json
 config/showcase-history.json
 config/llm-daily.json
+config/fleet-energy.json
+config/.fleet-energy.json.*.tmp
 config/gpu-memory.json
 config/gpu-memory.json.*
 config/bench-exports/

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ sparkDash/
 | DELETE | `/api/sparks/:id` | Remove Spark and drain monitor |
 | PUT | `/api/sparks/order` | Persist tab order |
 | GET | `/api/sparks/:id/metrics` | One-shot metrics snapshot |
+| GET | `/api/fleet-energy` | Estimated fleet watts, rolling energy, coverage, and Wh/output-token |
 | POST | `/api/sparks/test` | Ephemeral SSH + LLM (+ Comfy if enabled) test (no persist) |
 | POST | `/api/sparks/:id/test` | Connectivity test (can save password) |
 | POST | `/api/sparks/:id/comfy/cancel` | Cancel ComfyUI job by `promptId` |
@@ -359,6 +360,15 @@ sparkDash/
 | WS | `/ws` | Real-time metrics stream |
 
 There is no authentication on the HTTP/WebSocket API. Run sparkDash only on a trusted network (or behind your own reverse proxy with auth).
+
+`/api/fleet-energy` samples the configured fleet independently every two seconds. It estimates
+each node as GPU board draw + a CPU utilization model (5.2–65 W) + 23 W of memory/network/base
+overhead, clamped to the DGX Spark power envelope. Current and hourly fleet watts require fresh,
+simultaneous telemetry from every node; coverage fields make gaps explicit. Minute buckets are
+persisted at mode `0600` for rolling 24-hour and 31-day windows. Wh/output-token is reported when
+exactly one configured node has role `head` and exposes a monotonic LLM output-token counter.
+These values are estimates, not wall-meter measurements. Restart sparkDash after changing fleet
+membership so the persisted series has one stable node set.
 
 ---
 
@@ -402,6 +412,7 @@ Copy `.env.example` to `.env` if needed:
 | `HOST_SYS_PATH` | `/host/sys` | Host sys mount |
 | `HOST_ROOT_PATH` | `/host/root` | Host root mount |
 | `SSH_IDENTITY_FILE` | _(unset)_ | Path **inside the process** to a private key (`ssh -i`). Use when the bind-mount is not a default OpenSSH name. |
+| `FLEET_ENERGY_JSON_PATH` | `config/fleet-energy.json` | Rolling fleet-energy persistence path |
 
 > The listener defaults to `127.0.0.1` (loopback) so the dashboard — which can SSH into and
 > power off your Sparks — isn't reachable on the LAN by default. Set `BIND_HOST` to the host's

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -4,6 +4,21 @@ import { HOST_PATHS, GPU_MEMORY_JSON_PATH, DGX_SPARK, HARDWARE_DEFAULTS } from "
 import { normalizeMac, WOL_INTERFACE } from "../wol.js";
 import { sshExec } from "./ssh.js";
 
+export const COLLECTION_SUCCESS = Symbol("sparkdash.collectionSuccess");
+
+export function collectionWasSuccessful(result) {
+  return result?.[COLLECTION_SUCCESS] === true;
+}
+
+function tagCollectionResult(result, successful) {
+  Object.defineProperty(result, COLLECTION_SUCCESS, {
+    value: successful === true,
+    enumerable: false,
+    configurable: true,
+  });
+  return result;
+}
+
 /**
  * SystemCollector — collects hardware metrics for a Spark.
  * In Phase 2, this is the LOCAL path only (no SSH).
@@ -37,45 +52,87 @@ export class SystemCollector {
 
   /** Collect GPU metrics (temperature, usage, power, VRAM). */
   async collectGpu() {
-    if (!this.spark.isLocal) return this._getRemoteGpu();
     try {
-      const gpuData = await this._getGPUAll();
-      return gpuData;
+      const gpuData = this.spark.isLocal
+        ? await this._getGPUAll()
+        : await this._getRemoteGpu();
+      return tagCollectionResult(gpuData, this._isSuccessfulGpuCollection(gpuData));
     } catch (err) {
       console.error(`[SystemCollector] GPU error for ${this.spark.id}:`, err.message);
-      return this._defaultGpu();
+      return tagCollectionResult(this._defaultGpu(), false);
     }
   }
 
   /** Collect CPU metrics (usage, temperature, power). */
   async collectCpu() {
     const collectionSequence = ++this._cpuCollectionSequence;
-    if (!this.spark.isLocal) return this._getRemoteCpu(collectionSequence);
     try {
+      if (!this.spark.isLocal) {
+        const cpuData = await this._getRemoteCpu(collectionSequence);
+        return tagCollectionResult(cpuData, this._isSuccessfulCpuCollection(cpuData));
+      }
+
       // Read /proc/stat once and compute usage BEFORE estimating power.
       // Previously _getCPUPower re-read /proc/stat in parallel with _getCPUUsage,
       // racing on lastCpuStat and producing 0% (idle power) on the first poll.
       const usage = await this._getCPUUsage();
+      if (!this._isValidCpuStat(usage)) {
+        throw new Error("invalid /proc/stat CPU counters");
+      }
       const totalDiff = usage.total - (this.lastCpuStat?.total || usage.total);
       const usedDiff = usage.used - (this.lastCpuStat?.used || usage.used);
       const cpuPercentage = totalDiff > 0 ? Math.round((usedDiff / totalDiff) * 100) : 0;
       const usageFraction = totalDiff > 0 ? usedDiff / totalDiff : 0;
-      if (collectionSequence === this._cpuCollectionSequence) {
-        this.lastCpuStat = usage;
-        this.lastCpuUsagePct = cpuPercentage;
-      }
-
       // Temperature and power can run in parallel — power is now a pure
       // function of the usage fraction (no extra /proc/stat read).
       const [temp, power] = await Promise.all([
         this._getCPUTemperature(),
         this._getCPUPower(usageFraction),
       ]);
-      return { usage: cpuPercentage, temperature: temp, ...power };
+      if (collectionSequence === this._cpuCollectionSequence) {
+        this.lastCpuStat = usage;
+        this.lastCpuUsagePct = cpuPercentage;
+      }
+      const cpuData = { usage: cpuPercentage, temperature: temp, ...power };
+      return tagCollectionResult(cpuData, this._isSuccessfulCpuCollection(cpuData));
     } catch (err) {
       console.error(`[SystemCollector] CPU error for ${this.spark.id}:`, err.message);
-      return this._defaultCpu();
+      return tagCollectionResult(this._defaultCpu(), false);
     }
+  }
+
+  _isSuccessfulGpuCollection(gpu) {
+    return (
+      Number.isFinite(gpu?.temperature) &&
+      gpu.temperature > 0 &&
+      Number.isFinite(gpu?.usage) &&
+      Number.isFinite(gpu?.power?.draw) &&
+      gpu.power.draw >= 0 &&
+      Number.isFinite(gpu?.power?.limit) &&
+      gpu.power.limit > 0
+    );
+  }
+
+  _isSuccessfulCpuCollection(cpu) {
+    return (
+      Number.isFinite(cpu?.usage) &&
+      cpu.usage >= 0 &&
+      cpu.usage <= 100 &&
+      Number.isFinite(cpu?.draw) &&
+      cpu.draw > 0 &&
+      Number.isFinite(cpu?.tdp) &&
+      cpu.tdp > 0
+    );
+  }
+
+  _isValidCpuStat(cpuStat) {
+    return (
+      Number.isFinite(cpuStat?.total) &&
+      cpuStat.total > 0 &&
+      Number.isFinite(cpuStat?.used) &&
+      cpuStat.used >= 0 &&
+      cpuStat.used <= cpuStat.total
+    );
   }
 
   /** Prevent an earlier monitor lifecycle from updating shared CPU baselines. */
@@ -1037,6 +1094,9 @@ export class SystemCollector {
       const tempOut = this.spark.kind === "host" ? sections[2] || "" : "";
 
       const cpuStat = this._parseCPUUsage(statOut);
+      if (!this._isValidCpuStat(cpuStat)) {
+        throw new Error("invalid remote /proc/stat CPU counters");
+      }
       const totalDiff = cpuStat.total - (this.lastCpuStat?.total || cpuStat.total);
       const usedDiff = cpuStat.used - (this.lastCpuStat?.used || cpuStat.used);
       const usage = totalDiff > 0 ? Math.round((usedDiff / totalDiff) * 100) : 0;

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -17,6 +17,7 @@ export class SystemCollector {
     // Rate-tracking baselines
     this.lastNetworkStats = new Map();
     this.lastCpuStat = null;
+    this._cpuCollectionSequence = 0;
     /** Last computed CPU usage percentage (0-100) — used by GPU system-draw estimate. */
     this.lastCpuUsagePct = 0;
     this.lastRaplReading = null;
@@ -48,7 +49,8 @@ export class SystemCollector {
 
   /** Collect CPU metrics (usage, temperature, power). */
   async collectCpu() {
-    if (!this.spark.isLocal) return this._getRemoteCpu();
+    const collectionSequence = ++this._cpuCollectionSequence;
+    if (!this.spark.isLocal) return this._getRemoteCpu(collectionSequence);
     try {
       // Read /proc/stat once and compute usage BEFORE estimating power.
       // Previously _getCPUPower re-read /proc/stat in parallel with _getCPUUsage,
@@ -58,8 +60,10 @@ export class SystemCollector {
       const usedDiff = usage.used - (this.lastCpuStat?.used || usage.used);
       const cpuPercentage = totalDiff > 0 ? Math.round((usedDiff / totalDiff) * 100) : 0;
       const usageFraction = totalDiff > 0 ? usedDiff / totalDiff : 0;
-      this.lastCpuStat = usage;
-      this.lastCpuUsagePct = cpuPercentage;
+      if (collectionSequence === this._cpuCollectionSequence) {
+        this.lastCpuStat = usage;
+        this.lastCpuUsagePct = cpuPercentage;
+      }
 
       // Temperature and power can run in parallel — power is now a pure
       // function of the usage fraction (no extra /proc/stat read).
@@ -72,6 +76,11 @@ export class SystemCollector {
       console.error(`[SystemCollector] CPU error for ${this.spark.id}:`, err.message);
       return this._defaultCpu();
     }
+  }
+
+  /** Prevent an earlier monitor lifecycle from updating shared CPU baselines. */
+  invalidatePendingCollections() {
+    this._cpuCollectionSequence += 1;
   }
 
   /** Collect RAM metrics. */
@@ -1001,7 +1010,10 @@ export class SystemCollector {
     }
   }
 
-  async _getRemoteCpu() {
+  async _getRemoteCpu(collectionSequence = null) {
+    const attemptSequence = Number.isInteger(collectionSequence)
+      ? collectionSequence
+      : ++this._cpuCollectionSequence;
     try {
       const cmd = [
         "cat /proc/stat | head -1",
@@ -1028,7 +1040,10 @@ export class SystemCollector {
       const totalDiff = cpuStat.total - (this.lastCpuStat?.total || cpuStat.total);
       const usedDiff = cpuStat.used - (this.lastCpuStat?.used || cpuStat.used);
       const usage = totalDiff > 0 ? Math.round((usedDiff / totalDiff) * 100) : 0;
-      this.lastCpuStat = cpuStat;
+      if (attemptSequence === this._cpuCollectionSequence) {
+        this.lastCpuStat = cpuStat;
+        this.lastCpuUsagePct = usage;
+      }
 
       // ARM/Neoverse power estimation
       const isArm = /CPU architecture:\s*[89]|aarch64|ARMv[89]|armv[89]/i.test(cpuinfoOut);

--- a/server/config.js
+++ b/server/config.js
@@ -18,6 +18,9 @@ const SECRETS_KEY_PATH =
 /** Daily LLM tok/s rollups (gitignored). */
 const LLM_DAILY_JSON_PATH =
   process.env.LLM_DAILY_JSON_PATH || path.join(ROOT, "config", "llm-daily.json");
+/** Rolling fleet energy estimates (gitignored; written atomically at mode 0600). */
+const FLEET_ENERGY_JSON_PATH =
+  process.env.FLEET_ENERGY_JSON_PATH || path.join(ROOT, "config", "fleet-energy.json");
 
 // ─── LLM / Comfy probe timeouts ──────────────────────────
 const LLM_PROBE_TIMEOUT_MS = 3000;
@@ -95,6 +98,7 @@ export {
   SPARKS_SECRETS_PATH,
   SECRETS_KEY_PATH,
   LLM_DAILY_JSON_PATH,
+  FLEET_ENERGY_JSON_PATH,
   LLM_PROBE_TIMEOUT_MS,
   COMFY_PROBE_TIMEOUT_MS,
   TAILSCALE_PROBE_TIMEOUT_MS,

--- a/server/energy/FleetEnergyRuntime.js
+++ b/server/energy/FleetEnergyRuntime.js
@@ -1,0 +1,160 @@
+const MAX_POWER_TELEMETRY_AGE_MS = 10_000;
+const ENERGY_SAMPLE_INTERVAL_MS = 2_000;
+
+function hasFreshTimestamp(timestamp, atMs) {
+  if (!Number.isFinite(timestamp) || !Number.isFinite(atMs)) return false;
+  const ageMs = atMs - timestamp;
+  return ageMs >= 0 && ageMs <= MAX_POWER_TELEMETRY_AGE_MS;
+}
+
+function isDefaultGpuResult(gpu) {
+  return (
+    gpu?.temperature === 0 &&
+    gpu?.usage === 0 &&
+    gpu?.power?.draw === 0 &&
+    gpu?.vram?.total === 0
+  );
+}
+
+function isDefaultCpuResult(cpu) {
+  return (
+    cpu?.usage === 0 &&
+    cpu?.temperature === 0 &&
+    cpu?.draw === 0 &&
+    cpu?.tdp === 0
+  );
+}
+
+function wasCollectionSuccessful(monitor, domain) {
+  return monitor?._metricCollectionSuccessful?.[domain] === true;
+}
+
+/** Determine whether a normal SparkMonitor snapshot has current usable power telemetry. */
+export function hasFreshPowerTelemetry(snapshot, monitor, atMs) {
+  const gpu = snapshot?.metrics?.gpu;
+  const cpu = snapshot?.metrics?.cpu;
+  return (
+    snapshot?.online === true &&
+    wasCollectionSuccessful(monitor, "gpu") &&
+    wasCollectionSuccessful(monitor, "cpu") &&
+    hasFreshTimestamp(monitor?._lastUpdate?.gpu, atMs) &&
+    hasFreshTimestamp(monitor?._lastUpdate?.cpu, atMs) &&
+    !isDefaultGpuResult(gpu) &&
+    !isDefaultCpuResult(cpu) &&
+    Number.isFinite(gpu?.power?.draw) &&
+    Number.isFinite(cpu?.usage)
+  );
+}
+
+/**
+ * Record one independent energy sample. Only the shallow clones passed to the
+ * tracker receive telemetryFresh; normal REST and WebSocket snapshots remain unchanged.
+ */
+export function runFleetEnergySamplerTick({
+  tracker,
+  orderedSnapshots,
+  monitors,
+  now = Date.now,
+}) {
+  const atMs = now();
+  const snapshots = orderedSnapshots();
+  const trackerInputs = snapshots.map((snapshot) => ({
+    ...snapshot,
+    telemetryFresh: hasFreshPowerTelemetry(
+      snapshot,
+      monitors?.get?.(snapshot?.id),
+      atMs
+    ),
+  }));
+  return tracker.record(trackerInputs, atMs);
+}
+
+/** Build the read-only Express handler around the tracker's canonical contract. */
+export function createFleetEnergyHandler(tracker) {
+  return (_req, res) => res.json(tracker.snapshot());
+}
+
+/** Register the read-only fleet-energy endpoint. */
+export function registerFleetEnergyRoute(app, tracker) {
+  return app.get("/api/fleet-energy", createFleetEnergyHandler(tracker));
+}
+
+/** Preserve startup ordering without coupling the sampler to server or WS state. */
+export function startFleetEnergyCollection({ startAllMonitors, energyRuntime }) {
+  startAllMonitors();
+  return energyRuntime.start();
+}
+
+/** Build the graceful server-close callback from the persistence outcome. */
+export function createFleetEnergyExitHandler(
+  energyPersistenceSucceeded,
+  exit = process.exit
+) {
+  return () => exit(energyPersistenceSucceeded ? 0 : 1);
+}
+
+/** Own the independent sampling timer and the tracker's one-time close lifecycle. */
+export function createFleetEnergyRuntime({
+  tracker,
+  orderedSnapshots,
+  monitors,
+  now = Date.now,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+  logError = console.error,
+}) {
+  let started = false;
+  let stopped = false;
+  let timer = null;
+  let stopResult = false;
+
+  const reportError = (message, error) => {
+    try {
+      logError(message, error);
+    } catch {
+      // Logging must never prevent shutdown from continuing.
+    }
+  };
+
+  const sample = () => {
+    if (stopped) return;
+    try {
+      runFleetEnergySamplerTick({ tracker, orderedSnapshots, monitors, now });
+    } catch (error) {
+      reportError("fleet energy sample error", error);
+    }
+  };
+
+  return {
+    start() {
+      if (started || stopped) return false;
+      started = true;
+      sample();
+      timer = setIntervalFn(sample, ENERGY_SAMPLE_INTERVAL_MS);
+      return true;
+    },
+
+    stop() {
+      if (stopped) return stopResult;
+      stopped = true;
+      if (timer !== null) {
+        try {
+          clearIntervalFn(timer);
+        } catch (error) {
+          reportError("fleet energy timer shutdown error", error);
+        }
+        timer = null;
+      }
+      for (let attempt = 1; attempt <= 2; attempt += 1) {
+        try {
+          tracker.close();
+          stopResult = true;
+          break;
+        } catch (error) {
+          reportError(`fleet energy shutdown error (attempt ${attempt}/2)`, error);
+        }
+      }
+      return stopResult;
+    },
+  };
+}

--- a/server/energy/FleetEnergyTracker.js
+++ b/server/energy/FleetEnergyTracker.js
@@ -1,0 +1,761 @@
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+const FILE_VERSION = 1;
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const RETENTION_MS = 31 * DAY_MS;
+const MAX_COMPLETED_BUCKETS = 44_640;
+const MAX_GAP_MS = 10_000;
+const CURRENT_WINDOW_MS = 30_000;
+const DEFAULT_FLUSH_INTERVAL_MS = 30_000;
+const MAX_RECENT_SAMPLES = 10_000;
+const MAX_NODE_WH_PER_MINUTE = 4;
+const MIN_NODE_WATTS = 28.2;
+const PERSISTENCE_RELATIVE_TOLERANCE = 1e-9;
+const UNSUPPORTED_DIRECTORY_FSYNC_CODES = new Set(["EINVAL", "ENOTSUP", "EISDIR", "EBADF"]);
+
+function clamp(value, minimum, maximum) {
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+// Minute buckets intentionally include the bucket crossing a rolling window's
+// exact leading edge, limiting approximation error to less than one minute.
+function alignedWindowCutoff(atMs, windowMs) {
+  return Math.floor((atMs - windowMs) / MINUTE_MS) * MINUTE_MS;
+}
+
+function normalizeNodeIds(nodeIds) {
+  if (!Array.isArray(nodeIds)) return [];
+  return [...new Set(nodeIds.filter((id) => typeof id === "string" && id.trim() !== ""))];
+}
+
+function nodeValues(nodeIds, value, fallback = 0) {
+  return Object.fromEntries(nodeIds.map((id) => [id, value?.[id] ?? fallback]));
+}
+
+function emptyBucket(minuteStartMs, nodeIds) {
+  return {
+    minuteStartMs,
+    nodeWh: nodeValues(nodeIds),
+    nodeCoverageMs: nodeValues(nodeIds),
+    fleetWattMs: 0,
+    fleetCoverageMs: 0,
+    outputTokens: 0,
+  };
+}
+
+function validNonnegative(value) {
+  return Number.isFinite(value) && value >= 0;
+}
+
+function validNonnegativeSafeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function validAccountingHighWater(value) {
+  return validNonnegative(value) && value <= Number.MAX_SAFE_INTEGER;
+}
+
+function exceedsWithFloatingTolerance(value, maximum) {
+  const tolerance = PERSISTENCE_RELATIVE_TOLERANCE * Math.max(1, Math.abs(maximum));
+  return value > maximum + tolerance;
+}
+
+function fallsBelowWithFloatingTolerance(value, minimum) {
+  const tolerance = PERSISTENCE_RELATIVE_TOLERANCE * Math.max(1, Math.abs(minimum));
+  return value < minimum - tolerance;
+}
+
+function unaccountedInterval(previous, current, highWaterMs) {
+  if (highWaterMs === null) return { previous, current };
+  if (current.atMs <= highWaterMs) return null;
+  if (previous.atMs >= highWaterMs) return { previous, current };
+
+  const fraction = (highWaterMs - previous.atMs) / (current.atMs - previous.atMs);
+  return {
+    previous: {
+      atMs: highWaterMs,
+      watts: previous.watts + (current.watts - previous.watts) * fraction,
+    },
+    current,
+  };
+}
+
+function hasExactNodeKeys(value, nodeIds, nodeIdSet) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length === nodeIds.length &&
+    keys.every((key) => nodeIdSet.has(key))
+  );
+}
+
+function tokenObservation(snapshots, atMs, nodeIdSet) {
+  const heads = snapshots.filter(
+    (snapshot) => nodeIdSet.has(snapshot?.id) && snapshot?.role === "head"
+  );
+  if (heads.length !== 1) return null;
+
+  const head = heads[0];
+  const entries = head?.metrics?.llm;
+  const ports = head?.llmPorts;
+  if (!Array.isArray(entries) || !Array.isArray(ports) || entries.length !== ports.length) {
+    return null;
+  }
+  const availableIndexes = [];
+  for (let index = 0; index < entries.length; index += 1) {
+    if (entries[index]?.available === true) availableIndexes.push(index);
+  }
+  if (availableIndexes.length !== 1) return null;
+  const index = availableIndexes[0];
+  const entry = entries[index];
+  const port = ports[index];
+  if (
+    !validNonnegativeSafeInteger(port) ||
+    !validNonnegativeSafeInteger(entry.totalOutputTokens)
+  ) {
+    return null;
+  }
+  return {
+    headId: head.id,
+    port,
+    totalOutputTokens: entry.totalOutputTokens,
+    observedAtMs: atMs,
+  };
+}
+
+function sameTokenSource(left, right) {
+  return (
+    left?.headId === right?.headId &&
+    left?.port === right?.port
+  );
+}
+
+function writeStateAtomically(filePath, contents, fileSystem) {
+  const directory = path.dirname(filePath);
+  const temporaryPath = path.join(
+    directory,
+    `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`
+  );
+  let temporaryFd = null;
+  let directoryFd = null;
+  let renamed = false;
+
+  fileSystem.mkdirSync(directory, { recursive: true });
+  try {
+    temporaryFd = fileSystem.openSync(temporaryPath, "wx", 0o600);
+    fileSystem.writeFileSync(temporaryFd, contents, { encoding: "utf8" });
+    fileSystem.fchmodSync(temporaryFd, 0o600);
+    fileSystem.fsyncSync(temporaryFd);
+    fileSystem.closeSync(temporaryFd);
+    temporaryFd = null;
+
+    fileSystem.renameSync(temporaryPath, filePath);
+    renamed = true;
+    fileSystem.chmodSync(filePath, 0o600);
+    const finalMode = fileSystem.statSync(filePath).mode & 0o777;
+    if (finalMode !== 0o600) {
+      throw new Error(`Failed to secure ${filePath}: expected mode 0600, got 0${finalMode.toString(8)}`);
+    }
+
+    try {
+      directoryFd = fileSystem.openSync(directory, "r");
+      fileSystem.fsyncSync(directoryFd);
+    } catch (error) {
+      if (!UNSUPPORTED_DIRECTORY_FSYNC_CODES.has(error?.code)) throw error;
+    } finally {
+      if (directoryFd !== null) fileSystem.closeSync(directoryFd);
+    }
+  } catch (error) {
+    if (temporaryFd !== null) {
+      try {
+        fileSystem.closeSync(temporaryFd);
+      } catch {
+        // Preserve the original persistence error.
+      }
+    }
+    if (!renamed) {
+      try {
+        fileSystem.unlinkSync(temporaryPath);
+      } catch {
+        // The temp may not have been created; never remove the prior target.
+      }
+    }
+    throw error;
+  }
+}
+
+/**
+ * Estimate a node's whole-system draw from raw GPU and CPU telemetry.
+ *
+ * Callers must explicitly mark combined GPU/CPU telemetry fresh. Liveness alone
+ * is insufficient because SparkMonitor can retain stale domain values.
+ */
+export function estimateNodeWatts(snapshot) {
+  const gpuDraw = snapshot?.metrics?.gpu?.power?.draw;
+  const cpuUsage = snapshot?.metrics?.cpu?.usage;
+  if (
+    snapshot?.telemetryFresh !== true ||
+    !validNonnegative(gpuDraw) ||
+    !Number.isFinite(cpuUsage)
+  ) {
+    return null;
+  }
+
+  const boundedCpuUsage = clamp(cpuUsage, 0, 100);
+  const cpuWatts = 5.2 + ((65 - 5.2) * boundedCpuUsage) / 100;
+  return clamp(gpuDraw + cpuWatts + 23, 0, 240);
+}
+
+export class FleetEnergyTracker {
+  constructor({
+    nodeIds = [],
+    filePath = null,
+    now = () => Date.now(),
+    load = true,
+    flushIntervalMs = DEFAULT_FLUSH_INTERVAL_MS,
+    setIntervalFn = setInterval,
+    clearIntervalFn = clearInterval,
+    fileSystem = fs,
+    writeState = writeStateAtomically,
+  } = {}) {
+    this.nodeIds = Object.freeze(normalizeNodeIds(nodeIds));
+    this._nodeIdSet = new Set(this.nodeIds);
+    this._minimumFleetWatts = MIN_NODE_WATTS * this.nodeIds.length;
+    this._maximumFleetWatts = 240 * this.nodeIds.length;
+    this.filePath = filePath;
+    this._now = typeof now === "function" ? now : () => Date.now();
+    this._setInterval = setIntervalFn;
+    this._clearInterval = clearIntervalFn;
+    this._fs = fileSystem;
+    this._writeState = writeState;
+    this._buckets = new Map();
+    this._bucketsOrdered = true;
+    this._latestBucketStart = null;
+    this._nodeBaselines = new Map();
+    this._fleetBaseline = null;
+    this._integrationHighWaterMs = null;
+    this._tokenCounter = null;
+    this._tokenNeedsRebase = false;
+    this._recentFullFleetSamples = [];
+    this._latestFreshNodeCount = 0;
+    this._latestRecordAt = null;
+    this._dirty = false;
+    this._flushTimer = null;
+
+    if (load) this._load();
+
+    const requestedFlushMs = Number.isFinite(flushIntervalMs) && flushIntervalMs > 0
+      ? flushIntervalMs
+      : DEFAULT_FLUSH_INTERVAL_MS;
+    this.flushIntervalMs = Math.min(requestedFlushMs, DEFAULT_FLUSH_INTERVAL_MS);
+    if (this.filePath && typeof this._setInterval === "function") {
+      this._flushTimer = this._setInterval(() => {
+        try {
+          this.flush();
+        } catch (error) {
+          console.error(`[FleetEnergyTracker] persist error: ${error.message}`);
+        }
+      }, this.flushIntervalMs);
+      this._flushTimer?.unref?.();
+    }
+  }
+
+  _time(atMs) {
+    return atMs === undefined ? this._now() : atMs;
+  }
+
+  _bucket(minuteStartMs) {
+    let bucket = this._buckets.get(minuteStartMs);
+    if (!bucket) {
+      bucket = emptyBucket(minuteStartMs, this.nodeIds);
+      this._buckets.set(minuteStartMs, bucket);
+      if (this._latestBucketStart !== null && minuteStartMs < this._latestBucketStart) {
+        this._bucketsOrdered = false;
+      }
+      this._latestBucketStart = Math.max(this._latestBucketStart ?? minuteStartMs, minuteStartMs);
+    }
+    return bucket;
+  }
+
+  _splitInterval(startMs, endMs, startWatts, endWatts, addSegment) {
+    const totalMs = endMs - startMs;
+    let segmentStart = startMs;
+    while (segmentStart < endMs) {
+      const minuteStartMs = Math.floor(segmentStart / MINUTE_MS) * MINUTE_MS;
+      const segmentEnd = Math.min(endMs, minuteStartMs + MINUTE_MS);
+      const startFraction = (segmentStart - startMs) / totalMs;
+      const endFraction = (segmentEnd - startMs) / totalMs;
+      const segmentStartWatts = startWatts + (endWatts - startWatts) * startFraction;
+      const segmentEndWatts = startWatts + (endWatts - startWatts) * endFraction;
+      addSegment(
+        this._bucket(minuteStartMs),
+        segmentEnd - segmentStart,
+        (segmentStartWatts + segmentEndWatts) / 2
+      );
+      segmentStart = segmentEnd;
+    }
+  }
+
+  _integrateNode(id, previous, current) {
+    this._splitInterval(
+      previous.atMs,
+      current.atMs,
+      previous.watts,
+      current.watts,
+      (bucket, durationMs, averageWatts) => {
+        bucket.nodeWh[id] += (averageWatts * durationMs) / 3_600_000;
+        bucket.nodeCoverageMs[id] += durationMs;
+      }
+    );
+  }
+
+  _integrateFleet(previous, current) {
+    this._splitInterval(
+      previous.atMs,
+      current.atMs,
+      previous.watts,
+      current.watts,
+      (bucket, durationMs, averageWatts) => {
+        bucket.fleetWattMs += averageWatts * durationMs;
+        bucket.fleetCoverageMs += durationMs;
+      }
+    );
+  }
+
+  _recordTokens(snapshots, atMs) {
+    const observation = tokenObservation(snapshots, atMs, this._nodeIdSet);
+    if (!observation) return;
+
+    const previous = this._tokenCounter;
+    const gapMs = previous ? atMs - previous.observedAtMs : null;
+    const rebase =
+      !previous ||
+      this._tokenNeedsRebase ||
+      !sameTokenSource(previous, observation) ||
+      observation.totalOutputTokens < previous.totalOutputTokens ||
+      gapMs < 0 ||
+      gapMs > MAX_GAP_MS;
+
+    if (!rebase && observation.totalOutputTokens > previous.totalOutputTokens) {
+      const delta = observation.totalOutputTokens - previous.totalOutputTokens;
+      const minuteStartMs = Math.floor(atMs / MINUTE_MS) * MINUTE_MS;
+      const bucket = this._bucket(minuteStartMs);
+      const nextTotal = bucket.outputTokens + delta;
+      if (Number.isSafeInteger(nextTotal)) bucket.outputTokens = nextTotal;
+    }
+    this._tokenCounter = observation;
+    this._tokenNeedsRebase = false;
+    this._dirty = true;
+  }
+
+  _pruneRecentSamples(atMs) {
+    const cutoff = atMs - CURRENT_WINDOW_MS;
+    this._recentFullFleetSamples = this._recentFullFleetSamples.filter(
+      (sample) => sample.atMs >= cutoff && sample.atMs <= atMs
+    );
+    if (this._recentFullFleetSamples.length > MAX_RECENT_SAMPLES) {
+      this._recentFullFleetSamples = this._recentFullFleetSamples.slice(-MAX_RECENT_SAMPLES);
+    }
+  }
+
+  _pruneBuckets(atMs) {
+    if (!this._bucketsOrdered) {
+      this._buckets = new Map(
+        [...this._buckets.entries()].sort(([left], [right]) => left - right)
+      );
+      this._bucketsOrdered = true;
+      this._latestBucketStart = [...this._buckets.keys()].at(-1) ?? null;
+    }
+    const cutoff = alignedWindowCutoff(atMs, RETENTION_MS);
+    let changed = false;
+    for (const minuteStartMs of this._buckets.keys()) {
+      if (minuteStartMs >= cutoff) break;
+      this._buckets.delete(minuteStartMs);
+      changed = true;
+    }
+
+    const maximum = MAX_COMPLETED_BUCKETS + 1;
+    while (this._buckets.size > maximum) {
+      const oldest = this._buckets.keys().next().value;
+      this._buckets.delete(oldest);
+      changed = true;
+    }
+    if (this._buckets.size === 0) this._latestBucketStart = null;
+    if (changed) this._dirty = true;
+  }
+
+  _prune(atMs) {
+    this._pruneRecentSamples(atMs);
+    this._pruneBuckets(atMs);
+  }
+
+  record(snapshots, atMs = undefined) {
+    const timestamp = this._time(atMs);
+    if (!Array.isArray(snapshots) || !Number.isFinite(timestamp)) return false;
+    if (this._latestRecordAt !== null && timestamp === this._latestRecordAt) return false;
+    if (this._latestRecordAt !== null && timestamp < this._latestRecordAt) {
+      this._tokenNeedsRebase = true;
+      this._nodeBaselines.clear();
+      this._fleetBaseline = null;
+      this._recentFullFleetSamples = [];
+      this._latestFreshNodeCount = 0;
+    }
+
+    const byId = new Map();
+    for (const snapshot of snapshots) {
+      if (this._nodeIdSet.has(snapshot?.id)) byId.set(snapshot.id, snapshot);
+    }
+
+    const validNodes = new Map();
+    const integrationHighWaterAtStart = this._integrationHighWaterMs;
+    let integratedAtTimestamp = false;
+    for (const id of this.nodeIds) {
+      const watts = estimateNodeWatts(byId.get(id));
+      if (watts === null) {
+        this._nodeBaselines.delete(id);
+        continue;
+      }
+
+      validNodes.set(id, watts);
+      const previous = this._nodeBaselines.get(id);
+      const gapMs = previous ? timestamp - previous.atMs : null;
+      const interval =
+        previous && gapMs > 0 && gapMs <= MAX_GAP_MS
+          ? unaccountedInterval(
+              previous,
+              { atMs: timestamp, watts },
+              integrationHighWaterAtStart
+            )
+          : null;
+      if (interval) {
+        this._integrateNode(id, interval.previous, interval.current);
+        integratedAtTimestamp = true;
+      }
+      this._nodeBaselines.set(id, { atMs: timestamp, watts });
+    }
+
+    if (this.nodeIds.length > 0 && validNodes.size === this.nodeIds.length) {
+      const fleetWatts = [...validNodes.values()].reduce((sum, watts) => sum + watts, 0);
+      const previous = this._fleetBaseline;
+      const gapMs = previous ? timestamp - previous.atMs : null;
+      const interval =
+        previous && gapMs > 0 && gapMs <= MAX_GAP_MS
+          ? unaccountedInterval(
+              previous,
+              { atMs: timestamp, watts: fleetWatts },
+              integrationHighWaterAtStart
+            )
+          : null;
+      if (interval) {
+        this._integrateFleet(interval.previous, interval.current);
+        integratedAtTimestamp = true;
+      }
+      this._fleetBaseline = { atMs: timestamp, watts: fleetWatts };
+      this._recentFullFleetSamples.push({ atMs: timestamp, watts: fleetWatts });
+    } else {
+      this._fleetBaseline = null;
+    }
+
+    if (integratedAtTimestamp && validAccountingHighWater(timestamp)) {
+      this._integrationHighWaterMs = Math.max(
+        this._integrationHighWaterMs ?? timestamp,
+        timestamp
+      );
+    }
+
+    this._recordTokens(snapshots, timestamp);
+    this._latestFreshNodeCount = validNodes.size;
+    this._latestRecordAt = timestamp;
+    this._dirty = true;
+    this._prune(timestamp);
+    return true;
+  }
+
+  _window(atMs, windowMs) {
+    const cutoff = alignedWindowCutoff(atMs, windowMs);
+    const nodeWh = nodeValues(this.nodeIds);
+    const nodeCoverageMs = nodeValues(this.nodeIds);
+    let fleetCoverageMs = 0;
+    let outputTokens = 0;
+
+    for (const bucket of this._buckets.values()) {
+      if (bucket.minuteStartMs < cutoff || bucket.minuteStartMs > atMs) continue;
+      for (const id of this.nodeIds) {
+        nodeWh[id] += bucket.nodeWh[id];
+        nodeCoverageMs[id] += bucket.nodeCoverageMs[id];
+      }
+      fleetCoverageMs += bucket.fleetCoverageMs;
+      outputTokens += bucket.outputTokens;
+    }
+
+    const energyWh = Object.values(nodeWh).reduce((sum, value) => sum + value, 0);
+    const hasObservedEnergy = Object.values(nodeCoverageMs).some((coverageMs) => coverageMs > 0);
+    return {
+      energyWh,
+      hasObservedEnergy,
+      nodeCoverageMs,
+      fleetCoverageMs,
+      outputTokens,
+    };
+  }
+
+  _hourly(atMs) {
+    const graphEnd = Math.floor(atMs / MINUTE_MS) * MINUTE_MS;
+    const graphStart = graphEnd - DAY_MS;
+    const aggregates = Array.from({ length: 24 }, () => ({
+      fleetWattMs: 0,
+      fleetCoverageMs: 0,
+    }));
+    for (const bucket of this._buckets.values()) {
+      if (bucket.minuteStartMs < graphStart || bucket.minuteStartMs >= graphEnd) continue;
+      const index = Math.floor((bucket.minuteStartMs - graphStart) / HOUR_MS);
+      aggregates[index].fleetWattMs += bucket.fleetWattMs;
+      aggregates[index].fleetCoverageMs += bucket.fleetCoverageMs;
+    }
+
+    return aggregates.map(({ fleetWattMs, fleetCoverageMs }) =>
+      fleetCoverageMs > 0 ? fleetWattMs / fleetCoverageMs : null
+    );
+  }
+
+  snapshot(atMs = undefined) {
+    const timestamp = this._time(atMs);
+    const safeTimestamp = Number.isFinite(timestamp)
+      ? timestamp
+      : Number.isFinite(this._latestRecordAt)
+        ? this._latestRecordAt
+        : 0;
+    this._prune(safeTimestamp);
+    const last24h = this._window(safeTimestamp, DAY_MS);
+    const last31d = this._window(safeTimestamp, RETENTION_MS);
+    const sampleCount = this._recentFullFleetSamples.length;
+    const currentWatts30s = sampleCount > 0
+      ? this._recentFullFleetSamples.reduce((sum, sample) => sum + sample.watts, 0) / sampleCount
+      : null;
+    const latestRecordAgeMs =
+      this._latestRecordAt === null ? null : safeTimestamp - this._latestRecordAt;
+    const freshNodeCount =
+      latestRecordAgeMs !== null && latestRecordAgeMs >= 0 && latestRecordAgeMs <= MAX_GAP_MS
+        ? this._latestFreshNodeCount
+        : 0;
+
+    return {
+      estimated: true,
+      freshNodeCount,
+      currentWatts30s,
+      energy24hKwh: last24h.hasObservedEnergy ? last24h.energyWh / 1000 : null,
+      energy31dKwh: last31d.hasObservedEnergy ? last31d.energyWh / 1000 : null,
+      whPerOutputToken24h:
+        last24h.hasObservedEnergy && last24h.outputTokens > 0
+          ? last24h.energyWh / last24h.outputTokens
+          : null,
+      outputTokens24h: last24h.outputTokens,
+      coverage24hMs: last24h.fleetCoverageMs,
+      coverage31dMs: last31d.fleetCoverageMs,
+      nodeCoverage24hMs: last24h.nodeCoverageMs,
+      nodeCoverage31dMs: last31d.nodeCoverageMs,
+      hourlyWatts24h: this._hourly(safeTimestamp),
+    };
+  }
+
+  _load() {
+    if (!this.filePath) return;
+    try {
+      const raw = JSON.parse(this._fs.readFileSync(this.filePath, "utf8"));
+      const legacyNodeIds = !Object.prototype.hasOwnProperty.call(raw || {}, "nodeIds");
+      if (
+        raw?.version !== FILE_VERSION ||
+        !Array.isArray(raw.buckets) ||
+        (!legacyNodeIds &&
+          (!Array.isArray(raw.nodeIds) ||
+            raw.nodeIds.length !== this.nodeIds.length ||
+            raw.nodeIds.some((id) => !this._nodeIdSet.has(id))))
+      ) {
+        return;
+      }
+
+      const candidates = [...raw.buckets].sort(
+        (left, right) => (left?.minuteStartMs ?? Infinity) - (right?.minuteStartMs ?? Infinity)
+      );
+      const seenMinuteStarts = new Set();
+      let rejectedBucket = false;
+      for (const candidate of candidates) {
+        const minuteStartMs = candidate?.minuteStartMs;
+        if (
+          !validNonnegativeSafeInteger(minuteStartMs) ||
+          minuteStartMs % MINUTE_MS !== 0 ||
+          seenMinuteStarts.has(minuteStartMs)
+        ) {
+          rejectedBucket = true;
+          continue;
+        }
+        seenMinuteStarts.add(minuteStartMs);
+        if (
+          !hasExactNodeKeys(candidate.nodeWh, this.nodeIds, this._nodeIdSet) ||
+          !hasExactNodeKeys(candidate.nodeCoverageMs, this.nodeIds, this._nodeIdSet)
+        ) {
+          rejectedBucket = true;
+          continue;
+        }
+        const bucket = emptyBucket(minuteStartMs, this.nodeIds);
+        let valid = true;
+        for (const id of this.nodeIds) {
+          const nodeWh = candidate?.nodeWh?.[id];
+          const nodeCoverageMs = candidate?.nodeCoverageMs?.[id];
+          if (
+            !validNonnegative(nodeWh) ||
+            nodeWh > MAX_NODE_WH_PER_MINUTE ||
+            !validNonnegative(nodeCoverageMs) ||
+            nodeCoverageMs > MINUTE_MS ||
+            exceedsWithFloatingTolerance(
+              nodeWh,
+              (240 * nodeCoverageMs) / 3_600_000
+            ) ||
+            fallsBelowWithFloatingTolerance(
+              nodeWh,
+              (MIN_NODE_WATTS * nodeCoverageMs) / 3_600_000
+            )
+          ) {
+            valid = false;
+            break;
+          }
+          bucket.nodeWh[id] = nodeWh;
+          bucket.nodeCoverageMs[id] = nodeCoverageMs;
+        }
+        if (
+          !valid ||
+          !validNonnegative(candidate.fleetWattMs) ||
+          candidate.fleetWattMs > this._maximumFleetWatts * MINUTE_MS ||
+          !validNonnegative(candidate.fleetCoverageMs) ||
+          candidate.fleetCoverageMs > MINUTE_MS ||
+          exceedsWithFloatingTolerance(
+            candidate.fleetWattMs,
+            this._maximumFleetWatts * candidate.fleetCoverageMs
+          ) ||
+          fallsBelowWithFloatingTolerance(
+            candidate.fleetWattMs,
+            this._minimumFleetWatts * candidate.fleetCoverageMs
+          ) ||
+          exceedsWithFloatingTolerance(
+            candidate.fleetWattMs,
+            Object.values(bucket.nodeWh).reduce((sum, nodeWh) => sum + nodeWh, 0) *
+              3_600_000
+          ) ||
+          this.nodeIds.some((id) =>
+            exceedsWithFloatingTolerance(
+              candidate.fleetCoverageMs,
+              bucket.nodeCoverageMs[id]
+            )
+          ) ||
+          !validNonnegativeSafeInteger(candidate.outputTokens)
+        ) {
+          rejectedBucket = true;
+          continue;
+        }
+        bucket.fleetWattMs = candidate.fleetWattMs;
+        bucket.fleetCoverageMs = candidate.fleetCoverageMs;
+        bucket.outputTokens = candidate.outputTokens;
+        this._buckets.set(minuteStartMs, bucket);
+      }
+      this._bucketsOrdered = true;
+      this._latestBucketStart = [...this._buckets.keys()].at(-1) ?? null;
+
+      let latestCoveredBucket = null;
+      for (const bucket of this._buckets.values()) {
+        const hasCoverage =
+          bucket.fleetCoverageMs > 0 ||
+          this.nodeIds.some((id) => bucket.nodeCoverageMs[id] > 0);
+        if (hasCoverage) latestCoveredBucket = bucket;
+      }
+      const latestCoveredMinuteStart = latestCoveredBucket?.minuteStartMs ?? null;
+      const creditedCoverageMs = latestCoveredBucket
+        ? Math.max(
+            latestCoveredBucket.fleetCoverageMs,
+            ...Object.values(latestCoveredBucket.nodeCoverageMs)
+          )
+        : null;
+      const hasPersistedHighWater = Object.prototype.hasOwnProperty.call(
+        raw,
+        "integrationHighWaterMs"
+      );
+      const persistedHighWater = raw.integrationHighWaterMs;
+      const validPersistedHighWater =
+        latestCoveredMinuteStart !== null &&
+        validNonnegativeSafeInteger(persistedHighWater) &&
+        persistedHighWater >= latestCoveredMinuteStart + creditedCoverageMs &&
+        persistedHighWater <= latestCoveredMinuteStart + MINUTE_MS;
+      let repairedHighWater = false;
+      if (validPersistedHighWater) {
+        this._integrationHighWaterMs = persistedHighWater;
+      } else if (latestCoveredMinuteStart !== null) {
+        this._integrationHighWaterMs = Math.min(
+          latestCoveredMinuteStart + MINUTE_MS,
+          Number.MAX_SAFE_INTEGER
+        );
+        repairedHighWater = true;
+      } else {
+        this._integrationHighWaterMs = null;
+        repairedHighWater = hasPersistedHighWater && persistedHighWater !== null;
+      }
+
+      const tokenCounter = raw.tokenCounter;
+      if (
+        this._nodeIdSet.has(tokenCounter?.headId) &&
+        validNonnegativeSafeInteger(tokenCounter?.port) &&
+        validNonnegativeSafeInteger(tokenCounter?.totalOutputTokens) &&
+        Number.isFinite(tokenCounter?.observedAtMs)
+      ) {
+        this._tokenCounter = {
+          headId: tokenCounter.headId,
+          port: tokenCounter.port,
+          totalOutputTokens: tokenCounter.totalOutputTokens,
+          observedAtMs: tokenCounter.observedAtMs,
+        };
+        this._tokenNeedsRebase = true;
+      }
+      this._dirty = legacyNodeIds || rejectedBucket || repairedHighWater;
+      const now = this._now();
+      if (Number.isFinite(now)) this._prune(now);
+    } catch (error) {
+      if (error?.code === "ENOENT") return;
+      console.warn(`[FleetEnergyTracker] unable to load ${this.filePath}: ${error.message}`);
+    }
+  }
+
+  flush() {
+    if (!this.filePath || !this._dirty) return false;
+    const now = this._now();
+    if (Number.isFinite(now)) this._prune(now);
+    const buckets = [...this._buckets.values()].sort(
+      (left, right) => left.minuteStartMs - right.minuteStartMs
+    );
+    const state = {
+      version: FILE_VERSION,
+      nodeIds: this.nodeIds,
+      savedAt: now,
+      integrationHighWaterMs:
+        this._integrationHighWaterMs === null
+          ? null
+          : Math.ceil(this._integrationHighWaterMs),
+      tokenCounter: this._tokenCounter,
+      buckets,
+    };
+    this._writeState(this.filePath, `${JSON.stringify(state)}\n`, this._fs);
+    this._dirty = false;
+    return true;
+  }
+
+  close() {
+    if (this._flushTimer !== null) {
+      this._clearInterval?.(this._flushTimer);
+      this._flushTimer = null;
+    }
+    return this.flush();
+  }
+}
+
+export default FleetEnergyTracker;

--- a/server/index.js
+++ b/server/index.js
@@ -21,6 +21,12 @@ import { showcaseManager } from "./collectors/ShowcaseManager.js";
 import { llmProbeHost } from "./collectors/llmHost.js";
 import { llmDaily } from "./collectors/LlmDaily.js";
 import { compareSemver, getLatestRelease } from "./collectors/HermesReleases.js";
+import { FLEET_ENERGY_JSON_PATH } from "./config.js";
+import { FleetEnergyTracker } from "./energy/FleetEnergyTracker.js";
+import {
+  createFleetEnergyRuntime,
+  registerFleetEnergyRoute,
+} from "./energy/FleetEnergyRuntime.js";
 
 dotenv.config();
 
@@ -85,6 +91,11 @@ const allowTest = createRateLimiter(20, 60_000);
 // ─── Spark registry ──────────────────────────────────────
 const registry = new SparkRegistry();
 
+const fleetEnergyTracker = new FleetEnergyTracker({
+  nodeIds: registry.sparkIds,
+  filePath: FLEET_ENERGY_JSON_PATH,
+});
+
 // ─── Monitor map ─────────────────────────────────────────
 const monitors = new Map();
 
@@ -130,6 +141,12 @@ function orderedSnapshots() {
     .map((m) => m.snapshot());
 }
 
+const fleetEnergyRuntime = createFleetEnergyRuntime({
+  tracker: fleetEnergyTracker,
+  orderedSnapshots,
+  monitors,
+});
+
 // ─── Express app ─────────────────────────────────────────
 const app = express();
 const server = createServer(app);
@@ -141,6 +158,8 @@ function clientKey(req) {
 }
 
 // ─── REST API ────────────────────────────────────────────
+registerFleetEnergyRoute(app, fleetEnergyTracker);
+
 // Never return SSH passwords in any response
 app.get("/api/sparks", (_req, res) => {
   res.json({ sparks: registry.publicSparks });
@@ -1385,6 +1404,7 @@ server.listen(PORT, BIND_HOST, () => {
     );
   }
   startAllMonitors();
+  fleetEnergyRuntime.start();
 });
 
 // ─── Graceful shutdown ─────────────────────────────────
@@ -1407,6 +1427,7 @@ function shutdown(signal) {
   } catch (err) {
     console.error("[sparkDash] failed to flush LLM daily history:", err.message);
   }
+  const energyPersistenceSucceeded = fleetEnergyRuntime.stop();
   try {
     if (broadcastTimer) {
       clearInterval(broadcastTimer);
@@ -1430,7 +1451,7 @@ function shutdown(signal) {
     /* ignore */
   }
   wss.close();
-  server.close(() => process.exit(0));
+  server.close(() => process.exit(energyPersistenceSucceeded ? 0 : 1));
   // Safety net: if server.close hangs (lingering keep-alive), force-exit.
   setTimeout(() => process.exit(1), 3000).unref();
 }

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -126,7 +126,8 @@ export class SparkMonitor {
     /** @type {ReturnType<typeof setInterval> | null} */
     this._tailscaleIntervalId = null;
     this._running = false;
-    /** @type {Record<string, boolean>} in-flight domain guards */
+    this._runGeneration = 0;
+    /** @type {Record<string, boolean | symbol>} in-flight domain guards */
     this._inflight = {};
   }
 
@@ -137,6 +138,9 @@ export class SparkMonitor {
     const prevComfyPort = this._comfyPort(this.spark);
     const wasHermes = this._hermesMonitoringEnabled(this.spark);
     const wasTailscale = this._tailscaleMonitoringEnabled(this.spark);
+    this.collector.invalidatePendingCollections();
+    this._runGeneration += 1;
+    this._inflight = {};
     this.spark = spark;
     this.collector.spark = spark;
 
@@ -341,6 +345,7 @@ export class SparkMonitor {
   /** Start background polling. */
   start() {
     if (this._running) return;
+    this._runGeneration += 1;
     this._running = true;
     this._stopped = false;
     this._poll();
@@ -361,6 +366,8 @@ export class SparkMonitor {
 
   /** Stop background polling. */
   stop() {
+    this.collector.invalidatePendingCollections();
+    this._runGeneration += 1;
     this._running = false;
     this._stopped = true;
     for (const id of this._intervals) clearInterval(id);
@@ -452,36 +459,42 @@ export class SparkMonitor {
   // ─── Liveness ─────────────────────────────────────────────
   async _checkOnline() {
     if (!this._running || this._inflight.online) return;
-    this._inflight.online = true;
+    const runGeneration = this._runGeneration;
+    const checkToken = Symbol("online");
+    this._inflight.online = checkToken;
+    const isCurrentRun = () =>
+      this._running && this._runGeneration === runGeneration;
     try {
       if (this.spark.isLocal) {
         await this.collector.pingHost();
       } else {
         const result = await sshTest(this.spark);
-        // Re-check after the (up to 10s) SSH await — `stop()` may have fired
-        // mid-flight (removeSpark / updateSpark). Bail before mutating state or
-        // running into a stopped registry entry.
-        if (!this._running) return;
+        if (!isCurrentRun()) return;
         if (!result.ok) throw new Error(result.message);
       }
-      if (!this._running) return;
-      this.online = true;
-      this.lastOnlineOk = Date.now();
+      if (!isCurrentRun()) return;
 
       // Collect system uptime
+      let uptimeSeconds = this._uptimeSeconds;
       try {
-        this._uptimeSeconds = await this._readUptime();
+        uptimeSeconds = await this._readUptime();
       } catch {
         // Non-fatal — uptime stays at previous value or null
       }
+      if (!isCurrentRun()) return;
+      this.online = true;
+      this.lastOnlineOk = Date.now();
+      this._uptimeSeconds = uptimeSeconds;
     } catch {
-      if (!this._running) return;
+      if (!isCurrentRun()) return;
       if (!this.lastOnlineOk || Date.now() - this.lastOnlineOk > ONLINE_GRACE_MS) {
         this.online = false;
         this._uptimeSeconds = null;
       }
     } finally {
-      this._inflight.online = false;
+      if (this._inflight.online === checkToken) {
+        this._inflight.online = false;
+      }
     }
   }
 
@@ -512,7 +525,9 @@ export class SparkMonitor {
     if (domain === "comfy" && !this._comfyMonitoringEnabled()) return;
     if (domain === "hermes" && !this._hermesMonitoringEnabled()) return;
     if (domain === "tailscale" && !this._tailscaleMonitoringEnabled()) return;
-    this._inflight[domain] = true;
+    const runGeneration = this._runGeneration;
+    const pollToken = Symbol(domain);
+    this._inflight[domain] = pollToken;
     try {
       let result;
       switch (domain) {
@@ -555,7 +570,7 @@ export class SparkMonitor {
       // isn't user-visible (monitors.delete already happened) but it's a
       // latent class of bug worth killing, and a replaced monitor could
       // otherwise race the tail-end await onto the wrong object.
-      if (!this._running) return;
+      if (!this._running || this._runGeneration !== runGeneration) return;
       switch (domain) {
         case "gpu":
           this._metrics.gpu = result;
@@ -606,32 +621,30 @@ export class SparkMonitor {
     } catch (err) {
       console.error(`[SparkMonitor] ${this.spark.id} ${domain} poll error:`, err.message);
     } finally {
-      this._inflight[domain] = false;
+      if (this._inflight[domain] === pollToken) {
+        this._inflight[domain] = false;
+      }
     }
   }
 
   /** Manually refresh a single domain, bypassing auto-poll guards. */
   async refreshDomain(domain) {
-    if (this._inflight[domain]) return;
-    this._inflight[domain] = true;
+    if (domain !== "storage") return this._pollDomain(domain);
+    if (!this._running || this._inflight[domain]) return;
+    const runGeneration = this._runGeneration;
+    const refreshToken = Symbol(domain);
+    this._inflight[domain] = refreshToken;
     try {
-      let result;
-      switch (domain) {
-        case "storage":
-          result = await this.collector.collectStorage();
-          break;
-        default:
-          // Fall back to _pollDomain for other domains
-          this._inflight[domain] = false;
-          return this._pollDomain(domain);
-      }
-      if (!this._running) return;
+      const result = await this.collector.collectStorage();
+      if (!this._running || this._runGeneration !== runGeneration) return;
       this._metrics.storage = result;
       this._lastUpdate[domain] = Date.now();
     } catch (err) {
       console.error(`[SparkMonitor] ${this.spark.id} ${domain} refresh error:`, err.message);
     } finally {
-      this._inflight[domain] = false;
+      if (this._inflight[domain] === refreshToken) {
+        this._inflight[domain] = false;
+      }
     }
   }
 
@@ -777,4 +790,3 @@ export class SparkMonitor {
     };
   }
 }
-

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -1,6 +1,9 @@
 import fs from "fs";
 import path from "path";
-import { SystemCollector } from "../collectors/SystemCollector.js";
+import {
+  SystemCollector,
+  collectionWasSuccessful,
+} from "../collectors/SystemCollector.js";
 import { LlmProbe } from "../collectors/LlmProbe.js";
 import { ComfyProbe } from "../collectors/ComfyProbe.js";
 import { HermesProbe } from "../collectors/HermesProbe.js";
@@ -99,6 +102,7 @@ export class SparkMonitor {
       tailscale: null,
     };
     this._lastUpdate = {};
+    this._metricCollectionSuccessful = { gpu: false, cpu: false };
 
     // Hardware summary: kind "spark" uses the static DGX Spark specs; kind
     // "host" (dedicated GPU Linux box) detects real hardware once in the
@@ -141,6 +145,7 @@ export class SparkMonitor {
     this.collector.invalidatePendingCollections();
     this._runGeneration += 1;
     this._inflight = {};
+    this._metricCollectionSuccessful = { gpu: false, cpu: false };
     this.spark = spark;
     this.collector.spark = spark;
 
@@ -368,6 +373,7 @@ export class SparkMonitor {
   stop() {
     this.collector.invalidatePendingCollections();
     this._runGeneration += 1;
+    this._metricCollectionSuccessful = { gpu: false, cpu: false };
     this._running = false;
     this._stopped = true;
     for (const id of this._intervals) clearInterval(id);
@@ -574,9 +580,11 @@ export class SparkMonitor {
       switch (domain) {
         case "gpu":
           this._metrics.gpu = result;
+          this._metricCollectionSuccessful.gpu = collectionWasSuccessful(result);
           break;
         case "cpu":
           this._metrics.cpu = result;
+          this._metricCollectionSuccessful.cpu = collectionWasSuccessful(result);
           break;
         case "ram":
           this._metrics.ram = result;
@@ -619,6 +627,13 @@ export class SparkMonitor {
       }
       this._lastUpdate[domain] = Date.now();
     } catch (err) {
+      if (
+        this._running &&
+        this._runGeneration === runGeneration &&
+        (domain === "gpu" || domain === "cpu")
+      ) {
+        this._metricCollectionSuccessful[domain] = false;
+      }
       console.error(`[SparkMonitor] ${this.spark.id} ${domain} poll error:`, err.message);
     } finally {
       if (this._inflight[domain] === pollToken) {

--- a/server/sparks/__tests__/fleet-energy.test.js
+++ b/server/sparks/__tests__/fleet-energy.test.js
@@ -1,0 +1,1602 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import {
+  FleetEnergyTracker as BaseFleetEnergyTracker,
+  estimateNodeWatts,
+} from "../../energy/FleetEnergyTracker.js";
+
+const fleetEnergyRuntime = await import("../../energy/FleetEnergyRuntime.js").catch(() => ({}));
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const CANONICAL_NODE_IDS = Object.freeze([
+  "node-a",
+  "node-b",
+  "node-c",
+  "node-d",
+]);
+
+class FleetEnergyTracker extends BaseFleetEnergyTracker {
+  constructor(options = {}) {
+    super({ nodeIds: CANONICAL_NODE_IDS, ...options });
+  }
+}
+
+function almostEqual(actual, expected, epsilon = 1e-10) {
+  assert.ok(
+    Math.abs(actual - expected) <= epsilon,
+    `expected ${actual} to be within ${epsilon} of ${expected}`
+  );
+}
+
+function nodeSnapshot(
+  id,
+  {
+    watts = 100,
+    cpuUsage = 0,
+    gpuDraw,
+    online = true,
+    fresh,
+    telemetryFresh = true,
+    role,
+    outputTokens,
+    outputAvailable = true,
+    outputPort = 8000,
+    llmEntries,
+    llmPorts,
+  } = {}
+) {
+  const cpuWatts = 5.2 + ((65 - 5.2) * Math.max(0, Math.min(100, cpuUsage))) / 100;
+  const resolvedGpuDraw = gpuDraw ?? watts - cpuWatts - 23;
+  const snapshot = {
+    id,
+    online,
+    llmPorts:
+      llmPorts ??
+      (outputTokens === undefined && llmEntries === undefined ? [] : [outputPort]),
+    metrics: {
+      gpu: { power: { draw: resolvedGpuDraw } },
+      cpu: { usage: cpuUsage },
+      llm:
+        llmEntries ??
+        (outputTokens === undefined
+          ? []
+          : [{ available: outputAvailable, totalOutputTokens: outputTokens }]),
+    },
+  };
+  if (fresh !== undefined) snapshot.fresh = fresh;
+  if (telemetryFresh !== undefined) snapshot.telemetryFresh = telemetryFresh;
+  if (role !== undefined) snapshot.role = role;
+  return snapshot;
+}
+
+function fleetSnapshots(watts, { outputTokens } = {}) {
+  return CANONICAL_NODE_IDS.map((id, index) =>
+    nodeSnapshot(id, {
+      watts,
+      role: index === 0 ? "head" : "worker",
+      outputTokens: index === 0 ? outputTokens : undefined,
+    })
+  );
+}
+
+function noTimerOptions() {
+  return { filePath: null, load: false };
+}
+
+function runtimeFunction(name) {
+  assert.equal(
+    typeof fleetEnergyRuntime[name],
+    "function",
+    `FleetEnergyRuntime must export ${name}()`
+  );
+  return fleetEnergyRuntime[name];
+}
+
+function realShapeSnapshot(id = "node-a", overrides = {}) {
+  return {
+    id,
+    name: id,
+    online: true,
+    role: id === "node-a" ? "head" : "worker",
+    llmPorts: id === "node-a" ? [8000] : [],
+    metrics: {
+      gpu: {
+        temperature: 42,
+        usage: 0,
+        power: { draw: 18.5, limit: 120, systemDraw: 44 },
+        vram: { used: 0, total: 128_000, percentage: 0, available: 120_000 },
+        processes: [],
+        temperatureAverage1h: null,
+        temperatureAverage1hSamples: 0,
+        temperatureAverage1hCoverageMs: 0,
+      },
+      cpu: { usage: 0, temperature: 38, draw: 5.2, tdp: 65 },
+      llm:
+        id === "node-a"
+          ? [{ available: true, totalOutputTokens: 100 }]
+          : [],
+    },
+    ...overrides,
+  };
+}
+
+function failedGpuSnapshot() {
+  const snapshot = realShapeSnapshot();
+  snapshot.metrics.gpu = {
+    temperature: 0,
+    usage: 0,
+    power: { draw: 0, limit: 120, systemDraw: 0 },
+    vram: { used: 0, total: 0, percentage: 0, available: 0 },
+    processes: [],
+    temperatureAverage1h: null,
+    temperatureAverage1hSamples: 0,
+    temperatureAverage1hCoverageMs: 0,
+  };
+  return snapshot;
+}
+
+function failedCpuSnapshot() {
+  const snapshot = realShapeSnapshot();
+  snapshot.metrics.cpu = { usage: 0, temperature: 0, draw: 0, tdp: 0 };
+  return snapshot;
+}
+
+function monitorWithCollectionState({
+  gpuAt,
+  cpuAt,
+  gpuSuccessful = true,
+  cpuSuccessful = true,
+} = {}) {
+  return {
+    _lastUpdate: { gpu: gpuAt, cpu: cpuAt },
+    _metricCollectionSuccessful: {
+      gpu: gpuSuccessful,
+      cpu: cpuSuccessful,
+    },
+    collector: {
+      wasLastCollectionSuccessful() {
+        throw new Error("freshness must not read collector-global state");
+      },
+    },
+  };
+}
+
+const APPROVED_RESPONSE_FIELDS = [
+  "estimated",
+  "freshNodeCount",
+  "currentWatts30s",
+  "energy24hKwh",
+  "energy31dKwh",
+  "whPerOutputToken24h",
+  "outputTokens24h",
+  "coverage24hMs",
+  "coverage31dMs",
+  "nodeCoverage24hMs",
+  "nodeCoverage31dMs",
+  "hourlyWatts24h",
+];
+
+function assertNullableFiniteNumber(value) {
+  assert.ok(value === null || Number.isFinite(value));
+}
+
+function assertFleetEnergyResponseContract(response) {
+  assert.deepEqual(Object.keys(response).sort(), [...APPROVED_RESPONSE_FIELDS].sort());
+  assert.equal(typeof response.estimated, "boolean");
+  for (const field of [
+    "freshNodeCount",
+    "outputTokens24h",
+    "coverage24hMs",
+    "coverage31dMs",
+  ]) {
+    assert.equal(typeof response[field], "number", field);
+    assert.equal(Number.isFinite(response[field]), true, field);
+  }
+  for (const field of [
+    "currentWatts30s",
+    "energy24hKwh",
+    "energy31dKwh",
+    "whPerOutputToken24h",
+  ]) {
+    assertNullableFiniteNumber(response[field]);
+  }
+  for (const field of ["nodeCoverage24hMs", "nodeCoverage31dMs"]) {
+    assert.deepEqual(Object.keys(response[field]), CANONICAL_NODE_IDS);
+    assert.equal(
+      Object.values(response[field]).every((value) => Number.isFinite(value)),
+      true
+    );
+  }
+  assert.equal(response.hourlyWatts24h.length, 24);
+  response.hourlyWatts24h.forEach(assertNullableFiniteNumber);
+}
+
+test("power telemetry freshness accepts current and 10-second-old real monitor samples", () => {
+  const hasFreshPowerTelemetry = runtimeFunction("hasFreshPowerTelemetry");
+  const now = 50_000;
+  const snapshot = realShapeSnapshot();
+
+  assert.equal(
+    hasFreshPowerTelemetry(
+      snapshot,
+      monitorWithCollectionState({ gpuAt: now, cpuAt: now }),
+      now
+    ),
+    true
+  );
+  assert.equal(
+    hasFreshPowerTelemetry(snapshot, { _lastUpdate: { gpu: now, cpu: now } }, now),
+    false,
+    "timestamps alone cannot distinguish a failed collection from a real idle sample"
+  );
+  assert.equal(
+    hasFreshPowerTelemetry(
+      snapshot,
+      monitorWithCollectionState({ gpuAt: now - 10_000, cpuAt: now - 10_000 }),
+      now
+    ),
+    true
+  );
+});
+
+test("power telemetry freshness rejects liveness, clock, default-result, and power-input failures", () => {
+  const hasFreshPowerTelemetry = runtimeFunction("hasFreshPowerTelemetry");
+  const now = 50_000;
+  const freshMonitor = monitorWithCollectionState({
+    gpuAt: now - 1_000,
+    cpuAt: now - 1_000,
+  });
+  const offline = realShapeSnapshot("node-a", { online: false });
+  const nonfiniteGpuDraw = realShapeSnapshot();
+  nonfiniteGpuDraw.metrics.gpu.power.draw = Number.NaN;
+  const nonfiniteCpuUsage = realShapeSnapshot();
+  nonfiniteCpuUsage.metrics.cpu.usage = Number.POSITIVE_INFINITY;
+
+  const cases = [
+    [offline, freshMonitor],
+    [realShapeSnapshot(), monitorWithCollectionState({ cpuAt: now })],
+    [realShapeSnapshot(), monitorWithCollectionState({ gpuAt: now + 1, cpuAt: now })],
+    [realShapeSnapshot(), monitorWithCollectionState({ gpuAt: now - 10_001, cpuAt: now })],
+    [realShapeSnapshot(), monitorWithCollectionState({ gpuAt: Number.NaN, cpuAt: now })],
+    [
+      realShapeSnapshot(),
+      monitorWithCollectionState({ gpuAt: now, cpuAt: now, gpuSuccessful: false }),
+    ],
+    [
+      realShapeSnapshot(),
+      monitorWithCollectionState({ gpuAt: now, cpuAt: now, cpuSuccessful: false }),
+    ],
+    [failedGpuSnapshot(), freshMonitor],
+    [failedCpuSnapshot(), freshMonitor],
+    [nonfiniteGpuDraw, freshMonitor],
+    [nonfiniteCpuUsage, freshMonitor],
+  ];
+
+  for (const [snapshot, monitor] of cases) {
+    assert.equal(hasFreshPowerTelemetry(snapshot, monitor, now), false);
+  }
+});
+
+test("one fleet-energy sampler tick records decorated clones without changing normal snapshots", () => {
+  const runFleetEnergySamplerTick = runtimeFunction("runFleetEnergySamplerTick");
+  const now = 50_000;
+  const snapshots = [realShapeSnapshot("node-a"), failedCpuSnapshot()];
+  snapshots[1].id = "node-b";
+  snapshots[1].role = "worker";
+  snapshots[1].llmPorts = [];
+  snapshots[1].metrics.llm = [];
+  let orderedCalls = 0;
+  let recorded = null;
+  const result = runFleetEnergySamplerTick({
+    tracker: {
+      record(decorated, atMs) {
+        recorded = { decorated, atMs };
+        return "recorded";
+      },
+    },
+    orderedSnapshots() {
+      orderedCalls += 1;
+      return snapshots;
+    },
+    monitors: new Map([
+      [
+        "node-a",
+        monitorWithCollectionState({ gpuAt: now - 2_000, cpuAt: now - 2_000 }),
+      ],
+      [
+        "node-b",
+        monitorWithCollectionState({ gpuAt: now - 2_000, cpuAt: now - 2_000 }),
+      ],
+    ]),
+    now: () => now,
+  });
+
+  assert.equal(result, "recorded");
+  assert.equal(orderedCalls, 1);
+  assert.equal(recorded.atMs, now);
+  assert.notEqual(recorded.decorated, snapshots);
+  assert.notEqual(recorded.decorated[0], snapshots[0]);
+  assert.equal(recorded.decorated[0].telemetryFresh, true);
+  assert.equal(recorded.decorated[1].telemetryFresh, false);
+  assert.equal(Object.hasOwn(snapshots[0], "telemetryFresh"), false);
+  assert.equal(Object.hasOwn(snapshots[1], "telemetryFresh"), false);
+});
+
+test("fleet-energy handler returns the exact empty tracker response contract", () => {
+  const createFleetEnergyHandler = runtimeFunction("createFleetEnergyHandler");
+  const tracker = new FleetEnergyTracker({
+    ...noTimerOptions(),
+    now: () => Date.UTC(2026, 7, 23, 12, 34, 0),
+  });
+  let response;
+  createFleetEnergyHandler(tracker)({}, { json: (value) => (response = value) });
+
+  assertFleetEnergyResponseContract(response);
+  assert.equal(response.currentWatts30s, null);
+  assert.equal(response.energy24hKwh, null);
+  assert.equal(response.energy31dKwh, null);
+  assert.equal(response.whPerOutputToken24h, null);
+  assert.deepEqual(response.hourlyWatts24h, Array(24).fill(null));
+});
+
+test("fleet-energy handler returns the exact populated tracker response contract", () => {
+  const createFleetEnergyHandler = runtimeFunction("createFleetEnergyHandler");
+  const now = Date.UTC(2026, 7, 23, 12, 34, 0);
+  const tracker = new FleetEnergyTracker({ ...noTimerOptions(), now: () => now });
+  tracker.record(fleetSnapshots(100, { outputTokens: 100 }), now - 30 * MINUTE_MS);
+  tracker.record(fleetSnapshots(100, { outputTokens: 120 }), now - 30 * MINUTE_MS + 2_000);
+  tracker.record(fleetSnapshots(100, { outputTokens: 120 }), now);
+  let response;
+  createFleetEnergyHandler(tracker)({}, { json: (value) => (response = value) });
+
+  assertFleetEnergyResponseContract(response);
+  assert.equal(response.freshNodeCount, 4);
+  assert.equal(response.currentWatts30s, 400);
+  assert.ok(response.energy24hKwh > 0);
+  assert.ok(response.energy31dKwh > 0);
+  assert.ok(response.whPerOutputToken24h > 0);
+  assert.equal(response.outputTokens24h, 20);
+  assert.equal(response.hourlyWatts24h.some(Number.isFinite), true);
+});
+
+test("fleet-energy runtime samples without WebSockets and schedules decorated ticks every 2000ms", () => {
+  const createFleetEnergyRuntime = runtimeFunction("createFleetEnergyRuntime");
+  const now = 50_000;
+  const snapshots = [realShapeSnapshot("node-a")];
+  const records = [];
+  let scheduled = null;
+  let intervalCalls = 0;
+  const runtime = createFleetEnergyRuntime({
+    tracker: {
+      record(inputs, atMs) {
+        records.push({ inputs, atMs });
+      },
+      close() {},
+    },
+    orderedSnapshots: () => snapshots,
+    monitors: new Map([
+      [
+        "node-a",
+        monitorWithCollectionState({ gpuAt: now - 2_000, cpuAt: now - 2_000 }),
+      ],
+    ]),
+    now: () => now,
+    setIntervalFn(callback, intervalMs) {
+      intervalCalls += 1;
+      scheduled = { callback, intervalMs, timer: Symbol("energy-timer") };
+      return scheduled.timer;
+    },
+    clearIntervalFn() {},
+    logError() {},
+  });
+
+  runtime.start();
+  runtime.start();
+  assert.equal(records.length, 1, "start performs one immediate sample even without WS clients");
+  assert.equal(intervalCalls, 1, "start is idempotent");
+  assert.equal(scheduled.intervalMs, 2_000);
+  assert.equal(records[0].inputs[0].telemetryFresh, true);
+  assert.equal(Object.hasOwn(snapshots[0], "telemetryFresh"), false);
+
+  scheduled.callback();
+  assert.equal(records.length, 2);
+  assert.equal(records[1].atMs, now);
+  assert.equal(records[1].inputs[0].telemetryFresh, true);
+});
+
+test("fleet-energy startup helper starts monitors before the sampler", () => {
+  const startFleetEnergyCollection = runtimeFunction("startFleetEnergyCollection");
+  const events = [];
+
+  startFleetEnergyCollection({
+    startAllMonitors: () => events.push("monitors"),
+    energyRuntime: { start: () => events.push("sampler") },
+  });
+
+  assert.deepEqual(events, ["monitors", "sampler"]);
+});
+
+test("fleet-energy runtime retries one transient close failure and stays idempotent", () => {
+  const createFleetEnergyRuntime = runtimeFunction("createFleetEnergyRuntime");
+  const timer = Symbol("energy-timer");
+  const cleared = [];
+  const logged = [];
+  let closeCalls = 0;
+  const runtime = createFleetEnergyRuntime({
+    tracker: {
+      record() {},
+      close() {
+        closeCalls += 1;
+        if (closeCalls === 1) throw new Error("transient close failure");
+      },
+    },
+    orderedSnapshots: () => [],
+    monitors: new Map(),
+    setIntervalFn: () => timer,
+    clearIntervalFn: (received) => cleared.push(received),
+    logError: (...args) => logged.push(args),
+  });
+
+  runtime.start();
+  assert.equal(runtime.stop(), true);
+  assert.equal(runtime.stop(), true);
+
+  assert.deepEqual(cleared, [timer]);
+  assert.equal(closeCalls, 2);
+  assert.equal(logged.length, 1);
+  assert.match(logged[0].map(String).join(" "), /transient close failure/);
+});
+
+test("fleet-energy runtime contains two persistent close failures and returns false", () => {
+  const createFleetEnergyRuntime = runtimeFunction("createFleetEnergyRuntime");
+  const timer = Symbol("energy-timer");
+  const cleared = [];
+  const logged = [];
+  let closeCalls = 0;
+  const runtime = createFleetEnergyRuntime({
+    tracker: {
+      record() {},
+      close() {
+        closeCalls += 1;
+        throw new Error(`persistent close failure ${closeCalls}`);
+      },
+    },
+    orderedSnapshots: () => [],
+    monitors: new Map(),
+    setIntervalFn: () => timer,
+    clearIntervalFn: (received) => cleared.push(received),
+    logError: (...args) => logged.push(args),
+  });
+
+  runtime.start();
+  assert.equal(runtime.stop(), false);
+  assert.equal(runtime.stop(), false);
+
+  assert.deepEqual(cleared, [timer]);
+  assert.equal(closeCalls, 2);
+  assert.equal(logged.length, 2);
+  assert.match(logged[0].map(String).join(" "), /persistent close failure 1/);
+  assert.match(logged[1].map(String).join(" "), /persistent close failure 2/);
+});
+
+test("fleet-energy server-close handler exits non-zero only after failed persistence", () => {
+  const createFleetEnergyExitHandler = runtimeFunction("createFleetEnergyExitHandler");
+  const exitCodes = [];
+
+  createFleetEnergyExitHandler(true, (code) => exitCodes.push(code))();
+  createFleetEnergyExitHandler(false, (code) => exitCodes.push(code))();
+
+  assert.deepEqual(exitCodes, [0, 1]);
+});
+
+test("registered fleet-energy GET is read-only and serves the exact contract", async (t) => {
+  const registerFleetEnergyRoute = runtimeFunction("registerFleetEnergyRoute");
+  const tracker = new FleetEnergyTracker({
+    ...noTimerOptions(),
+    now: () => Date.UTC(2026, 7, 23, 12, 34, 0),
+  });
+  const app = express();
+  registerFleetEnergyRoute(app, tracker);
+
+  const server = await new Promise((resolve, reject) => {
+    const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
+    listening.on("error", reject);
+  });
+  t.after(
+    () =>
+      new Promise((resolve) => {
+        server.close(resolve);
+        server.closeAllConnections?.();
+      })
+  );
+  const address = server.address();
+  const endpoint = `http://127.0.0.1:${address.port}/api/fleet-energy`;
+
+  const read = await fetch(endpoint);
+  assert.equal(read.status, 200);
+  const response = await read.json();
+  assertFleetEnergyResponseContract(response);
+  assert.equal(response.currentWatts30s, null);
+  assert.equal(response.energy24hKwh, null);
+  assert.deepEqual(response.hourlyWatts24h, Array(24).fill(null));
+
+  for (const method of ["POST", "PUT", "DELETE"]) {
+    const mutation = await fetch(endpoint, {
+      method,
+    });
+    assert.equal(mutation.status, 404, `${method} must not be registered`);
+  }
+});
+
+test("estimator models CPU at 0, 50, and 100 percent without using systemDraw", () => {
+  const atCpu = (usage) =>
+    estimateNodeWatts({
+      online: true,
+      telemetryFresh: true,
+      metrics: {
+        gpu: { power: { draw: 10, systemDraw: 999 } },
+        cpu: { usage },
+      },
+    });
+
+  almostEqual(atCpu(0), 38.2);
+  almostEqual(atCpu(50), 68.1);
+  almostEqual(atCpu(100), 98);
+});
+
+test("estimator clamps CPU usage and total node power", () => {
+  almostEqual(estimateNodeWatts(nodeSnapshot("node-a", { cpuUsage: -20, gpuDraw: 10 })), 38.2);
+  almostEqual(estimateNodeWatts(nodeSnapshot("node-a", { cpuUsage: 120, gpuDraw: 10 })), 98);
+  assert.equal(estimateNodeWatts(nodeSnapshot("node-a", { gpuDraw: 500 })), 240);
+});
+
+test("estimator requires explicit telemetryFresh true", () => {
+  const onlineOnly = nodeSnapshot("node-a", { online: true });
+  delete onlineOnly.telemetryFresh;
+  assert.equal(
+    estimateNodeWatts(onlineOnly),
+    null
+  );
+  assert.equal(
+    estimateNodeWatts(nodeSnapshot("node-a", { online: true, telemetryFresh: false })),
+    null
+  );
+  assert.equal(
+    estimateNodeWatts(nodeSnapshot("node-a", { online: false, telemetryFresh: true })),
+    100
+  );
+  assert.equal(estimateNodeWatts(nodeSnapshot("node-a", { gpuDraw: -1 })), null);
+  assert.equal(estimateNodeWatts(nodeSnapshot("node-a", { cpuUsage: Number.NaN })), null);
+});
+
+test("record integrates constant and changing power with trapezoids", () => {
+  const constant = new FleetEnergyTracker(noTimerOptions());
+  constant.record([nodeSnapshot("node-a", { watts: 100 })], 0);
+  constant.record([nodeSnapshot("node-a", { watts: 100 })], 10_000);
+  almostEqual(constant.snapshot(10_000).energy24hKwh, (100 * 10_000) / 3_600_000 / 1000);
+
+  const changing = new FleetEnergyTracker(noTimerOptions());
+  changing.record([nodeSnapshot("node-a", { watts: 100 })], 0);
+  changing.record([nodeSnapshot("node-a", { watts: 200 })], 10_000);
+  almostEqual(changing.snapshot(10_000).energy24hKwh, (150 * 10_000) / 3_600_000 / 1000);
+});
+
+test("integration splits energy and coverage at UTC minute boundaries", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-split-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const minute = Date.UTC(2026, 7, 23, 12, 0, 0);
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    load: false,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+
+  tracker.record([nodeSnapshot("node-a", { watts: 100 })], minute + 59_000);
+  tracker.record([nodeSnapshot("node-a", { watts: 100 })], minute + 61_000);
+  assert.equal(tracker.flush(), true);
+
+  const saved = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.deepEqual(
+    saved.buckets.map((bucket) => bucket.minuteStartMs),
+    [minute, minute + MINUTE_MS]
+  );
+  for (const bucket of saved.buckets) {
+    almostEqual(bucket.nodeWh["node-a"], 100 / 3_600);
+    assert.equal(bucket.nodeCoverageMs["node-a"], 1_000);
+  }
+});
+
+test("a 10 second gap integrates but a longer gap resets the node baseline", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record([nodeSnapshot("node-a", { watts: 100 })], 0);
+  tracker.record([nodeSnapshot("node-a", { watts: 100 })], 10_000);
+  tracker.record([nodeSnapshot("node-a", { watts: 200 })], 20_001);
+  tracker.record([nodeSnapshot("node-a", { watts: 200 })], 22_001);
+
+  const expectedWh = (100 * 10_000 + 200 * 2_000) / 3_600_000;
+  almostEqual(tracker.snapshot(22_001).energy24hKwh, expectedWh / 1000);
+});
+
+test("a disappearing node cannot invent a ramp when it reappears", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record([nodeSnapshot("node-a", { watts: 100 })], 0);
+  tracker.record([], 2_000);
+  tracker.record([nodeSnapshot("node-a", { watts: 200 })], 4_000);
+  tracker.record([nodeSnapshot("node-a", { watts: 200 })], 6_000);
+
+  almostEqual(tracker.snapshot(6_000).energy24hKwh, (200 * 2_000) / 3_600_000 / 1000);
+});
+
+test("full-fleet samples drive the arithmetic 30 second mean and simultaneous coverage", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record(fleetSnapshots(100), 0);
+  tracker.record(fleetSnapshots(200), 2_000);
+  tracker.record(fleetSnapshots(300).slice(0, 3), 4_000);
+  tracker.record(fleetSnapshots(300), 6_000);
+
+  const snapshot = tracker.snapshot(6_000);
+  assert.equal(snapshot.freshNodeCount, 4);
+  almostEqual(snapshot.currentWatts30s, (400 + 800 + 960) / 3);
+  assert.equal(snapshot.coverage24hMs, 2_000);
+  assert.equal(snapshot.coverage31dMs, 2_000);
+  assert.deepEqual(snapshot.nodeCoverage24hMs, {
+    "node-a": 6_000,
+    "node-b": 6_000,
+    "node-c": 6_000,
+    "node-d": 2_000,
+  });
+  assert.deepEqual(Object.keys(snapshot.nodeCoverage31dMs), CANONICAL_NODE_IDS);
+});
+
+test("currentWatts30s excludes stale full-fleet samples and is null without any", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  assert.equal(tracker.snapshot(0).currentWatts30s, null);
+  tracker.record(fleetSnapshots(100), 0);
+  tracker.record(fleetSnapshots(200), 31_000);
+  assert.equal(tracker.snapshot(31_000).currentWatts30s, 800);
+});
+
+test("a backward wall-clock step clears live baselines without recounting prior intervals", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record(fleetSnapshots(100), 10_000);
+  tracker.record(fleetSnapshots(100), 12_000);
+
+  assert.equal(tracker.record(fleetSnapshots(200), 5_000), true);
+  assert.equal(tracker.snapshot(5_000).currentWatts30s, 800);
+  assert.equal(tracker.record(fleetSnapshots(200), 7_000), true);
+  assert.equal(tracker.record(fleetSnapshots(200), 7_000), false);
+
+  const expectedKwh = (400 * 2_000) / 3_600_000 / 1000;
+  almostEqual(tracker.snapshot(7_000).energy24hKwh, expectedKwh);
+});
+
+test("rollback catch-up clips and interpolates an interval that straddles high-water", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-straddle-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  let now = 0;
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    load: false,
+    now: () => now,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+  tracker.record(fleetSnapshots(100), 0);
+  tracker.record(fleetSnapshots(100), 10_000);
+
+  tracker.record(fleetSnapshots(100), 4_000);
+  tracker.record(fleetSnapshots(100), 8_000);
+  now = 12_000;
+  tracker.record(fleetSnapshots(200), now);
+
+  const snapshot = tracker.snapshot(now);
+  assert.equal(snapshot.coverage24hMs, 12_000);
+  assert.deepEqual(
+    snapshot.nodeCoverage24hMs,
+    Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, 12_000]))
+  );
+  almostEqual(snapshot.energy24hKwh, 5_400_000 / 3_600_000 / 1000);
+
+  tracker.flush();
+  const bucket = JSON.parse(fs.readFileSync(filePath, "utf8")).buckets[0];
+  almostEqual(bucket.fleetWattMs, 5_400_000);
+  for (const id of CANONICAL_NODE_IDS) {
+    almostEqual(bucket.nodeWh[id], 1_350_000 / 3_600_000);
+  }
+});
+
+test("rollback suppression survives reload and prevents duplicate UTC-minute energy", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-rollback-reload-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  let now = 0;
+  const timerOptions = { setIntervalFn: () => 1, clearIntervalFn: () => {} };
+  const first = new FleetEnergyTracker({
+    filePath,
+    load: false,
+    now: () => now,
+    ...timerOptions,
+  });
+
+  for (let atMs = 0; atMs <= MINUTE_MS; atMs += 10_000) {
+    first.record(fleetSnapshots(100), atMs);
+  }
+  const beforeRollback = first.snapshot(MINUTE_MS);
+  assert.equal(beforeRollback.coverage24hMs, MINUTE_MS);
+  assert.deepEqual(
+    beforeRollback.nodeCoverage24hMs,
+    Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, MINUTE_MS]))
+  );
+
+  first.record(fleetSnapshots(100), 0);
+  first.record(fleetSnapshots(100), 10_000);
+  now = 20_000;
+  first.record(fleetSnapshots(100), now);
+  first.flush();
+
+  const rolledBackState = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const completedMinute = rolledBackState.buckets.find((bucket) => bucket.minuteStartMs === 0);
+  assert.equal(completedMinute.fleetCoverageMs, MINUTE_MS);
+  assert.ok(Object.values(completedMinute.nodeCoverageMs).every((value) => value <= MINUTE_MS));
+  assert.equal(rolledBackState.integrationHighWaterMs, MINUTE_MS);
+
+  const second = new FleetEnergyTracker({ filePath, now: () => now, ...timerOptions });
+  const afterReload = second.snapshot(now);
+  assert.equal(afterReload.coverage24hMs, beforeRollback.coverage24hMs);
+  almostEqual(afterReload.energy24hKwh, beforeRollback.energy24hKwh);
+
+  for (const atMs of [30_000, 40_000, 50_000, 60_000, 70_000, 80_000]) {
+    now = atMs;
+    second.record(fleetSnapshots(100), atMs);
+  }
+  const caughtUp = second.snapshot(now);
+  assert.equal(caughtUp.coverage24hMs, 80_000);
+  assert.deepEqual(
+    caughtUp.nodeCoverage24hMs,
+    Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, 80_000]))
+  );
+  almostEqual(caughtUp.energy24hKwh, (400 * 80_000) / 3_600_000 / 1000);
+
+  second.flush();
+  const caughtUpState = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.ok(caughtUpState.buckets.every((bucket) => bucket.fleetCoverageMs <= MINUTE_MS));
+  assert.ok(
+    caughtUpState.buckets.every((bucket) =>
+      Object.values(bucket.nodeCoverageMs).every((value) => value <= MINUTE_MS)
+    )
+  );
+});
+
+test("reload repairs a safe but impossible high-water so integration can resume", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-high-water-repair-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const nodeCoverageMs = Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, 10_000]));
+  const nodeWh = Object.fromEntries(
+    CANONICAL_NODE_IDS.map((id) => [id, (100 * 10_000) / 3_600_000])
+  );
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({
+      version: 1,
+      nodeIds: CANONICAL_NODE_IDS,
+      integrationHighWaterMs: Number.MAX_SAFE_INTEGER,
+      buckets: [{
+        minuteStartMs: 0,
+        nodeWh,
+        nodeCoverageMs,
+        fleetWattMs: 400 * 10_000,
+        fleetCoverageMs: 10_000,
+        outputTokens: 0,
+      }],
+    })
+  );
+
+  let now = MINUTE_MS;
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    now: () => now,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+  tracker.record(fleetSnapshots(100), now);
+  now += 2_000;
+  tracker.record(fleetSnapshots(100), now);
+
+  const snapshot = tracker.snapshot(now);
+  assert.equal(snapshot.coverage24hMs, 12_000);
+  almostEqual(snapshot.energy24hKwh, (400 * 12_000) / 3_600_000 / 1000);
+  tracker.flush();
+  assert.equal(
+    JSON.parse(fs.readFileSync(filePath, "utf8")).integrationHighWaterMs,
+    now
+  );
+});
+
+test("reload repairs high-water below credited coverage before catch-up", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-high-water-coverage-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const nodeCoverageMs = Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, MINUTE_MS]));
+  const nodeWh = Object.fromEntries(
+    CANONICAL_NODE_IDS.map((id) => [id, (100 * MINUTE_MS) / 3_600_000])
+  );
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({
+      version: 1,
+      nodeIds: CANONICAL_NODE_IDS,
+      integrationHighWaterMs: 1,
+      buckets: [{
+        minuteStartMs: 0,
+        nodeWh,
+        nodeCoverageMs,
+        fleetWattMs: 400 * MINUTE_MS,
+        fleetCoverageMs: MINUTE_MS,
+        outputTokens: 0,
+      }],
+    })
+  );
+
+  let now = 1_000;
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    now: () => now,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+  const beforeCatchUp = tracker.snapshot(now);
+  tracker.record(fleetSnapshots(100), now);
+  now = 2_000;
+  tracker.record(fleetSnapshots(100), now);
+
+  const afterCatchUp = tracker.snapshot(now);
+  assert.equal(afterCatchUp.coverage24hMs, MINUTE_MS);
+  assert.deepEqual(afterCatchUp.nodeCoverage24hMs, nodeCoverageMs);
+  almostEqual(afterCatchUp.energy24hKwh, beforeCatchUp.energy24hKwh);
+
+  tracker.flush();
+  const saved = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.equal(saved.integrationHighWaterMs, MINUTE_MS);
+  assert.equal(saved.buckets[0].fleetCoverageMs, MINUTE_MS);
+  assert.deepEqual(saved.buckets[0].nodeCoverageMs, nodeCoverageMs);
+});
+
+test("flush persists a conservative safe-integer high-water for fractional clocks", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-fractional-clock-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  let now = 0.25;
+  const timerOptions = { setIntervalFn: () => 1, clearIntervalFn: () => {} };
+  const first = new FleetEnergyTracker({
+    filePath,
+    load: false,
+    now: () => now,
+    ...timerOptions,
+  });
+  first.record(fleetSnapshots(100), now);
+  now = 2_000.25;
+  first.record(fleetSnapshots(100), now);
+  first.flush();
+
+  const saved = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.equal(saved.integrationHighWaterMs, 2_001);
+  assert.equal(Number.isSafeInteger(saved.integrationHighWaterMs), true);
+
+  const second = new FleetEnergyTracker({ filePath, now: () => now, ...timerOptions });
+  assert.equal(second.snapshot(now).coverage24hMs, 2_000);
+});
+
+test("nonfinite clocks neither prune history nor freeze snapshot output", () => {
+  const tracker = new FleetEnergyTracker({ ...noTimerOptions(), now: () => Number.NaN });
+  tracker.record(fleetSnapshots(100), 0);
+  tracker.record(fleetSnapshots(100), 2_000);
+  const expected = tracker.snapshot(2_000);
+
+  assert.equal(tracker.record(fleetSnapshots(200), Number.NaN), false);
+  const fallback = tracker.snapshot();
+  almostEqual(fallback.energy31dKwh, expected.energy31dKwh);
+  assert.equal(fallback.currentWatts30s, expected.currentWatts30s);
+  assert.equal(fallback.freshNodeCount, expected.freshNodeCount);
+
+  const empty = new FleetEnergyTracker({ ...noTimerOptions(), now: () => Number.NaN });
+  assert.equal(empty.snapshot().energy31dKwh, null);
+  assert.equal(empty.snapshot().hourlyWatts24h.length, 24);
+});
+
+test("head output-token deltas accumulate while counter resets establish a new baseline", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record(fleetSnapshots(100, { outputTokens: 100 }), 0);
+  tracker.record(fleetSnapshots(100, { outputTokens: 150 }), 2_000);
+  tracker.record(fleetSnapshots(100, { outputTokens: 25 }), 4_000);
+  tracker.record(fleetSnapshots(100, { outputTokens: 40 }), 6_000);
+
+  const snapshot = tracker.snapshot(6_000);
+  assert.equal(snapshot.outputTokens24h, 65);
+  const observedWh = (400 * 6_000) / 3_600_000;
+  almostEqual(snapshot.whPerOutputToken24h, observedWh / 65);
+});
+
+test("a short unavailable token-source gap preserves the baseline", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record(fleetSnapshots(100, { outputTokens: 1_000 }), 0);
+  const unavailable = fleetSnapshots(100, { outputTokens: 0 });
+  unavailable[0].metrics.llm[0].available = false;
+  tracker.record(unavailable, 2_000);
+  tracker.record(fleetSnapshots(100, { outputTokens: 1_020 }), 4_000);
+
+  assert.equal(tracker.snapshot(4_000).outputTokens24h, 20);
+});
+
+test("a backward clock rebases tokens even when rollback telemetry is unavailable", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record(fleetSnapshots(100, { outputTokens: 100 }), 10_000);
+  tracker.record(fleetSnapshots(100, { outputTokens: 120 }), 12_000);
+
+  const unavailable = fleetSnapshots(100, { outputTokens: 0 });
+  unavailable[0].metrics.llm[0].available = false;
+  tracker.record(unavailable, 5_000);
+  tracker.record(fleetSnapshots(100, { outputTokens: 140 }), 12_000);
+  assert.equal(tracker.snapshot(12_000).outputTokens24h, 20);
+
+  tracker.record(fleetSnapshots(100, { outputTokens: 145 }), 14_000);
+  assert.equal(tracker.snapshot(14_000).outputTokens24h, 25);
+});
+
+test("token observation gaps over 10 seconds and source changes rebase", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record(fleetSnapshots(100, { outputTokens: 100 }), 0);
+  tracker.record(fleetSnapshots(100, { outputTokens: 150 }), 10_001);
+  tracker.record(fleetSnapshots(100, { outputTokens: 160 }), 12_001);
+
+  const changedPort = fleetSnapshots(100, { outputTokens: 900 });
+  changedPort[0].llmPorts[0] = 9000;
+  tracker.record(changedPort, 14_001);
+  const sameChangedPort = fleetSnapshots(100, { outputTokens: 910 });
+  sameChangedPort[0].llmPorts[0] = 9000;
+  tracker.record(sameChangedPort, 16_001);
+
+  assert.equal(tracker.snapshot(16_001).outputTokens24h, 20);
+});
+
+test("token source requires exactly one canonical head and ignores noncanonical heads", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  const withIntruder = fleetSnapshots(100, { outputTokens: 100 });
+  withIntruder.push(
+    nodeSnapshot("spark-intruder", { role: "head", outputTokens: 9_000 })
+  );
+  tracker.record(withIntruder, 0);
+  const withIntruderAgain = fleetSnapshots(100, { outputTokens: 120 });
+  withIntruderAgain.push(
+    nodeSnapshot("spark-intruder", { role: "head", outputTokens: 9_100 })
+  );
+  tracker.record(withIntruderAgain, 2_000);
+
+  const duplicateHeads = fleetSnapshots(100, { outputTokens: 999 });
+  duplicateHeads[1].role = "head";
+  duplicateHeads[1].llmPorts = [8000];
+  duplicateHeads[1].metrics.llm = [
+    { available: true, totalOutputTokens: 500 },
+  ];
+  tracker.record(duplicateHeads, 4_000);
+  tracker.record(fleetSnapshots(100, { outputTokens: 130 }), 6_000);
+
+  assert.equal(tracker.snapshot(6_000).outputTokens24h, 30);
+});
+
+test("token source ignores unavailable siblings but rejects ambiguous available entries", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  const first = fleetSnapshots(100, { outputTokens: 100 });
+  first[0].llmPorts = [7000, 8000, 9000];
+  first[0].metrics.llm = [
+    { available: false, totalOutputTokens: 0 },
+    { available: true, totalOutputTokens: 100 },
+    { available: false, totalOutputTokens: 0 },
+  ];
+  tracker.record(first, 0);
+
+  const second = fleetSnapshots(100, { outputTokens: 120 });
+  second[0].llmPorts = [7000, 8000, 9000];
+  second[0].metrics.llm = [
+    { available: false, totalOutputTokens: 0 },
+    { available: true, totalOutputTokens: 120 },
+    { available: false, totalOutputTokens: 0 },
+  ];
+  tracker.record(second, 2_000);
+
+  const ambiguous = fleetSnapshots(100, { outputTokens: 110 });
+  ambiguous[0].llmPorts = [8000, 9000];
+  ambiguous[0].metrics.llm = [
+    { available: true, totalOutputTokens: 130 },
+    { available: true, totalOutputTokens: 5 },
+  ];
+  tracker.record(ambiguous, 4_000);
+
+  const afterAmbiguous = fleetSnapshots(100, { outputTokens: 140 });
+  tracker.record(afterAmbiguous, 6_000);
+
+  assert.equal(tracker.snapshot(6_000).outputTokens24h, 40);
+});
+
+test("token source requires a matching safe-integer llmPorts entry and counter", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record(fleetSnapshots(100, { outputTokens: 100 }), 0);
+
+  const invalidCounters = [-1, 1.5, Number.MAX_SAFE_INTEGER + 1];
+  for (const [index, invalid] of invalidCounters.entries()) {
+    const snapshots = fleetSnapshots(100, { outputTokens: invalid });
+    tracker.record(snapshots, 2_000 + index * 1_000);
+  }
+
+  const invalidPort = fleetSnapshots(100, { outputTokens: 120 });
+  invalidPort[0].llmPorts[0] = 8000.5;
+  tracker.record(invalidPort, 5_000);
+  const mismatched = fleetSnapshots(100, { outputTokens: 125 });
+  mismatched[0].llmPorts = [];
+  tracker.record(mismatched, 6_000);
+  tracker.record(fleetSnapshots(100, { outputTokens: 130 }), 8_000);
+
+  assert.equal(tracker.snapshot(8_000).outputTokens24h, 30);
+});
+
+test("LLM port reordering and changes rebase instead of cross-counting counters", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record(fleetSnapshots(100, { outputTokens: 100 }), 0);
+
+  const reordered = fleetSnapshots(100, { outputTokens: 900 });
+  reordered[0].llmPorts = [9000, 8000];
+  reordered[0].metrics.llm = [
+    { available: true, totalOutputTokens: 900 },
+    { available: false, totalOutputTokens: 100 },
+  ];
+  tracker.record(reordered, 2_000);
+
+  const sameReordered = fleetSnapshots(100, { outputTokens: 910 });
+  sameReordered[0].llmPorts = [9000, 8000];
+  sameReordered[0].metrics.llm = [
+    { available: true, totalOutputTokens: 910 },
+    { available: false, totalOutputTokens: 100 },
+  ];
+  tracker.record(sameReordered, 4_000);
+
+  assert.equal(tracker.snapshot(4_000).outputTokens24h, 10);
+});
+
+test("Wh per output token is null with zero tokens or without observed energy", () => {
+  const noTokens = new FleetEnergyTracker(noTimerOptions());
+  noTokens.record(fleetSnapshots(100, { outputTokens: 0 }), 0);
+  noTokens.record(fleetSnapshots(100, { outputTokens: 0 }), 2_000);
+  assert.equal(noTokens.snapshot(2_000).outputTokens24h, 0);
+  assert.equal(noTokens.snapshot(2_000).whPerOutputToken24h, null);
+
+  const noEnergy = new FleetEnergyTracker(noTimerOptions());
+  noEnergy.record(fleetSnapshots(100, { outputTokens: 0 }), 0);
+  noEnergy.record(fleetSnapshots(100, { outputTokens: 10 }), 20_000);
+  assert.equal(noEnergy.snapshot(20_000).energy24hKwh, null);
+  assert.equal(noEnergy.snapshot(20_000).whPerOutputToken24h, null);
+});
+
+test("24 hour and 31 day windows prune old energy independently", () => {
+  const now = Date.UTC(2026, 7, 23, 12, 0, 0);
+  const tracker = new FleetEnergyTracker({ ...noTimerOptions(), now: () => now });
+  const intervals = [now - 31 * DAY_MS - 2 * MINUTE_MS, now - 25 * HOUR_MS, now - HOUR_MS];
+  for (const start of intervals) {
+    tracker.record([nodeSnapshot("node-a", { watts: 100 })], start);
+    tracker.record([nodeSnapshot("node-a", { watts: 100 })], start + 1_000);
+  }
+
+  const snapshot = tracker.snapshot(now);
+  const oneIntervalKwh = (100 * 1_000) / 3_600_000 / 1000;
+  almostEqual(snapshot.energy24hKwh, oneIntervalKwh);
+  almostEqual(snapshot.energy31dKwh, 2 * oneIntervalKwh);
+});
+
+test("an exact 24-hour cutoff excludes the completed minute before the boundary", () => {
+  const now = DAY_MS + MINUTE_MS;
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record([nodeSnapshot("node-a", { watts: 100 })], 58_000);
+  tracker.record([nodeSnapshot("node-a", { watts: 100 })], 59_000);
+  tracker.record([nodeSnapshot("node-a", { watts: 100 })], MINUTE_MS);
+  tracker.record([nodeSnapshot("node-a", { watts: 100 })], MINUTE_MS + 1_000);
+
+  const snapshot = tracker.snapshot(now);
+  almostEqual(snapshot.energy24hKwh, (100 * 1_000) / 3_600_000 / 1000);
+  assert.equal(snapshot.nodeCoverage24hMs["node-a"], 1_000);
+});
+
+test("hourly graph returns 24 scalar means oldest-to-newest with nulls for empty windows", () => {
+  const now = Date.UTC(2026, 7, 23, 12, 34, 45);
+  const tracker = new FleetEnergyTracker({ ...noTimerOptions(), now: () => now });
+  tracker.record(fleetSnapshots(100), now - 30 * MINUTE_MS);
+  tracker.record(fleetSnapshots(100), now - 30 * MINUTE_MS + 2_000);
+
+  const hourly = tracker.snapshot(now).hourlyWatts24h;
+  assert.equal(hourly.length, 24);
+  assert.deepEqual(hourly.slice(0, -1), Array(23).fill(null));
+  almostEqual(hourly.at(-1), 400);
+});
+
+test("persistence reload preserves aggregates, token baseline, and does not backfill downtime", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-reload-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  let now = Date.UTC(2026, 7, 23, 12, 0, 0);
+  const timerOptions = { setIntervalFn: () => 1, clearIntervalFn: () => {} };
+
+  const first = new FleetEnergyTracker({ filePath, load: false, now: () => now, ...timerOptions });
+  first.record(fleetSnapshots(100, { outputTokens: 100 }), now);
+  first.record(fleetSnapshots(100, { outputTokens: 150 }), now + 2_000);
+  assert.equal(first.flush(), true);
+  assert.deepEqual(JSON.parse(fs.readFileSync(filePath, "utf8")).tokenCounter, {
+    headId: "node-a",
+    port: 8000,
+    totalOutputTokens: 150,
+    observedAtMs: now + 2_000,
+  });
+  const before = first.snapshot(now + 2_000);
+
+  now += HOUR_MS;
+  const second = new FleetEnergyTracker({ filePath, now: () => now, ...timerOptions });
+  const loaded = second.snapshot(now);
+  almostEqual(loaded.energy24hKwh, before.energy24hKwh);
+  assert.equal(loaded.outputTokens24h, 50);
+
+  second.record(fleetSnapshots(100, { outputTokens: 175 }), now);
+  assert.equal(second.snapshot(now).outputTokens24h, 50);
+  almostEqual(second.snapshot(now).energy24hKwh, before.energy24hKwh);
+  second.record(fleetSnapshots(100, { outputTokens: 180 }), now + 2_000);
+  assert.equal(second.snapshot(now + 2_000).outputTokens24h, 55);
+  almostEqual(second.snapshot(now + 2_000).energy24hKwh, before.energy24hKwh + 0.8 / 3_600);
+});
+
+test("reload migrates legacy version-one state when its node keys match the configured fleet", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-legacy-state-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const coverageMs = Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, 2_000]));
+  const nodeWh = Object.fromEntries(
+    CANONICAL_NODE_IDS.map((id) => [id, (100 * 2_000) / 3_600_000])
+  );
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({
+      version: 1,
+      integrationHighWaterMs: 2_000,
+      buckets: [{
+        minuteStartMs: 0,
+        nodeWh,
+        nodeCoverageMs: coverageMs,
+        fleetWattMs: 400 * 2_000,
+        fleetCoverageMs: 2_000,
+        outputTokens: 25,
+      }],
+    })
+  );
+
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    now: () => 2_000,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+  const snapshot = tracker.snapshot(2_000);
+  assert.equal(snapshot.coverage24hMs, 2_000);
+  assert.equal(snapshot.outputTokens24h, 25);
+  assert.equal(tracker.close(), true);
+
+  const migrated = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.deepEqual(migrated.nodeIds, CANONICAL_NODE_IDS);
+});
+
+test("reload does not restore ephemeral freshness or current-power samples", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-ephemeral-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const now = Date.UTC(2026, 7, 23, 12, 0, 0);
+  const timerOptions = { setIntervalFn: () => 1, clearIntervalFn: () => {} };
+  const first = new FleetEnergyTracker({ filePath, load: false, now: () => now, ...timerOptions });
+  first.record(fleetSnapshots(100), now);
+  first.flush();
+
+  const second = new FleetEnergyTracker({ filePath, now: () => now, ...timerOptions });
+  const loaded = second.snapshot(now);
+  assert.equal(loaded.freshNodeCount, 0);
+  assert.equal(loaded.currentWatts30s, null);
+});
+
+test("freshNodeCount expires when the latest record is future-dated or over 10 seconds old", () => {
+  const tracker = new FleetEnergyTracker(noTimerOptions());
+  tracker.record(fleetSnapshots(100), 10_000);
+
+  assert.equal(tracker.snapshot(9_999).freshNodeCount, 0);
+  assert.equal(tracker.snapshot(20_000).freshNodeCount, 4);
+  assert.equal(tracker.snapshot(20_001).freshNodeCount, 0);
+});
+
+test("reload marks pruned persisted buckets dirty so close durably removes them", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-load-prune-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const now = Date.UTC(2026, 7, 23, 12, 0, 0);
+  const values = Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, 0]));
+  const bucket = (minuteStartMs) => ({
+    minuteStartMs,
+    nodeWh: { ...values },
+    nodeCoverageMs: { ...values },
+    fleetWattMs: 0,
+    fleetCoverageMs: 0,
+    outputTokens: 1,
+  });
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({
+      version: 1,
+      nodeIds: CANONICAL_NODE_IDS,
+      buckets: [bucket(now - 31 * DAY_MS - MINUTE_MS), bucket(now)],
+    })
+  );
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    now: () => now,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+
+  assert.equal(tracker.snapshot(now).outputTokens24h, 1);
+  assert.equal(tracker.close(), true);
+  const saved = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.deepEqual(saved.buckets.map((entry) => entry.minuteStartMs), [now]);
+});
+
+test("reload rejects persisted buckets and integration high-water outside physical bounds", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-invalid-buckets-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const now = 10 * MINUTE_MS;
+  const unsafeAlignedMinute =
+    Math.ceil((Number.MAX_SAFE_INTEGER + 1) / MINUTE_MS) * MINUTE_MS;
+  const values = Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, 0]));
+  const bucket = (minuteStartMs, outputTokens, changes = {}) => ({
+    minuteStartMs,
+    nodeWh: { ...values },
+    nodeCoverageMs: { ...values },
+    fleetWattMs: 0,
+    fleetCoverageMs: 0,
+    outputTokens,
+    ...changes,
+  });
+  const invalid = [
+    bucket(-MINUTE_MS, 1),
+    bucket(unsafeAlignedMinute, 8),
+    bucket(MINUTE_MS, 2, { nodeWh: { ...values, "node-a": 4.000_001 } }),
+    bucket(2 * MINUTE_MS, 3, {
+      nodeCoverageMs: { ...values, "node-b": MINUTE_MS + 1 },
+    }),
+    bucket(3 * MINUTE_MS, 4, { fleetWattMs: 57_600_001 }),
+    bucket(4 * MINUTE_MS, 5, { fleetCoverageMs: MINUTE_MS + 1 }),
+    bucket(5 * MINUTE_MS, 1.5),
+    bucket(6 * MINUTE_MS, Number.MAX_SAFE_INTEGER + 1),
+    bucket(7 * MINUTE_MS, 6, { nodeWh: { ...values, extra: 0 } }),
+  ];
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({
+      version: 1,
+      nodeIds: CANONICAL_NODE_IDS,
+      integrationHighWaterMs: Number.MAX_SAFE_INTEGER + 1,
+      buckets: [...invalid, bucket(now, 7)],
+    })
+  );
+
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    now: () => now,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+  assert.equal(tracker.snapshot(now).outputTokens24h, 7);
+  tracker.close();
+  const saved = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.deepEqual(saved.buckets.map((entry) => entry.minuteStartMs), [now]);
+  assert.equal(saved.integrationHighWaterMs, null);
+});
+
+test("reload rejects relationally impossible buckets while allowing floating tolerance", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-relational-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const zeros = Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, 0]));
+  const thousands = Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, 1_000]));
+  const bucket = (minuteStartMs, outputTokens, changes = {}) => ({
+    minuteStartMs,
+    nodeWh: { ...zeros },
+    nodeCoverageMs: { ...zeros },
+    fleetWattMs: 0,
+    fleetCoverageMs: 0,
+    outputTokens,
+    ...changes,
+  });
+  const invalidNodeEnergy = bucket(0, 1, {
+    nodeWh: { ...zeros, "node-a": 0.07 },
+    nodeCoverageMs: { ...thousands },
+  });
+  const invalidFleetPower = bucket(MINUTE_MS, 2, {
+    nodeCoverageMs: { ...thousands },
+    fleetWattMs: 1_000_000,
+    fleetCoverageMs: 1_000,
+  });
+  const invalidFleetCoverage = bucket(2 * MINUTE_MS, 3, {
+    nodeCoverageMs: { ...thousands, "node-d": 500 },
+    fleetCoverageMs: 600,
+  });
+  const tolerantCoverage = 1_000;
+  const tolerantFleetCoverage = tolerantCoverage + 1e-10;
+  const tolerant = bucket(3 * MINUTE_MS, 7, {
+    nodeWh: Object.fromEntries(
+      CANONICAL_NODE_IDS.map((id) => [
+        id,
+        (240 * tolerantCoverage) / 3_600_000 + 1e-12,
+      ])
+    ),
+    nodeCoverageMs: { ...thousands },
+    fleetWattMs: 960 * tolerantFleetCoverage + 1e-6,
+    fleetCoverageMs: tolerantFleetCoverage,
+  });
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({
+      version: 1,
+      nodeIds: CANONICAL_NODE_IDS,
+      integrationHighWaterMs: 3 * MINUTE_MS + 1_000,
+      buckets: [invalidNodeEnergy, invalidFleetPower, invalidFleetCoverage, tolerant],
+    })
+  );
+
+  const now = 4 * MINUTE_MS;
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    now: () => now,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+  assert.equal(tracker.snapshot(now).outputTokens24h, 7);
+  tracker.close();
+  const saved = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.deepEqual(saved.buckets.map((entry) => entry.minuteStartMs), [3 * MINUTE_MS]);
+});
+
+test("reload rejects energy below estimator minima and fleet energy above node energy", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-minimums-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const zeros = Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, 0]));
+  const oneSecondCoverage = Object.fromEntries(
+    CANONICAL_NODE_IDS.map((id) => [id, 1_000])
+  );
+  const nodeWhAt = (watts) =>
+    Object.fromEntries(
+      CANONICAL_NODE_IDS.map((id) => [id, (watts * 1_000) / 3_600_000])
+    );
+  const bucket = (minuteStartMs, outputTokens, changes) => ({
+    minuteStartMs,
+    nodeWh: { ...zeros },
+    nodeCoverageMs: { ...oneSecondCoverage },
+    fleetWattMs: 0,
+    fleetCoverageMs: 1_000,
+    outputTokens,
+    ...changes,
+  });
+  const belowAllMinimums = bucket(0, 1, {});
+  const belowFleetMinimum = bucket(MINUTE_MS, 2, {
+    nodeWh: nodeWhAt(28.2),
+  });
+  const fleetExceedsNodes = bucket(2 * MINUTE_MS, 4, {
+    nodeWh: nodeWhAt(30),
+    fleetWattMs: 200 * 1_000,
+  });
+  const validMinimum = bucket(3 * MINUTE_MS, 8, {
+    nodeWh: nodeWhAt(28.2),
+    fleetWattMs: 112.8 * 1_000,
+  });
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({
+      version: 1,
+      nodeIds: CANONICAL_NODE_IDS,
+      integrationHighWaterMs: 3 * MINUTE_MS + 1_000,
+      buckets: [belowAllMinimums, belowFleetMinimum, fleetExceedsNodes, validMinimum],
+    })
+  );
+
+  const now = 4 * MINUTE_MS;
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    now: () => now,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+  assert.equal(tracker.snapshot(now).outputTokens24h, 8);
+  tracker.close();
+  const saved = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.deepEqual(saved.buckets.map((entry) => entry.minuteStartMs), [3 * MINUTE_MS]);
+});
+
+test("reload keeps the first valid bucket when persisted minute timestamps are duplicated", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-duplicate-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const now = 10 * MINUTE_MS;
+  const values = Object.fromEntries(CANONICAL_NODE_IDS.map((id) => [id, 0]));
+  const bucket = (outputTokens) => ({
+    minuteStartMs: now,
+    nodeWh: { ...values },
+    nodeCoverageMs: { ...values },
+    fleetWattMs: 0,
+    fleetCoverageMs: 0,
+    outputTokens,
+  });
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({ version: 1, nodeIds: CANONICAL_NODE_IDS, buckets: [bucket(7), bucket(9)] })
+  );
+
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    now: () => now,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+  assert.equal(tracker.snapshot(now).outputTokens24h, 7);
+});
+
+test("truncated persistence warns and starts empty without throwing", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-truncated-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  fs.writeFileSync(filePath, '{"version":1,"buckets":[');
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+  t.after(() => {
+    console.warn = originalWarn;
+  });
+
+  let tracker;
+  assert.doesNotThrow(() => {
+    tracker = new FleetEnergyTracker({
+      filePath,
+      setIntervalFn: () => 1,
+      clearIntervalFn: () => {},
+    });
+  });
+  assert.equal(tracker.snapshot(0).energy31dKwh, null);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /unable to load/);
+});
+
+test("rename failure preserves the prior target and a dirty retry succeeds at mode 0600", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-rename-failure-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const priorContents = "prior-good-state\n";
+  fs.writeFileSync(filePath, priorContents, { mode: 0o666 });
+  fs.chmodSync(filePath, 0o666);
+  let failRename = true;
+  const fileSystem = {
+    ...fs,
+    renameSync(...args) {
+      if (failRename) {
+        failRename = false;
+        const error = new Error("injected rename failure");
+        error.code = "EIO";
+        throw error;
+      }
+      return fs.renameSync(...args);
+    },
+  };
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    fileSystem,
+    load: false,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+  tracker.record(fleetSnapshots(100, { outputTokens: 0 }), 0);
+
+  assert.throws(() => tracker.flush(), /injected rename failure/);
+  assert.equal(fs.readFileSync(filePath, "utf8"), priorContents);
+  assert.deepEqual(fs.readdirSync(dir), [path.basename(filePath)]);
+  assert.equal(tracker.flush(), true);
+  assert.equal(JSON.parse(fs.readFileSync(filePath, "utf8")).version, 1);
+  assert.equal(fs.statSync(filePath).mode & 0o777, 0o600);
+});
+
+test("persistence uses mode 0600 and auto-flush cadence is capped at 30 seconds", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-mode-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  let scheduled;
+  let cleared = false;
+  const timerId = { timer: true };
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    load: false,
+    flushIntervalMs: 60_000,
+    setIntervalFn: (callback, intervalMs) => {
+      scheduled = { callback, intervalMs };
+      return timerId;
+    },
+    clearIntervalFn: (received) => {
+      assert.equal(received, timerId);
+      cleared = true;
+    },
+  });
+
+  assert.equal(scheduled.intervalMs, 30_000);
+  tracker.record(fleetSnapshots(100, { outputTokens: 0 }), 0);
+  scheduled.callback();
+  assert.equal(fs.statSync(filePath).mode & 0o777, 0o600);
+  tracker.close();
+  assert.equal(cleared, true);
+});
+
+test("retention is bounded to 44,640 completed minute buckets plus the active minute", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-retention-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  const start = Date.UTC(2026, 6, 1, 0, 0, 0);
+  let now = start;
+  const completedBuckets = 44_640;
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    load: false,
+    now: () => now,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+
+  for (let index = 0; index < completedBuckets + 2; index += 1) {
+    now = start + index * MINUTE_MS;
+    tracker.record([nodeSnapshot("node-a")], now);
+    tracker.record([nodeSnapshot("node-a")], now + 1_000);
+    now += 1_000;
+  }
+  tracker.flush();
+
+  const saved = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.equal(saved.buckets.length, completedBuckets + 1);
+  assert.equal(saved.buckets.at(-1).minuteStartMs, start + (completedBuckets + 1) * MINUTE_MS);
+});
+
+test("bucket pruning remains correct after a backward clock inserts an older minute", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sparkdash-energy-clock-prune-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const filePath = path.join(dir, "fleet-energy.json");
+  let now = 30 * MINUTE_MS;
+  const tracker = new FleetEnergyTracker({
+    filePath,
+    load: false,
+    now: () => now,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+  });
+  tracker.record([nodeSnapshot("node-a")], now);
+  tracker.record([nodeSnapshot("node-a")], now + 2_000);
+  tracker.record([nodeSnapshot("node-a")], 0);
+  tracker.record([nodeSnapshot("node-a")], 2_000);
+
+  now = 31 * DAY_MS + 20 * MINUTE_MS;
+  tracker.snapshot(now);
+  tracker.flush();
+  const saved = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.deepEqual(saved.buckets.map((bucket) => bucket.minuteStartMs), [30 * MINUTE_MS]);
+});

--- a/server/sparks/__tests__/monitor-lifecycle.test.js
+++ b/server/sparks/__tests__/monitor-lifecycle.test.js
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { SparkMonitor } from "../SparkMonitor.js";
+import {
+  COLLECTION_SUCCESS,
+  SystemCollector,
+  collectionWasSuccessful,
+} from "../../collectors/SystemCollector.js";
 
 function spark() {
   return {
@@ -24,6 +29,66 @@ function validGpu(temperature = 42) {
     throttle: {},
   };
 }
+
+function tagged(result, successful = true) {
+  Object.defineProperty(result, COLLECTION_SUCCESS, {
+    value: successful,
+    enumerable: false,
+  });
+  return result;
+}
+
+test("collector provenance rejects partial GPU and malformed CPU samples", async (t) => {
+  t.mock.method(console, "error", () => {});
+  const remote = new SystemCollector({ id: "remote", isLocal: false });
+  remote._getRemoteGpu = async () => ({
+    ...validGpu(),
+    power: { draw: Number.NaN, limit: 120, systemDraw: 39 },
+  });
+  assert.equal(collectionWasSuccessful(await remote.collectGpu()), false);
+
+  const local = new SystemCollector({ id: "local", isLocal: true });
+  local._getCPUUsage = async () => ({ total: 0, used: 0 });
+  assert.equal(collectionWasSuccessful(await local.collectCpu()), false);
+});
+
+test("monitor publishes per-domain collection provenance", async () => {
+  const monitor = new SparkMonitor(spark());
+  monitor._running = true;
+  monitor.collector.collectGpu = async () => tagged(validGpu());
+
+  await monitor._pollDomain("gpu");
+  assert.equal(monitor._metricCollectionSuccessful.gpu, true);
+
+  monitor.collector.collectGpu = async () => validGpu(43);
+  await monitor._pollDomain("gpu");
+  assert.equal(monitor._metricCollectionSuccessful.gpu, false);
+
+  monitor.updateConfig({ ...spark(), lanIp: "127.0.0.2" });
+  assert.deepEqual(monitor._metricCollectionSuccessful, { gpu: false, cpu: false });
+});
+
+test("a rejected prior-run poll cannot clear current collection provenance", async (t) => {
+  t.mock.method(console, "error", () => {});
+  const monitor = new SparkMonitor(spark());
+  monitor._running = true;
+  let rejectPrior;
+  monitor.collector.collectGpu = () =>
+    new Promise((_resolve, reject) => {
+      rejectPrior = reject;
+    });
+
+  const priorPoll = monitor._pollDomain("gpu");
+  await Promise.resolve();
+  monitor.updateConfig({ ...spark(), lanIp: "127.0.0.2" });
+  monitor.collector.collectGpu = async () => tagged(validGpu(43));
+  await monitor._pollDomain("gpu");
+  assert.equal(monitor._metricCollectionSuccessful.gpu, true);
+
+  rejectPrior(new Error("prior target failed late"));
+  await priorPoll;
+  assert.equal(monitor._metricCollectionSuccessful.gpu, true);
+});
 
 test("a poll from an earlier monitor run cannot commit or clear a restarted poll", async (t) => {
   t.mock.method(console, "log", () => {});

--- a/server/sparks/__tests__/monitor-lifecycle.test.js
+++ b/server/sparks/__tests__/monitor-lifecycle.test.js
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { SparkMonitor } from "../SparkMonitor.js";
+
+function spark() {
+  return {
+    id: "spark-test",
+    name: "Spark Test",
+    lanIp: "127.0.0.1",
+    isLocal: true,
+    llmMonitoring: false,
+    comfyMonitoring: false,
+  };
+}
+
+function validGpu(temperature = 42) {
+  return {
+    temperature,
+    usage: 10,
+    power: { draw: 18.5, limit: 120, systemDraw: 39 },
+    vram: { used: 100, total: 128_000, percentage: 0, available: 120_000 },
+    processes: [],
+    throttle: {},
+  };
+}
+
+test("a poll from an earlier monitor run cannot commit or clear a restarted poll", async (t) => {
+  t.mock.method(console, "log", () => {});
+  t.mock.method(globalThis, "setInterval", () => Symbol("interval"));
+  t.mock.method(globalThis, "clearInterval", () => {});
+  const monitor = new SparkMonitor(spark());
+  monitor._poll = async () => {};
+  const pendingResolvers = [];
+  monitor.collector.collectGpu = () =>
+    new Promise((resolve) => pendingResolvers.push(resolve));
+
+  monitor.start();
+  const priorRunPoll = monitor._pollDomain("gpu");
+  await Promise.resolve();
+  monitor.stop();
+  monitor.start();
+  const currentRunPoll = monitor._pollDomain("gpu");
+  await Promise.resolve();
+
+  pendingResolvers[0](validGpu(41));
+  await priorRunPoll;
+  assert.equal(monitor.snapshot().metrics.gpu.temperature, 0);
+  assert.equal(monitor._lastUpdate.gpu, undefined);
+  assert.ok(monitor._inflight.gpu, "the earlier poll must not clear the current guard");
+
+  pendingResolvers[1](validGpu(42));
+  await currentRunPoll;
+  assert.equal(monitor.snapshot().metrics.gpu.temperature, 42);
+  assert.ok(Number.isFinite(monitor._lastUpdate.gpu));
+  monitor.stop();
+});
+
+test("a poll from before updateConfig cannot commit against the new target", async () => {
+  const monitor = new SparkMonitor(spark());
+  monitor._running = true;
+  const pendingResolvers = [];
+  monitor.collector.collectGpu = () =>
+    new Promise((resolve) => pendingResolvers.push(resolve));
+
+  const priorTargetPoll = monitor._pollDomain("gpu");
+  await Promise.resolve();
+  monitor.updateConfig({ ...spark(), lanIp: "127.0.0.2" });
+  const currentTargetPoll = monitor._pollDomain("gpu");
+  await Promise.resolve();
+
+  pendingResolvers[0](validGpu(41));
+  await priorTargetPoll;
+  assert.equal(monitor.snapshot().metrics.gpu.temperature, 0);
+  assert.ok(monitor._inflight.gpu, "the prior target poll must not clear the current guard");
+
+  pendingResolvers[1](validGpu(42));
+  await currentTargetPoll;
+  assert.equal(monitor.snapshot().metrics.gpu.temperature, 42);
+});
+
+test("a rejected older CPU poll cannot rewind the accepted generation baseline", async () => {
+  const monitor = new SparkMonitor(spark());
+  monitor._running = true;
+  monitor.collector.lastCpuStat = { total: 100, used: 20 };
+  let resolveOlder;
+  let resolveCurrent;
+  let callCount = 0;
+  monitor.collector._getCPUUsage = () => {
+    callCount += 1;
+    if (callCount === 1) return new Promise((resolve) => (resolveOlder = resolve));
+    if (callCount === 2) return new Promise((resolve) => (resolveCurrent = resolve));
+    return Promise.resolve({ total: 250, used: 120 });
+  };
+  monitor.collector._getCPUTemperature = async () => 0;
+  monitor.collector._getCPUPower = async () => ({ draw: 5.2, tdp: 65 });
+
+  const olderPoll = monitor._pollDomain("cpu");
+  await Promise.resolve();
+  monitor.updateConfig({ ...spark(), lanIp: "127.0.0.2" });
+  const currentPoll = monitor._pollDomain("cpu");
+  await Promise.resolve();
+
+  resolveCurrent({ total: 200, used: 100 });
+  await currentPoll;
+  assert.equal(monitor.snapshot().metrics.cpu.usage, 80);
+
+  resolveOlder({ total: 150, used: 70 });
+  await olderPoll;
+  await monitor._pollDomain("cpu");
+  assert.equal(monitor.snapshot().metrics.cpu.usage, 40);
+});
+
+test("a liveness check from an earlier run cannot commit or clear a restarted check", async (t) => {
+  t.mock.method(console, "log", () => {});
+  t.mock.method(globalThis, "setInterval", () => Symbol("interval"));
+  t.mock.method(globalThis, "clearInterval", () => {});
+  const monitor = new SparkMonitor(spark());
+  monitor._poll = async () => {};
+  monitor._readUptime = async () => 123;
+  const pendingResolvers = [];
+  monitor.collector.pingHost = () =>
+    new Promise((resolve) => pendingResolvers.push(resolve));
+
+  monitor.start();
+  const priorRunCheck = monitor._checkOnline();
+  await Promise.resolve();
+  monitor.stop();
+  monitor.start();
+  const currentRunCheck = monitor._checkOnline();
+  await Promise.resolve();
+
+  pendingResolvers[0]();
+  await priorRunCheck;
+  assert.equal(monitor.online, false);
+  assert.ok(monitor._inflight.online, "the earlier check must not clear the current guard");
+
+  pendingResolvers[1]();
+  await currentRunCheck;
+  assert.equal(monitor.online, true);
+  assert.equal(monitor._uptimeSeconds, 123);
+  assert.equal(monitor._inflight.online, false);
+  monitor.stop();
+});
+
+test("a storage refresh from an earlier run cannot commit or clear a restarted refresh", async (t) => {
+  t.mock.method(console, "log", () => {});
+  t.mock.method(globalThis, "setInterval", () => Symbol("interval"));
+  t.mock.method(globalThis, "clearInterval", () => {});
+  const monitor = new SparkMonitor(spark());
+  monitor._poll = async () => {};
+  const pendingResolvers = [];
+  monitor.collector.collectStorage = () =>
+    new Promise((resolve) => pendingResolvers.push(resolve));
+
+  monitor.start();
+  const priorRunRefresh = monitor.refreshDomain("storage");
+  await Promise.resolve();
+  monitor.stop();
+  monitor.start();
+  const currentRunRefresh = monitor.refreshDomain("storage");
+  await Promise.resolve();
+
+  pendingResolvers[0]([{ mount: "/old" }]);
+  await priorRunRefresh;
+  assert.deepEqual(monitor.snapshot().metrics.storage, []);
+  assert.ok(monitor._inflight.storage, "the earlier refresh must not clear the current guard");
+
+  pendingResolvers[1]([{ mount: "/current" }]);
+  await currentRunRefresh;
+  assert.deepEqual(monitor.snapshot().metrics.storage, [{ mount: "/current" }]);
+  assert.equal(monitor._inflight.storage, false);
+  monitor.stop();
+});


### PR DESCRIPTION
## Summary

sparkDash can now report estimated whole-fleet power, rolling 24-hour and 31-day energy, coverage, a 24-hour hourly-watts graph, and watt-hours per output token through `GET /api/fleet-energy`.

This PR is stacked on #59. The monitor/freshness commits remain visible here until that prerequisite merges; the fleet-energy capability itself is the final commit.

Related: #59, #64

## Design decisions

- Samples run independently of WebSocket clients every two seconds.
- A node contributes only when its GPU and CPU collectors explicitly succeeded and both timestamps are at most 10 seconds old.
- Whole-node watts are estimated from GPU board draw, a bounded CPU utilization model, and fixed platform overhead. Values are marked `estimated` because this is not a wall meter.
- Trapezoidal integration stops across gaps longer than 10 seconds. Coverage fields expose missing fleet time instead of silently filling it.
- Minute buckets persist atomically at mode `0600`. The loader rejects corrupt or physically impossible state and prevents restart double-counting.
- Wh/output-token uses one canonical head and rebases across counter resets, source changes, or observation gaps.

## New concepts

### Coverage-aware energy integration

Energy is accumulated only between consecutive valid power samples. Each interval also adds coverage time, so clients can distinguish a low-energy period from an unobserved period. This avoids the common but misleading alternative of carrying the last watt value through outages.

Use this approach for telemetry-derived totals when source gaps are expected. Do not use it when a hardware meter already supplies cumulative energy directly.

## Validation

- `node --test server/sparks/__tests__/monitor-lifecycle.test.js server/sparks/__tests__/fleet-energy.test.js` - 61 passed
- `npm run typecheck` - passed
- `npm run build` - passed
- The deployed v1.8 integration preserved the legacy rolling state, reported all four fresh nodes, and served authenticated LCD reads without container restarts or API errors.
- Code review receipt: complete, no remaining actionable findings.

The unrelated exact-rate timing flakes in the EXL3 and llama.cpp tests are fixed separately in #64.

## Post-Deploy Monitoring & Validation

- Search logs for `FleetEnergyTracker`, `fleet energy sample error`, and `fleet energy shutdown error` for the first hour.
- Watch `freshNodeCount`, `coverage24hMs`, state-file growth, and process event-loop responsiveness.
- Healthy signal: all configured nodes become fresh, current watts is non-null, coverage advances only while all nodes are valid, and the state file stays mode `0600` across a restart.
- Failure signal: impossible watts, advancing coverage during a node outage, state-load warnings, persistence errors, or non-zero shutdown caused by failed persistence. Stop the sampler and roll back this PR if observed; retain the state file for diagnosis.
- Validation window and owner: first hour plus one restart; sparkDash maintainer/operator.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
