### PR TITLE
fix: probe current SGLang /server_info and /model_info first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Format: version sections are listed newest first.
 
 ## [Unreleased]
 
+### Fixed
+- **SGLang log spam** — probe current `/server_info` and `/model_info` first; keep the deprecated `/get_*` aliases as fallback so old servers still work. ([#52](https://github.com/MiaAI-Lab/sparkDash/issues/52))
+
 ---
 
 ## [1.8.5] — 2026-08-28

--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ Each configured LLM port gets its own `LlmProbe` instance running in parallel. P
 
 - **llama.cpp** — `/slots` for live decode rates; model from `/props`
 - **ds4-server** (Entrpi/ds4-on-spark) — `/v1/models` (`owned_by: ds4.c`) + Prometheus `ds4_*` token counters for live tok/s
-- **vLLM / sglang** — `/v1/models`; sglang via `/get_server_info` (`last_gen_throughput` when metrics off), vLLM via Prometheus `/metrics` counters (scientific notation supported)
+- **vLLM / sglang** — `/v1/models`; sglang via `/server_info` (`last_gen_throughput` when metrics off; `/get_server_info` fallback), vLLM via Prometheus `/metrics` counters (scientific notation supported)
 
 Rates are derived from per-probe cumulative counter diffs (or SGLang sticky throughput while it moves). Multiple ports can be added or removed at runtime without restarting the monitor.
 

--- a/server/collectors/LlmProbe.js
+++ b/server/collectors/LlmProbe.js
@@ -10,6 +10,9 @@ import { llmProbeHost } from "./llmHost.js";
 
 const FAIL_RESET_THRESHOLD = 3;
 const REDETECT_INTERVAL_MS = 60_000;
+/** Current SGLang names first. Deprecated aliases still work but log a warning per hit. */
+const SGLANG_SERVER_INFO_PATHS = ["/server_info", "/get_server_info"];
+const SGLANG_MODEL_INFO_PATHS = ["/model_info", "/get_model_info"];
 /**
  * SGLang's last_gen_throughput is a sticky gauge (holds last decode rate when
  * idle). Only treat it as live after we observe a change between polls, and
@@ -362,19 +365,28 @@ export class LlmProbe {
     return data.ok === true && typeof data.busy === "boolean";
   }
 
-  /** True when SGLang native server-info endpoints respond. */
-  async _probeIsSglang() {
-    for (const path of ["/get_server_info", "/server_info"]) {
+  /**
+   * First successful SGLang JSON from `paths` (current name, then deprecated alias).
+   * @param {string[]} paths
+   * @returns {Promise<object|null>}
+   */
+  async _fetchSglangJson(paths) {
+    for (const path of paths) {
       try {
         const res = await this._fetch(`${this.baseUrl}${path}`);
         if (!res.ok) continue;
         const data = await res.json().catch(() => null);
-        if (data && typeof data === "object" && !Array.isArray(data)) return true;
+        if (data && typeof data === "object" && !Array.isArray(data)) return data;
       } catch {
         /* try next */
       }
     }
-    return false;
+    return null;
+  }
+
+  /** True when SGLang native server-info endpoints respond. */
+  async _probeIsSglang() {
+    return (await this._fetchSglangJson(SGLANG_SERVER_INFO_PATHS)) != null;
   }
 
   /** True when Prometheus /metrics exposes ds4-server series (ds4-on-spark). */
@@ -456,26 +468,24 @@ export class LlmProbe {
     }
 
     // SGLang: native info endpoints. Skip on known vLLM/ds4 to avoid 404 spam.
+    // Prefer /server_info — /get_server_info is a deprecated alias that logs every poll.
     if (this.backendType === "sglang" || this.backendType == null) {
-      try {
-        const sgRes = await this._fetch(`${this.baseUrl}/get_server_info`);
-        if (sgRes.ok) {
-          this.backendType = "sglang";
-          const sgData = await sgRes.json();
-          // Load before last_gen_throughput so inflight can keep a steady rate live.
-          await this._probeSglangLoad();
-          this._applySglangServerInfo(sgData, dtSec);
-          // Engine tile: Active vs Sleeping. SGLang has no live sleep gauge
-          // (sleep_on_idle is a launch flag, not current state). A reachable
-          // server with weights resident is Active / ready.
-          if (this.gpuMemoryUtilization == null) this.gpuMemoryUtilization = 1;
-        }
-      } catch {}
+      const sgData = await this._fetchSglangJson(SGLANG_SERVER_INFO_PATHS);
+      if (sgData) {
+        this.backendType = "sglang";
+        // Load before last_gen_throughput so inflight can keep a steady rate live.
+        await this._probeSglangLoad();
+        this._applySglangServerInfo(sgData, dtSec);
+        // Engine tile: Active vs Sleeping. SGLang has no live sleep gauge
+        // (sleep_on_idle is a launch flag, not current state). A reachable
+        // server with weights resident is Active / ready.
+        if (this.gpuMemoryUtilization == null) this.gpuMemoryUtilization = 1;
+      }
     }
 
     if (this.backendType === "sglang") {
       // Prometheus is optional (--enable-metrics). Do not mix those counters
-      // into lastTokenCounts when /get_server_info already produced live rates.
+      // into lastTokenCounts when server-info already produced live rates.
       try {
         const metricsRes = await this._fetch(`${this.baseUrl}/metrics`);
         if (metricsRes.ok) {
@@ -740,7 +750,7 @@ export class LlmProbe {
   }
 
   /**
-   * Apply SGLang /get_server_info.
+   * Apply SGLang /server_info (or deprecated /get_server_info).
    * Older builds expose total_input_tokens / total_output_tokens.
    * Current builds (metrics often off) expose sticky last_gen_throughput under
    * internal_states[i]. Only treat it as live after the value changes between
@@ -1028,9 +1038,9 @@ export class LlmProbe {
     );
   }
 
-  /** Prefer SGLang /get_model_info (or /model_info) over raw HF cache paths. */
+  /** Prefer SGLang /model_info (or deprecated /get_model_info) over raw HF cache paths. */
   async _enrichSglangModelInfo() {
-    for (const path of ["/get_model_info", "/model_info"]) {
+    for (const path of SGLANG_MODEL_INFO_PATHS) {
       try {
         const res = await this._fetch(`${this.baseUrl}${path}`);
         if (!res.ok) continue;

--- a/server/collectors/LlmStreaming.js
+++ b/server/collectors/LlmStreaming.js
@@ -115,21 +115,23 @@ export async function readServerGenerationTokens(baseUrl, opts = {}) {
     /* try next */
   }
 
-  // SGLang
-  try {
-    const res = await fetch(`${baseUrl}/get_server_info`, {
-      signal: AbortSignal.timeout(5_000),
-      headers,
-    });
-    if (res.ok) {
-      const data = await res.json();
-      if (data?.total_output_tokens != null) {
-        const v = Number(data.total_output_tokens);
-        if (Number.isFinite(v)) return v;
+  // SGLang — current /server_info first; /get_server_info is a deprecated alias.
+  for (const path of ["/server_info", "/get_server_info"]) {
+    try {
+      const res = await fetch(`${baseUrl}${path}`, {
+        signal: AbortSignal.timeout(5_000),
+        headers,
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data?.total_output_tokens != null) {
+          const v = Number(data.total_output_tokens);
+          if (Number.isFinite(v)) return v;
+        }
       }
+    } catch {
+      /* try next */
     }
-  } catch {
-    /* ignore */
   }
 
   return null;

--- a/server/collectors/__tests__/LlmProbe.sglang.test.js
+++ b/server/collectors/__tests__/LlmProbe.sglang.test.js
@@ -67,6 +67,81 @@ test("_probeIsSglang: true when /get_server_info returns JSON object", async () 
   assert.equal(await probe._probeIsSglang(), true);
 });
 
+test("_probeIsSglang: prefers /server_info and skips deprecated /get_server_info", async () => {
+  const probe = new LlmProbe({ lanIp: "127.0.0.1" }, 30000);
+  const hits = [];
+  probe._fetch = async (url) => {
+    const u = String(url);
+    hits.push(u.slice(u.lastIndexOf("/")));
+    if (u.endsWith("/server_info")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ version: "0.5.0", model_path: "org/model" }),
+      };
+    }
+    if (u.endsWith("/get_server_info")) {
+      assert.fail("must not call deprecated /get_server_info when /server_info works");
+    }
+    return { ok: false, status: 404, json: async () => ({}) };
+  };
+  assert.equal(await probe._probeIsSglang(), true);
+  assert.deepEqual(hits, ["/server_info"]);
+});
+
+test("probe: prefers /server_info and /model_info over deprecated aliases", async () => {
+  const probe = new LlmProbe({ lanIp: "10.0.0.1" }, 30000);
+  probe.serverIsOpenAI = true;
+  probe.backendType = "sglang";
+  probe.authOpen = true;
+  probe._lastDetectAt = Date.now();
+  probe.lastProbeTime = Date.now() - 2000;
+  const hits = [];
+  probe._fetch = async (url) => {
+    const u = String(url);
+    const path = u.slice(u.lastIndexOf("/"));
+    hits.push(path);
+    if (u.endsWith("/v1/models")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{ id: "org/model", owned_by: "sglang", max_model_len: 8192 }],
+        }),
+      };
+    }
+    if (u.endsWith("/server_info")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          model_path: "org/model",
+          context_length: 8192,
+          internal_states: [{ last_gen_throughput: 0 }],
+        }),
+      };
+    }
+    if (u.endsWith("/model_info")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ model_path: "org/ShortName" }),
+      };
+    }
+    if (u.endsWith("/get_server_info") || u.endsWith("/get_model_info")) {
+      assert.fail(`must not call deprecated ${path} when current endpoints work`);
+    }
+    return { ok: false, status: 404, json: async () => ({}), text: async () => "" };
+  };
+  const snap = await probe.probe();
+  assert.equal(snap.backend, "sglang");
+  assert.equal(snap.modelId, "org/ShortName");
+  assert.equal(hits.includes("/get_server_info"), false);
+  assert.equal(hits.includes("/get_model_info"), false);
+  assert.equal(hits.includes("/server_info"), true);
+  assert.equal(hits.includes("/model_info"), true);
+});
+
 test("_probeIsSglang: false when endpoints missing", async () => {
   const probe = new LlmProbe({ lanIp: "127.0.0.1" }, 8000);
   probe._fetch = async () => ({ ok: false, status: 404, json: async () => ({}) });


### PR DESCRIPTION
## Summary
- SGLang still serves `/get_server_info` and `/get_model_info` but logs a deprecation warning on every hit. The 2s LLM poll used those first, so SGLang hosts got warning spam.
- Probe `/server_info` and `/model_info` first; keep the `/get_*` aliases as fallback for older servers.
- Same order in showcase/bench token reads (`LlmStreaming`).

Fixes #52

## Test plan
- [x] `node --test` SGLang / vLLM / EXL3 / streaming tests (57 passed), including new tests that fail if the deprecated paths are hit when current ones work
- [ ] Point sparkDash at an SGLang server and confirm its logs no longer print the `/get_server_info` / `/get_model_info` deprecation warning every poll
- [ ] Older SGLang with only `/get_*` still detects and reports tok/s
