### PR TITLE
fix: copy decode-bench tok/s with one decimal like the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Format: version sections are listed newest first.
 
 ## [Unreleased]
 
+### Fixed
+- **Copy results tok/s** — clipboard text now uses one decimal like the decode-bench table (`31.5` not `31`), and TTFT uses the same mean as the table. ([#57](https://github.com/MiaAI-Lab/sparkDash/issues/57))
+
 ---
 
 ## [1.8.5] — 2026-08-28

--- a/src/components/SparkPage/BenchmarkDialog.tsx
+++ b/src/components/SparkPage/BenchmarkDialog.tsx
@@ -97,7 +97,7 @@ function buildShareText(job: DecodeBenchJob, modelId: string | null): string {
     .map((r) => {
       if (r.totalDecodeTokens > 0 || r.totalCompletionTokens > 0) {
         const agg = r.aggregateDecodeTps > 0 ? r.aggregateDecodeTps : r.meanDecodeTps;
-        return `×${r.concurrency}  ${agg.toFixed(0)} agg  ${r.meanDecodeTps.toFixed(0)}/str  · TTFT ${formatTtft(r.medianTtftMs)}`;
+        return `×${r.concurrency}  ${agg.toFixed(1)} agg  ${r.meanDecodeTps.toFixed(1)}/str  · TTFT ${formatTtft(r.meanTtftMs)}`;
       }
       return `×${r.concurrency}  failed${r.error ? ` — ${r.error}` : ""}`;
     });


### PR DESCRIPTION
## Summary
- Copy results used `toFixed(0)` while the decode-bench table uses `toFixed(1)`, so clipboard tok/s disagreed with what you see (e.g. `31.5` copied as `31`).
- TTFT in the copied text now uses the same mean as the table (it was median).

Fixes #57

## Test plan
- [ ] Run a decode bench, compare table vs Copy results — aggregate and /str should match to one decimal
- [ ] TTFT on the copied line matches the table's TTFT
- [x] `npx tsc --noEmit`
