### PR TITLE
fix: reuse SSH transports for remote collectors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ POLL_INTERVAL_LLM=2000
 POLL_INTERVAL_BANDWIDTH=1000
 # Optional: ssh -i path inside the container when the key is not a default OpenSSH name
 # SSH_IDENTITY_FILE=/root/.ssh/id_ed25519
+# Reuse authenticated SSH transports for remote polling. Set to 0 to disable.
+SSH_CONTROL_PERSIST_SECONDS=60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Format: version sections are listed newest first.
 
 ## [Unreleased]
 
+### Fixed
+- **Remote SSH session churn** — collectors reuse an authenticated SSH transport instead of creating a full SSH/PAM login for every metric poll. `SSH_CONTROL_PERSIST_SECONDS=0` restores one connection per command if needed.
+
 ---
 
 ## [1.8.6] — 2026-09-01

--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Copy `.env.example` to `.env` if needed:
 | `HOST_SYS_PATH` | `/host/sys` | Host sys mount |
 | `HOST_ROOT_PATH` | `/host/root` | Host root mount |
 | `SSH_IDENTITY_FILE` | _(unset)_ | Path **inside the process** to a private key (`ssh -i`). Use when the bind-mount is not a default OpenSSH name. |
+| `SSH_CONTROL_PERSIST_SECONDS` | `60` | Reuse authenticated SSH transports for remote collectors. Set to `0` to disable multiplexing. |
 
 > The listener defaults to `127.0.0.1` (loopback) so the dashboard — which can SSH into and
 > power off your Sparks — isn't reachable on the LAN by default. Set `BIND_HOST` to the host's
@@ -482,7 +483,7 @@ Choice is stored in `localStorage`.
 
 ### Local vs remote Sparks
 
-One `SystemCollector` path for both modes. When `spark.isLocal` is true, metrics come from host sysfs/proc and `nvidia-smi` (often via nsenter into the host namespace). Remote Sparks wrap the same commands in a shared `sshExec()` helper (key agent or `sshpass`). For `kind: "host"` units, actual hardware (GPU model, driver version, CPU, RAM) is detected once and cached in place of the static DGX Spark specs, and GPU VRAM comes straight from `nvidia-smi` while system RAM is read from `/proc/meminfo`.
+One `SystemCollector` path for both modes. When `spark.isLocal` is true, metrics come from host sysfs/proc and `nvidia-smi` (often via nsenter into the host namespace). Remote Sparks wrap the same commands in a shared `sshExec()` helper (key agent or `sshpass`). The helper reuses an authenticated OpenSSH transport by default so frequent metric polls do not create a new SSH/PAM login lifecycle each time. Set `SSH_CONTROL_PERSIST_SECONDS=0` to disable reuse. For `kind: "host"` units, actual hardware (GPU model, driver version, CPU, RAM) is detected once and cached in place of the static DGX Spark specs, and GPU VRAM comes straight from `nvidia-smi` while system RAM is read from `/proc/meminfo`.
 
 ### Graceful degradation
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,3 +36,4 @@ services:
       - HOST_PROC_PATH=/host/proc
       - HOST_SYS_PATH=/host/sys
       - HOST_ROOT_PATH=/host/root
+      - SSH_CONTROL_PERSIST_SECONDS=${SSH_CONTROL_PERSIST_SECONDS:-60}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,4 @@ services:
       - HOST_PROC_PATH=/host/proc
       - HOST_SYS_PATH=/host/sys
       - HOST_ROOT_PATH=/host/root
+      - SSH_CONTROL_PERSIST_SECONDS=${SSH_CONTROL_PERSIST_SECONDS:-60}

--- a/server/collectors/__tests__/ssh.multiplex.test.js
+++ b/server/collectors/__tests__/ssh.multiplex.test.js
@@ -1,7 +1,24 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
-import { ensureMultiplexReady, sshMultiplexConfig } from "../ssh.js";
+import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
+import { ensureMultiplexReady, sshExec, sshMultiplexConfig } from "../ssh.js";
+
+function mockExec(t, handler) {
+  const mocked = t.mock.method(childProcess, "execFile", handler);
+  syncBuiltinESMExports();
+  t.after(() => {
+    mocked.mock.restore();
+    syncBuiltinESMExports();
+  });
+}
+
+function unit(id) {
+  return { id, ssh: { host: "10.0.0.2", user: "sparky" } };
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
 
 test("builds a private, isolated control socket config", () => {
   delete process.env.SSH_CONTROL_PERSIST_SECONDS;
@@ -47,4 +64,69 @@ test("gates concurrent cold probes behind one connection setup", async () => {
   releaseProbe();
   await Promise.all([initial, follower]);
   assert.equal(calls, 1);
+});
+
+test("post-probe transport failure gates recovery and ignores stale failures", async (t) => {
+  const spark = unit("transport-recovery");
+  let probes = 0;
+  let releaseRecovery;
+  let failLate;
+  let brokenCalls = 0;
+  mockExec(t, (_file, args, _options, callback) => {
+    const cmd = args.at(-1);
+    if (cmd === "true") {
+      probes += 1;
+      if (probes === 2) { releaseRecovery = callback; return; }
+    }
+    if (cmd === "late") { failLate = callback; return; }
+    if (cmd === "broken") {
+      brokenCalls += 1;
+      callback(Object.assign(new Error("lost transport"), { code: 255 }), "", "connection lost");
+      return;
+    }
+    callback(null, "ok", "");
+  });
+  assert.equal(await sshExec(spark, "seed"), "ok");
+  const late = assert.rejects(sshExec(spark, "late"), /connection lost/);
+  await tick();
+  await assert.rejects(sshExec(spark, "broken"), /connection lost/);
+  assert.equal(brokenCalls, 1, "failed command is not replayed");
+  const wave = Array.from({ length: 12 }, () => sshExec(spark, "metric"));
+  await tick();
+  assert.equal(probes, 2, "one new probe before TTL expiry");
+  failLate(Object.assign(new Error("lost transport"), { code: 255 }), "", "connection lost");
+  await late;
+  const follower = sshExec(spark, "metric");
+  await tick();
+  assert.equal(probes, 2, "late failure preserves the recovery generation");
+  releaseRecovery(null, "", "");
+  assert.deepEqual(await Promise.all([...wave, follower]), Array(13).fill("ok"));
+});
+
+test("remote command exit does not invalidate a healthy transport", async (t) => {
+  let probes = 0;
+  mockExec(t, (_file, args, _options, callback) => {
+    if (args.at(-1) === "true") probes += 1;
+    if (args.at(-1) === "missing") {
+      callback(Object.assign(new Error("exit 1"), { code: 1 }), "", "not found");
+    } else callback(null, "ok", "");
+  });
+  const spark = unit("remote-exit");
+  await assert.rejects(sshExec(spark, "missing"), /not found/);
+  await sshExec(spark, "metric");
+  assert.equal(probes, 1);
+});
+
+test("timed-out command invalidates multiplex readiness", async (t) => {
+  let probes = 0;
+  mockExec(t, (_file, args, _options, callback) => {
+    if (args.at(-1) === "true") probes += 1;
+    if (args.at(-1) === "slow") {
+      callback(Object.assign(new Error("timed out"), { killed: true, signal: "SIGTERM", code: null }), "", "");
+    } else callback(null, "ok", "");
+  });
+  const spark = unit("timeout-recovery");
+  await assert.rejects(sshExec(spark, "slow"), /timed out/);
+  await Promise.all([sshExec(spark, "metric"), sshExec(spark, "metric")]);
+  assert.equal(probes, 2);
 });

--- a/server/collectors/__tests__/ssh.multiplex.test.js
+++ b/server/collectors/__tests__/ssh.multiplex.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { ensureMultiplexReady, sshMultiplexConfig } from "../ssh.js";
+
+test("builds a private, isolated control socket config", () => {
+  delete process.env.SSH_CONTROL_PERSIST_SECONDS;
+  const config = sshMultiplexConfig({ id: "spark-2" }, "10.0.0.2", "sparky", "key", null);
+  assert.equal(config.persistSeconds, 60);
+  assert.ok(config.args.includes("ControlMaster=auto"));
+  assert.ok(config.args.includes("ControlPersist=60"));
+  const pathArg = config.args.find((arg) => arg.startsWith("ControlPath="));
+  const socketDir = pathArg.slice("ControlPath=".length).replace(/\/[^/]+$/, "");
+  assert.equal(fs.statSync(socketDir).mode & 0o777, 0o700);
+});
+
+test("isolates password credentials without exposing them", () => {
+  const spark = { id: "test" };
+  const first = sshMultiplexConfig(spark, "192.168.1.2", "user", "pass", "secret-one");
+  const second = sshMultiplexConfig(spark, "192.168.1.2", "user", "pass", "secret-two");
+  assert.notEqual(first.key, second.key);
+  assert.equal(first.args.join(" ").includes("secret-one"), false);
+});
+
+test("supports disable and clamps excessive persistence", () => {
+  process.env.SSH_CONTROL_PERSIST_SECONDS = "0";
+  assert.equal(sshMultiplexConfig({ id: "s" }, "10.0.0.1", "u", "key", null), null);
+  process.env.SSH_CONTROL_PERSIST_SECONDS = "99999";
+  assert.equal(sshMultiplexConfig({ id: "s" }, "10.0.0.1", "u", "key", null).persistSeconds, 3600);
+  delete process.env.SSH_CONTROL_PERSIST_SECONDS;
+});
+
+test("gates concurrent cold probes behind one connection setup", async () => {
+  const config = { key: `gate-${Date.now()}`, persistSeconds: 60 };
+  let releaseProbe;
+  let calls = 0;
+  const initial = ensureMultiplexReady(config, async () => {
+    calls += 1;
+    await new Promise((resolve) => { releaseProbe = resolve; });
+  });
+  await Promise.resolve();
+  const follower = ensureMultiplexReady(config, async () => {
+    calls += 1;
+  });
+  await Promise.resolve();
+  assert.equal(calls, 1);
+  releaseProbe();
+  await Promise.all([initial, follower]);
+  assert.equal(calls, 1);
+});

--- a/server/collectors/ssh.js
+++ b/server/collectors/ssh.js
@@ -83,6 +83,7 @@ export async function ensureMultiplexReady(config, establish) {
 
   try {
     await state.ready;
+    return state;
   } catch (err) {
     if (_multiplexStates.get(config.key) === state) _multiplexStates.delete(config.key);
     throw err;
@@ -225,19 +226,35 @@ export async function sshExec(spark, cmd, options = {}) {
       execFile(file, execArgs, { timeout: timeoutMs, env, maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
         if (err) {
           const msg = stderr?.trim() || err.message;
-          reject(new Error(`SSH to ${targetHost} failed: ${msg}`));
+          reject(new Error(`SSH to ${targetHost} failed: ${msg}`, { cause: err }));
         } else {
           resolve(String(stdout).trim());
         }
       });
     });
 
+  let multiplexState;
   if (multiplex) {
     const probeArgs = [...args];
     probeArgs[probeArgs.length - 1] = "true";
-    await ensureMultiplexReady(multiplex, () => execute(probeArgs));
+    multiplexState = await ensureMultiplexReady(multiplex, () => execute(probeArgs));
   }
-  return execute(args);
+  try {
+    return await execute(args);
+  } catch (err) {
+    // OpenSSH reports transport errors as 255. Signals/timeouts and local
+    // execution errors also leave transport health unknown. Ordinary remote
+    // nonzero exits do not mean the shared connection is dead.
+    const failure = err.cause;
+    const transportFailed = failure?.code === 255 || failure?.killed ||
+      failure?.signal || typeof failure?.code !== "number";
+    // A late failure from an old command must not evict a newer recovery probe.
+    if (multiplex && transportFailed && _multiplexStates.get(multiplex.key) === multiplexState) {
+      _multiplexStates.delete(multiplex.key);
+    }
+    // Never replay the command: the remote side may already have executed it.
+    throw err;
+  }
 }
 
 /**

--- a/server/collectors/ssh.js
+++ b/server/collectors/ssh.js
@@ -6,6 +6,7 @@
  * Password auth uses sshpass -e (password via env), not -p on the command line.
  */
 import { execFile } from "child_process";
+import crypto from "crypto";
 import fs from "fs";
 import { COMFY_PORT, COMFY_PROBE_TIMEOUT_MS, SSH_CONNECT_TIMEOUT } from "../config.js";
 import { isAllowedTargetHost, isValidSshUser } from "../validate.js";
@@ -14,6 +15,88 @@ import { llmProbeHost } from "./llmHost.js";
 // Detect sshpass without shelling out to `which` on every cold call —
 // checking PATH entries directly is faster and avoids spawning a shell.
 let _sshpassAvailable = null;
+const _multiplexStates = new Map();
+const _controlDir = fs.mkdtempSync("/tmp/sparkdash-ssh-");
+const _controlSalt = crypto.randomBytes(32);
+fs.chmodSync(_controlDir, 0o700);
+
+function controlPersistSeconds() {
+  const configured = Number.parseInt(process.env.SSH_CONTROL_PERSIST_SECONDS ?? "60", 10);
+  return Number.isFinite(configured) ? Math.min(3600, Math.max(0, configured)) : 60;
+}
+
+function ensureControlDir() {
+  fs.mkdirSync(_controlDir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(_controlDir, 0o700);
+}
+
+/**
+ * Build an isolated OpenSSH control socket config. Credentials are included
+ * only in the digest so two password records cannot share an authenticated
+ * transport; the secret itself is never exposed in argv or the socket path.
+ */
+export function sshMultiplexConfig(spark, targetHost, user, auth, password) {
+  const persistSeconds = controlPersistSeconds();
+  if (persistSeconds === 0) return null;
+
+  ensureControlDir();
+  const identityFile = process.env.SSH_IDENTITY_FILE || "default";
+  const isolationKey = [spark.id, user, targetHost, auth || "key", identityFile, password || ""].join("\0");
+  const digest = crypto
+    .createHash("sha256")
+    .update(_controlSalt)
+    .update(isolationKey)
+    .digest("hex")
+    .slice(0, 24);
+  return {
+    key: digest,
+    persistSeconds,
+    args: [
+      "-o",
+      "ControlMaster=auto",
+      "-o",
+      `ControlPersist=${persistSeconds}`,
+      "-o",
+      `ControlPath=${_controlDir}/${digest}`,
+    ],
+  };
+}
+
+/** Establish or re-check the master before concurrent pollers run. */
+export async function ensureMultiplexReady(config, establish) {
+  if (!config) return;
+
+  const now = Date.now();
+  let state = _multiplexStates.get(config.key);
+  if (state && now >= state.expiresAt) {
+    _multiplexStates.delete(config.key);
+    state = null;
+  }
+
+  if (!state) {
+    state = {
+      ready: Promise.resolve().then(establish),
+      expiresAt: now + config.persistSeconds * 1000,
+    };
+    _multiplexStates.set(config.key, state);
+  }
+
+  try {
+    await state.ready;
+  } catch (err) {
+    if (_multiplexStates.get(config.key) === state) _multiplexStates.delete(config.key);
+    throw err;
+  }
+}
+
+process.once("exit", () => {
+  try {
+    fs.rmSync(_controlDir, { recursive: true, force: true });
+  } catch {
+    // ControlPersist bounds any master left behind by an abrupt shutdown.
+  }
+});
+
 function sshpassAvailable() {
   if (_sshpassAvailable !== null) return _sshpassAvailable;
   try {
@@ -93,6 +176,8 @@ export async function sshExec(spark, cmd, options = {}) {
   ];
 
   const remote = `${user}@${targetHost}`;
+  const multiplex = sshMultiplexConfig(spark, targetHost, user, auth, password);
+  const multiplexOpts = multiplex?.args || [];
   // Remote command as a single argument — ssh does not invoke a local shell for it
   // when using execFile without a shell. `--` stops option parsing before destination.
   let file;
@@ -123,11 +208,11 @@ export async function sshExec(spark, cmd, options = {}) {
     // Password via env (sshpass -e) — never on argv or in process list as -p
     env.SSHPASS = password;
     file = "sshpass";
-    args = ["-e", "ssh", ...baseOpts, "--", remote, cmd];
+    args = ["-e", "ssh", ...baseOpts, ...multiplexOpts, "--", remote, cmd];
   } else {
     // Key-based SSH (default) — BatchMode prevents hanging on missing keys
     file = "ssh";
-    args = [...baseOpts, "-o", "BatchMode=yes"];
+    args = [...baseOpts, ...multiplexOpts, "-o", "BatchMode=yes"];
     const identityFile = process.env.SSH_IDENTITY_FILE;
     if (identityFile) {
       args.push("-i", identityFile);
@@ -135,16 +220,24 @@ export async function sshExec(spark, cmd, options = {}) {
     args.push("--", remote, cmd);
   }
 
-  return new Promise((resolve, reject) => {
-    execFile(file, args, { timeout: timeoutMs, env, maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
-      if (err) {
-        const msg = stderr?.trim() || err.message;
-        reject(new Error(`SSH to ${targetHost} failed: ${msg}`));
-      } else {
-        resolve(String(stdout).trim());
-      }
+  const execute = (execArgs) =>
+    new Promise((resolve, reject) => {
+      execFile(file, execArgs, { timeout: timeoutMs, env, maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
+        if (err) {
+          const msg = stderr?.trim() || err.message;
+          reject(new Error(`SSH to ${targetHost} failed: ${msg}`));
+        } else {
+          resolve(String(stdout).trim());
+        }
+      });
     });
-  });
+
+  if (multiplex) {
+    const probeArgs = [...args];
+    probeArgs[probeArgs.length - 1] = "true";
+    await ensureMultiplexReady(multiplex, () => execute(probeArgs));
+  }
+  return execute(args);
 }
 
 /**


### PR DESCRIPTION
## Summary

Remote collectors currently create a full SSH/PAM login for every metric poll. Reuse one authenticated OpenSSH transport per remote unit, while keeping each collector command on its own exec channel with the existing timeout and output limit.

- Single-flight initial and recovery probes using `ControlMaster=auto` and `ControlPersist`.
- Isolate sockets by unit, target, user, authentication mode, key identity and credential using a process-salted digest in a private `0700` directory. Passwords stay out of argv and socket paths.
- Invalidate the matching readiness generation when a post-probe command reports a transport failure, timeout, signal or local execution error. Subsequent calls share a fresh probe; late failures cannot evict a newer recovery generation.
- Keep readiness for ordinary remote nonzero exit statuses. Failed commands are never automatically replayed.
- Preserve main's `sshCommandSpec` API for independent tunnel callers.

`SSH_CONTROL_PERSIST_SECONDS` defaults to 60 seconds, is capped at one hour, and accepts `0` to restore one connection per command. Key and `sshpass` authentication are supported.

## Evidence

On a two-DGX-Spark deployment, the old collectors generated about 3.6 complete SSH/PAM login lifecycles per second on the worker. An on/off/on monitor test measured `polkitd` anonymous RSS growth of 0.954 MiB/min, flat while monitoring was stopped, and 0.966 MiB/min after restart. A same-command-rate comparison measured 0.526 MiB/min with independent SSH connections and 0 with a multiplexed connection.

Production validation of the initial transport-reuse change showed a 0.000 MiB/min anonymous-RSS slope in two observation windows; a cold start dropped from 56 SSH authentications to one. These observations support reducing session churn, not a claim to fix an internal polkit allocation bug. The post-probe failure recovery added during review is covered by regression tests; it has not been separately deployed in that production test.

OpenSSH reference: https://man.openbsd.org/ssh_config.5#ControlPersist

## Validation

Updated against main at `e03b9d6`, including its SSH tunnel helper and test fixes.

- SSH multiplex regression suite: **7/7 pass**. Includes post-probe transport failure, one recovery probe for concurrent callers before TTL expiry, stale failures during recovery, ordinary remote exit status, and timeout recovery.
- `npm test`: **197/197 pass**, including the local TCP tunnel tests (requires permission to bind loopback sockets).
- `npm run typecheck`: pass.
- `npm run build`: pass.
- `git diff --check`: pass.
