### PR TITLE
feat: collect and show CPU temperature on DGX Sparks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Format: version sections are listed newest first.
 
 ## [Unreleased]
 
+### Added
+- **DGX Spark CPU temperature** — remote Sparks collect CPU temp over SSH with the same hwmon allowlist as hosts (`acpitz` / `coretemp` / `k10temp` / `zenpower`; NVMe / CX7 filtered out). Overview shows a CPU bar and Spark pages show a CPU row on the GPU panel when the reading is above 0°C.
+
 ---
 
 ## [1.8.5] — 2026-08-28

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -1001,28 +1001,33 @@ export class SystemCollector {
     }
   }
 
-  async _getRemoteCpu() {
-    try {
-      const cmd = [
-        "cat /proc/stat | head -1",
-        "echo '---'",
-        "cat /proc/cpuinfo | grep -E 'CPU architecture|aarch64' | head -1",
-        ...(this.spark.kind === "host"
-          ? [
-              "echo '---'",
-              // Same hwmon-then-thermal priority as local `_getCPUTemperature()`.
-              // GB10 also exposes nvme/mlx5 sensors; the name allowlist keeps those out.
-              'for h in /sys/class/hwmon/*; do n=$(cat "$h/name" 2>/dev/null); case "$n" in coretemp|k10temp|zenpower|acpitz) for t in "$h"/temp*_input; do cat "$t" 2>/dev/null; break; done;; esac; done',
-              "cat /sys/class/thermal/thermal_zone*/temp 2>/dev/null",
-            ]
-          : []),
-      ].join("; ");
+  /**
+   * One SSH round trip: /proc/stat, CPU arch, then the same hwmon-then-thermal
+   * sensor dump local `_getCPUTemperature()` uses. `|| true` on the thermal
+   * glob keeps a missing zone from failing the whole CPU poll (sshExec treats
+   * any non-zero exit as a hard error).
+   */
+  _buildRemoteCpuCommand() {
+    return [
+      "cat /proc/stat | head -1",
+      "echo '---'",
+      "cat /proc/cpuinfo | grep -E 'CPU architecture|aarch64' | head -1",
+      "echo '---'",
+      // GB10 also exposes nvme/mlx5 sensors; the name allowlist keeps those out.
+      'for h in /sys/class/hwmon/*; do n=$(cat "$h/name" 2>/dev/null); case "$n" in coretemp|k10temp|zenpower|acpitz) for t in "$h"/temp*_input; do cat "$t" 2>/dev/null; break; done;; esac; done',
+      "cat /sys/class/thermal/thermal_zone*/temp 2>/dev/null || true",
+    ].join("; ");
+  }
 
-      const output = await sshExec(this.spark, cmd);
+  async _getRemoteCpu(sshExecutor = sshExec) {
+    try {
+      const cmd = this._buildRemoteCpuCommand();
+
+      const output = await sshExecutor(this.spark, cmd);
       const sections = output.split("---");
       const statOut = sections[0]?.trim() || "";
       const cpuinfoOut = sections[1]?.trim() || "";
-      const tempOut = this.spark.kind === "host" ? sections[2] || "" : "";
+      const tempOut = sections[2] || "";
 
       const cpuStat = this._parseCPUUsage(statOut);
       const totalDiff = cpuStat.total - (this.lastCpuStat?.total || cpuStat.total);
@@ -1038,7 +1043,7 @@ export class SystemCollector {
 
       return {
         usage,
-        temperature: this.spark.kind === "host" ? this._parseSensorTemp(tempOut) : 0,
+        temperature: this._parseSensorTemp(tempOut),
         draw: Math.round(draw * 10) / 10,
         tdp: Math.round(tdp),
       };

--- a/server/collectors/__tests__/SystemCollector.cpuTemp.test.js
+++ b/server/collectors/__tests__/SystemCollector.cpuTemp.test.js
@@ -5,6 +5,38 @@ import { SystemCollector } from "../SystemCollector.js";
 const c = Object.create(SystemCollector.prototype);
 const parse = (raw) => c._parseSensorTemp(raw);
 
+test("remote CPU command always includes the sensor dump", () => {
+  const spark = new SystemCollector({ id: "spark-test", kind: "spark" });
+  const host = new SystemCollector({ id: "host-test", kind: "host" });
+  const sparkCmd = spark._buildRemoteCpuCommand();
+  const hostCmd = host._buildRemoteCpuCommand();
+  assert.equal(sparkCmd, hostCmd);
+  assert.match(sparkCmd, /coretemp\|k10temp\|zenpower\|acpitz/);
+  assert.match(sparkCmd, /thermal_zone\*\/temp/);
+  assert.match(sparkCmd, /\|\| true$/);
+  assert.equal((sparkCmd.match(/echo '---'/g) || []).length, 2);
+});
+
+test("remote CPU collection returns temperature for DGX Spark nodes", async () => {
+  const collector = new SystemCollector({ id: "spark-test", kind: "spark" });
+  const result = await collector._getRemoteCpu(async (spark, command) => {
+    assert.equal(spark.id, "spark-test");
+    assert.match(command, /coretemp\|k10temp\|zenpower\|acpitz/);
+    assert.match(command, /thermal_zone\*\/temp/);
+    assert.equal((command.match(/echo '---'/g) || []).length, 2);
+    return [
+      "cpu 100 0 40 860 0 0 0 0",
+      "---",
+      "CPU architecture: 8",
+      "---",
+      "70900",
+    ].join("\n");
+  });
+
+  assert.equal(result.temperature, 70.9);
+  assert.equal(result.tdp, 65);
+});
+
 test("converts millidegrees to Celsius", () => {
   assert.equal(parse("70900"), 70.9);
   assert.equal(parse("69200"), 69.2);

--- a/src/components/OverviewPage/OverviewPage.tsx
+++ b/src/components/OverviewPage/OverviewPage.tsx
@@ -227,13 +227,17 @@ function SparkCard({
               );
             })()}
             <MetricBar
-              label={spark.kind === "host" ? "GPU" : "Temperature"}
+              label={
+                spark.kind === "host" || (spark.metrics.cpu?.temperature ?? 0) > 0
+                  ? "GPU"
+                  : "Temperature"
+              }
               value={displayTemp}
               max={temperatureUnit === "fahrenheit" ? 212 : 100}
               color={tempBarColor}
               caption={tempLabel}
             />
-            {spark.kind === "host" && (spark.metrics.cpu?.temperature ?? 0) > 0 && (() => {
+            {(spark.metrics.cpu?.temperature ?? 0) > 0 && (() => {
               const cpuRaw = spark.metrics.cpu?.temperature ?? 0;
               const cpuDisplay =
                 temperatureUnit === "fahrenheit" ? celsiusToFahrenheit(cpuRaw) : cpuRaw;

--- a/src/components/SparkPage/GpuPanel.tsx
+++ b/src/components/SparkPage/GpuPanel.tsx
@@ -1,4 +1,4 @@
-import type { GpuMetrics } from "../../api/types";
+import type { CpuMetrics, GpuMetrics } from "../../api/types";
 import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
 import { ActivityIcon } from "../ui/icons";
@@ -7,6 +7,8 @@ import { useMetricsHistoryTail } from "../../hooks/metricsStore";
 
 interface GpuPanelProps {
   gpu: GpuMetrics | null;
+  /** When set and temperature > 0, show a CPU temp row (DGX Spark pages). */
+  cpu?: CpuMetrics | null;
   sparkId: string;
   temperatureUnit: "celsius" | "fahrenheit";
   className?: string;
@@ -43,9 +45,10 @@ function MetricRow({
   );
 }
 
-export function GpuPanel({ gpu, sparkId, temperatureUnit, className }: GpuPanelProps) {
+export function GpuPanel({ gpu, cpu, sparkId, temperatureUnit, className }: GpuPanelProps) {
   const tempHistory = useMetricsHistoryTail(sparkId, "gpu.temp");
   const usageHistory = useMetricsHistoryTail(sparkId, "gpu.usage");
+  const cpuTempHistory = useMetricsHistoryTail(sparkId, "cpu.temp");
 
   const temperature = gpu?.temperature ?? 0;
   const displayTemp = temperatureUnit === "fahrenheit" ? celsiusToFahrenheit(temperature) : temperature;
@@ -58,10 +61,23 @@ export function GpuPanel({ gpu, sparkId, temperatureUnit, className }: GpuPanelP
   const vramTotal = gpu?.vram?.total ?? 0;
   const vramPct = gpu?.vram?.percentage ?? 0;
 
+  const cpuTemperature = cpu?.temperature ?? 0;
+  const cpuDisplayTemp =
+    temperatureUnit === "fahrenheit" ? celsiusToFahrenheit(cpuTemperature) : cpuTemperature;
+  const cpuTempLabel =
+    temperatureUnit === "fahrenheit" ? `${cpuDisplayTemp}°F` : `${cpuDisplayTemp}°C`;
+
   const tempColor =
     temperature > 85
       ? "var(--color-danger)"
       : temperature > 65
+        ? "var(--color-warning)"
+        : "var(--color-accent)";
+  // GB10 junction bands (warn 85 / crit 95) — idle CPU sits ~70°C, so GPU 65/85 would pin amber.
+  const cpuTempColor =
+    cpuTemperature > 95
+      ? "var(--color-danger)"
+      : cpuTemperature > 85
         ? "var(--color-warning)"
         : "var(--color-accent)";
 
@@ -85,6 +101,14 @@ export function GpuPanel({ gpu, sparkId, temperatureUnit, className }: GpuPanelP
         spark={<Sparkline data={tempHistory} color={tempColor} width={180} />}
         value={<span className="text-text-strong">{tempLabel}</span>}
       />
+      {cpuTemperature > 0 && (
+        <MetricRow
+          label="CPU"
+          color={cpuTempColor}
+          spark={<Sparkline data={cpuTempHistory} color={cpuTempColor} width={180} />}
+          value={<span className="text-text-strong">{cpuTempLabel}</span>}
+        />
+      )}
       <div className="flex justify-between text-sm">
         <span className="text-muted">GPU Power</span>
         <span className="font-tabular text-sm text-text">

--- a/src/components/SparkPage/RamPanel.tsx
+++ b/src/components/SparkPage/RamPanel.tsx
@@ -25,7 +25,7 @@ function celsiusToFahrenheit(c: number): number {
 /**
  * System RAM panel — shown for non-Spark GPU hosts, where RAM (system memory)
  * and VRAM (discrete GPU memory) are separate things. CPU temperature lives
- * here because Sparks do not show a CPU panel.
+ * here for hosts; Spark pages show it on the GPU panel.
  */
 export function RamPanel({ ram, cpu, sparkId, temperatureUnit, className }: RamPanelProps) {
   const history = useMetricsHistoryTail(sparkId, "ram.percentage");

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -265,6 +265,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
               <>
                 <GpuPanel
                   gpu={metrics.gpu}
+                  cpu={metrics.cpu}
                   sparkId={spark.id}
                   temperatureUnit={temperatureUnit}
                   className={tailscaleOn ? "md:row-span-3" : "md:row-span-2"}

--- a/src/hooks/metricsStore.ts
+++ b/src/hooks/metricsStore.ts
@@ -95,8 +95,8 @@ export function ingestSnapshots(sparks: SparkSnapshot[]): void {
     }
     if (m.cpu) {
       pushHistory(`${s.id}:cpu.usage`, m.cpu.usage);
-      // CPU temp is only shown for dedicated GPU hosts (not DGX Sparks).
-      if (s.kind === "host" && m.cpu.temperature > 0) {
+      // Skip 0°C so a missing sensor does not draw a fake floor on the sparkline.
+      if (m.cpu.temperature > 0) {
         pushHistory(`${s.id}:cpu.temp`, m.cpu.temperature);
       }
     }


### PR DESCRIPTION
## Summary
- Remote DGX Sparks collect CPU temperature over SSH instead of always returning `0` — same hwmon allowlist as hosts (`acpitz` / `coretemp` / `k10temp` / `zenpower`), with NVMe / CX7 filtered out.
- Overview shows a CPU bar and Spark pages show a CPU row on the GPU panel when the reading is above 0°C. Hosts still use the RAM panel.
- Thermal glob ends with `|| true` so a missing zone cannot fail the whole CPU poll.

Supersedes #60 (collector-only). Related: #34.

## Test plan
- [x] `node --test server/collectors/__tests__/SystemCollector.cpuTemp.test.js` (9 passed)
- [x] `npx tsc --noEmit`
- [x] Live: Spark 1 / Spark 2 remote CPU ~53–54°C; Spark 3 local matches `hwmon0`/`acpitz`
- [x] Overview CPU bars + Spark GPU-panel CPU rows; offline 5090 stays empty
- [ ] Rebuild production image if you review on :5555 (Vite :5173 already has the UI)
