### PR TITLE
Derive worker card label from head's live model (fail-closed)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -105,6 +105,10 @@ function startMonitor(spark) {
     },
     // Hermes check / update results must not wait for the next broadcast tick.
     onHermesChange: () => forceBroadcast(),
+    // Worker derived label: resolve a head id to its live LLM model id.
+    // Returns null when the head is unknown/offline/model-less so workers
+    // never display a stale model. Display-only; never writes to config.
+    resolveHeadModelId: (headId) => monitors.get(headId)?.headLlmModelId() ?? null,
   });
   monitors.set(spark.id, monitor);
   monitor.start();

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -32,13 +32,18 @@ const ONLINE_GRACE_MS = 10000;
 export class SparkMonitor {
   /**
    * @param {object} spark
-   * @param {{ onWolMac?: (sparkId: string, mac: string) => void }} [options]
+   * @param {{ onWolMac?: (sparkId: string, mac: string) => void, onHermesChange?: () => void, resolveHeadModelId?: ((headId: string) => string | null) }} [options]
    */
   constructor(spark, options = {}) {
     this.spark = spark;
     this._onWolMac = typeof options.onWolMac === "function" ? options.onWolMac : null;
     this._onHermesChange =
       typeof options.onHermesChange === "function" ? options.onHermesChange : null;
+    // Resolver for worker derived label: maps a head spark id to its live
+    // LLM model id (or null when unknown). Wired by index.js from the monitor
+    // map; never writes back to registry config (derived display only).
+    this._resolveHeadModelId =
+      typeof options.resolveHeadModelId === "function" ? options.resolveHeadModelId : null;
     this.collector = new SystemCollector(spark);
 
     // One LlmProbe per port — none when LLM monitoring is off
@@ -230,6 +235,50 @@ export class SparkMonitor {
     return spark?.llmMonitoring !== false;
   }
 
+  /**
+   * Live LLM model id from this monitor's own probes (first non-empty
+   * modelId on an AVAILABLE entry across ports), or null when unknown /
+   * offline / protected. Protected/auth-failure snapshots can retain a
+   * previous modelId with available:false — those entries are skipped so a
+   * dead or locked head never yields a stale model (fail-closed).
+   * @returns {string | null}
+   */
+  headLlmModelId() {
+    const llm = this._metrics?.llm;
+    if (!Array.isArray(llm)) return null;
+    for (const entry of llm) {
+      if (entry?.available !== true) continue;
+      const id = typeof entry?.modelId === "string" ? entry.modelId.trim() : "";
+      if (id) return id;
+    }
+    return null;
+  }
+
+  /**
+   * Derived worker label: mirror the head's live served model. Display-only —
+   * never written back to registry config. Non-null only when ALL hold:
+   * role is worker, workerHeadId points at another spark, and the resolver
+   * yields a non-empty model id. A hand-written workerLabel (non-empty) is a
+   * manual override and takes display priority in the frontend; it does not
+   * suppress this derived value.
+   * @returns {string | null}
+   */
+  workerDerivedLabel() {
+    const spark = this.spark || {};
+    const role = spark.role || (spark.workerNode ? "worker" : "standalone");
+    if (role !== "worker") return null;
+    const headId = typeof spark.workerHeadId === "string" ? spark.workerHeadId.trim() : "";
+    if (!headId || headId === spark.id) return null;
+    if (typeof this._resolveHeadModelId !== "function") return null;
+    let model = null;
+    try {
+      model = this._resolveHeadModelId(headId);
+    } catch {
+      return null;
+    }
+    return typeof model === "string" && model.trim() ? model.trim() : null;
+  }
+
   /** Start or clear the LLM poll timer based on monitoring flag. */
   _restartLlmPollInterval() {
     if (this._llmIntervalId != null) {
@@ -400,6 +449,9 @@ export class SparkMonitor {
       role: this.spark.role || (this.spark.workerNode ? "worker" : "standalone"),
       workerLabel: this.spark.workerLabel || null,
       workerHeadId: this.spark.workerHeadId || null,
+      // Derived display label (head model mirror). Raw workerLabel above is
+      // untouched — frontend prefers a non-empty manual label over this.
+      workerDerivedLabel: this.workerDerivedLabel(),
       llmMonitoring: this._llmMonitoringEnabled(),
       llmPort: ports[0] ?? LLM_PORT,
       llmPorts: ports,

--- a/server/sparks/__tests__/worker-derived-label.test.js
+++ b/server/sparks/__tests__/worker-derived-label.test.js
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SparkMonitor } from "../SparkMonitor.js";
+
+// Real instances, never started (no timers / no I/O in constructors).
+// Head metrics are injected to simulate probe results.
+const head = (id = "h") =>
+  new SparkMonitor({ id, name: id, kind: "spark", role: "head", lanIp: "10.0.0.1" });
+
+const worker = (partial = {}, options = {}) =>
+  new SparkMonitor(
+    {
+      id: "w",
+      name: "w",
+      kind: "spark",
+      role: "worker",
+      lanIp: "10.0.0.2",
+      workerHeadId: "h",
+      workerLabel: null,
+      ...partial,
+    },
+    options,
+  );
+
+const withHead = (workerMon, headMon) => {
+  workerMon._resolveHeadModelId = (headId) =>
+    headId === headMon.spark.id ? headMon.headLlmModelId() : null;
+  return workerMon;
+};
+
+test("worker mirrors head model when head probe is healthy", () => {
+  const h = head();
+  h._metrics.llm = [{ available: true, modelId: "glm-5.3-flash-exl3-abliterated" }];
+  const w = withHead(worker(), h);
+  const snap = w.snapshot();
+  assert.equal(snap.workerDerivedLabel, "glm-5.3-flash-exl3-abliterated");
+  // Raw config label untouched (derived display never writes back).
+  assert.equal(snap.workerLabel, null);
+  assert.equal(w.spark.workerLabel, null);
+});
+
+test("manual workerLabel override is preserved alongside derived (frontend prefers manual)", () => {
+  const h = head();
+  h._metrics.llm = [{ available: true, modelId: "glm-5.3-flash-exl3-abliterated" }];
+  const w = withHead(worker({ workerLabel: "Custom cluster" }), h);
+  const snap = w.snapshot();
+  assert.equal(snap.workerLabel, "Custom cluster");
+  assert.equal(snap.workerDerivedLabel, "glm-5.3-flash-exl3-abliterated");
+});
+
+test("head offline yields no derived label (never a stale model)", () => {
+  const h = head();
+  h._metrics.llm = [{ modelId: null, available: false }]; // failed-probe shape
+  const w = withHead(worker(), h);
+  assert.equal(w.snapshot().workerDerivedLabel, null);
+
+  const h2 = head();
+  h2._metrics.llm = []; // no probe data yet
+  const w2 = withHead(worker(), h2);
+  assert.equal(w2.snapshot().workerDerivedLabel, null);
+});
+
+test("unresolvable or self workerHeadId yields no derived label", () => {
+  const h = head();
+  h._metrics.llm = [{ available: true, modelId: "glm-x" }];
+  const w = withHead(worker({ workerHeadId: "ghost" }), h);
+  assert.equal(w.snapshot().workerDerivedLabel, null);
+
+  const wSelf = withHead(worker({ id: "h", workerHeadId: "h" }), h);
+  assert.equal(wSelf.snapshot().workerDerivedLabel, null);
+});
+
+test("standalone never mirrors, even with a workerHeadId set", () => {
+  const h = head();
+  h._metrics.llm = [{ available: true, modelId: "glm-x" }];
+  const s = withHead(
+    worker({ id: "s", role: "standalone", workerHeadId: "h" }),
+    h,
+  );
+  assert.equal(s.snapshot().workerDerivedLabel, null);
+});
+
+test("headLlmModelId picks first non-empty model across ports", () => {
+  const h = head();
+  h._metrics.llm = [{ available: true, modelId: null }, { available: true, modelId: "  " }, { available: true, modelId: "qwen-x" }];
+  assert.equal(h.headLlmModelId(), "qwen-x");
+  h._metrics.llm = "oops";
+  assert.equal(h.headLlmModelId(), null);
+});
+
+test("unavailable entries are skipped even when they retain a stale modelId", () => {
+  const h = head();
+  h._metrics.llm = [
+    { available: false, modelId: "stale" },
+    { available: true, modelId: "live" },
+  ];
+  assert.equal(h.headLlmModelId(), "live");
+  const w = withHead(worker(), h);
+  assert.equal(w.snapshot().workerDerivedLabel, "live");
+});
+
+test("all entries unavailable yields no derived label", () => {
+  const h = head();
+  h._metrics.llm = [
+    { available: false, modelId: "stale-a" },
+    { available: false, modelId: null },
+  ];
+  assert.equal(h.headLlmModelId(), null);
+  const w = withHead(worker(), h);
+  assert.equal(w.snapshot().workerDerivedLabel, null);
+});

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -486,6 +486,12 @@ export interface SparkSnapshot {
   workerNode?: boolean;
   /** Optional cluster/model label when role is worker */
   workerLabel?: string | null;
+  /**
+   * Derived worker label: live mirror of the head's served model id.
+   * Display-only (never written to config). A non-empty manual workerLabel
+   * takes priority over this in the UI.
+   */
+  workerDerivedLabel?: string | null;
   /** Optional head Spark id when role is worker */
   workerHeadId?: string | null;
   /** Standalone: whether LLM is probed (head always true, worker always false) */

--- a/src/components/OverviewPage/OverviewPage.tsx
+++ b/src/components/OverviewPage/OverviewPage.tsx
@@ -308,8 +308,12 @@ function SparkCard({
               const role = resolveSparkRole(spark);
 
               // Workers have no local LLM API — show cluster/model label instead.
+              // Priority: manual workerLabel override > derived head-model
+              // mirror > generic fallback. Derived never shows a stale model:
+              // the backend nulls it when the head is unresolvable/offline.
               if (role === "worker") {
-                const label = spark.workerLabel?.trim() || "distributed";
+                const label =
+                  spark.workerLabel?.trim() || spark.workerDerivedLabel?.trim() || "distributed";
                 const title = headSparkName
                   ? `${label} · worker of ${headSparkName}`
                   : `${label} · distributed LLM worker`;

--- a/src/components/SparkPage/SparkHeader.tsx
+++ b/src/components/SparkPage/SparkHeader.tsx
@@ -49,8 +49,11 @@ export function SparkHeader({ spark, onEdit }: SparkHeaderProps) {
                     : spark.llmMonitoring === false
                       ? "Standalone — LLM monitoring off"
                       : "Standalone — local LLM API";
+              // Manual override first, then derived head-model mirror.
               const workerLabel =
-                role === "worker" ? spark.workerLabel?.trim() || null : null;
+                role === "worker"
+                  ? spark.workerLabel?.trim() || spark.workerDerivedLabel?.trim() || null
+                  : null;
               return (
                 <>
                   <span


### PR DESCRIPTION
## Summary
Worker cards showed a hand-maintained `workerLabel` that went stale on every topology switch (e.g. 02 still said DeepSeek 0731 after moving to GLM-5.3-Flash EXL3). The snapshot now carries `workerDerivedLabel`, a display-only mirror of the head's live served model.

- Mirror only when ALL hold: role is worker, `workerHeadId` resolves to another spark, and the head probe entry is `available === true` with a non-empty modelId
- Unavailable/protected entries are skipped (they can retain a stale modelId), so a dead head never yields a stale model — fail-closed
- A non-empty manual `workerLabel` still takes display priority; nothing writes back to `config/sparks.json`
- Frontend (Overview + Spark header): manual > derived > fallback

## Test plan
- [x] New `server/sparks/__tests__/worker-derived-label.test.js`: 8 tests (override priority, head-offline, standalone, self/unresolvable head, stale-entry skip pins)
- [x] Full suite: 180/180 pass
- [x] `tsc --noEmit` clean, `vite build` succeeds
- [x] Live-verified on a 2-node TP=2 deployment (head + worker): worker card mirrors head's live model; clearing manual label engages auto mode