### PR TITLE
test: retarget DecodeBench assertions at the lab structured protocol

### DIFF
--- a/server/collectors/__tests__/showcasePrompts.test.js
+++ b/server/collectors/__tests__/showcasePrompts.test.js
@@ -91,12 +91,18 @@ test("catalog prompts exist for text, structural, and mixed pickers", () => {
   assert.ok(textCount >= 2);
 });
 
-test("DecodeBench uses Showcase structural prompts at temperature 0, thinking off", () => {
-  assert.match(benchSrc, /pickShowcasePrompts\("structural"/);
-  assert.match(benchSrc, /withFillToMaxInstruction/);
+test("DecodeBench uses the lab structured protocol at temperature 0, thinking off", () => {
+  // 1.8.3 moved DecodeBench off the Showcase structural catalog + fill-to-max
+  // and onto the lab structured protocol (count 1 -> 200); 1.8.4 added the
+  // output-type picker. These assertions still referenced the removed API.
+  assert.match(benchSrc, /pickDecodeBenchPrompts\(/);
+  assert.match(benchSrc, /decodeBenchPromptForType\(/);
+  assert.match(benchSrc, /normalizeDecodeBenchType\(/);
   assert.match(benchSrc, /temperature:\s*0/);
+  assert.match(benchSrc, /top_p:\s*1/);
   assert.match(benchSrc, /applyThinkingFlags\(body,\s*modelId,\s*false\)/);
   assert.match(benchSrc, /min_tokens:\s*maxTokens/);
+  assert.doesNotMatch(benchSrc, /withFillToMaxInstruction/);
   assert.doesNotMatch(benchSrc, /uniquePrefillPrefix/);
   assert.doesNotMatch(benchSrc, /BENCH_PROMPTS/);
 });


### PR DESCRIPTION
The `DecodeBench uses Showcase structural prompts at temperature 0, thinking off` test fails on a clean `main` (currently e93fc87).

It still asserts the API that 1.8.3 deliberately removed:

```js
assert.match(benchSrc, /pickShowcasePrompts\("structural"/);
assert.match(benchSrc, /withFillToMaxInstruction/);
```

Per CHANGELOG 1.8.3, DecodeBench moved off the Showcase structural catalog + fill-to-max and onto the lab structured protocol (count 1→200); 1.8.4 then added the output-type picker. `DecodeBench.js` now imports `pickDecodeBenchPrompts` / `decodeBenchPromptForType` / `normalizeDecodeBenchType` from `src/shared/llmPrompts.js`, and `withFillToMaxInstruction` is gone.

**Reproduce on main:**

```
$ node --test server/collectors/__tests__/showcasePrompts.test.js
not ok 8 - DecodeBench uses Showcase structural prompts at temperature 0, thinking off
   The input did not match the regular expression /pickShowcasePrompts\("structural"/
# pass 7
# fail 1
```

**This PR** retargets the assertions at the current API and pins the protocol in the direction it actually moved:

- asserts `pickDecodeBenchPrompts` / `decodeBenchPromptForType` / `normalizeDecodeBenchType`
- adds `top_p: 1` (part of the documented lab protocol, previously unasserted)
- turns `withFillToMaxInstruction` into a negative assertion so a regression back to fill-to-max is caught

The five protocol assertions that still hold (`temperature: 0`, `applyThinkingFlags(body, modelId, false)`, `min_tokens: maxTokens`, no `uniquePrefillPrefix`, no `BENCH_PROMPTS`) are untouched. Test-only change; no production code touched.

Found while merging 1.8.5 into a downstream fork.