### PR TITLE
perf(ssh): reuse one connection per Spark instead of a login per poll

### DIFF
--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -1178,6 +1178,12 @@ export class SystemCollector {
         "echo '---'",
         // WoL MAC for the primary LAN NIC on DGX Spark
         `cat /sys/class/net/${WOL_INTERFACE}/address 2>/dev/null || true`,
+        "echo '---'",
+        // Link speed for every interface, not just the primary one: which
+        // interface is primary only falls out of the route table above, and
+        // fetching that one afterwards cost a second SSH login per poll.
+        // Virtual interfaces have no `speed`; they just come back blank.
+        "for d in /sys/class/net/*/speed; do echo \"$(basename $(dirname $d)):$(cat $d 2>/dev/null)\"; done 2>/dev/null || true",
       ].join("; ");
 
       const output = await sshExec(this.spark, cmd);
@@ -1187,6 +1193,16 @@ export class SystemCollector {
       const ipOut = sections[2]?.trim() || "";
       const operstateOut = sections[3]?.trim() || "";
       const wolMac = normalizeMac(sections[4]?.trim() || "");
+      const speedOut = sections[5]?.trim() || "";
+
+      // Parse link speed lines ("enP7s7:10000"); blank values stay unknown.
+      const speedMap = new Map();
+      for (const line of speedOut.split("\n")) {
+        const idx = line.indexOf(":");
+        if (idx <= 0) continue;
+        const mbps = parseInt(line.slice(idx + 1).trim(), 10);
+        if (Number.isFinite(mbps) && mbps > 0) speedMap.set(line.slice(0, idx), mbps);
+      }
 
       // Parse operstate lines ("enP7s7:up")
       const operstateMap = new Map();
@@ -1256,22 +1272,7 @@ export class SystemCollector {
         primaryInterface = alt?.name ?? primaryInterface;
       }
 
-      let linkSpeedMbps = null;
-      if (primaryInterface) {
-        try {
-          // Interface name is from the kernel; still keep it to safe chars
-          if (/^[a-zA-Z0-9._-]+$/.test(primaryInterface)) {
-            const speedRaw = await sshExec(
-              this.spark,
-              `cat /sys/class/net/${primaryInterface}/speed 2>/dev/null || true`
-            );
-            const n = parseInt(String(speedRaw).trim(), 10);
-            if (Number.isFinite(n) && n > 0) linkSpeedMbps = n;
-          }
-        } catch {
-          /* link speed optional */
-        }
-      }
+      const linkSpeedMbps = (primaryInterface && speedMap.get(primaryInterface)) || null;
 
       return { primaryInterface, linkSpeedMbps, interfaces: tagged, wolMac };
     } catch (err) {

--- a/server/collectors/__tests__/ssh.test.js
+++ b/server/collectors/__tests__/ssh.test.js
@@ -40,3 +40,21 @@ test("sshCommandSpec: missing user throws", () => {
     /SSH config missing/
   );
 });
+
+test("sshCommandSpec: commands share one master connection", () => {
+  const spec = sshCommandSpec(keySpark, { remoteArgv: ["cat /proc/uptime"] });
+  const dash = spec.args.indexOf("--");
+  const master = spec.args.indexOf("ControlMaster=auto");
+  const controlPath = spec.args.find((a) => a.startsWith("ControlPath="));
+  const persist = spec.args.find((a) => a.startsWith("ControlPersist="));
+  assert.ok(master >= 0 && master < dash);
+  assert.ok(controlPath && controlPath.endsWith("sparkdash-%C"));
+  assert.equal(persist, "ControlPersist=300");
+});
+
+test("sshCommandSpec: multiplex:false opts out (tunnels own their connection)", () => {
+  const spec = sshCommandSpec(keySpark, { multiplex: false, extraSshArgs: ["-N"] });
+  assert.ok(spec.args.includes("ControlMaster=no"));
+  assert.ok(spec.args.includes("ControlPath=none"));
+  assert.ok(!spec.args.includes("ControlMaster=auto"));
+});

--- a/server/collectors/llmTunnel.js
+++ b/server/collectors/llmTunnel.js
@@ -151,6 +151,10 @@ export async function openSshLlmTunnel(spark, remotePort, opts = {}) {
   opts.onStatus?.(`Opening SSH tunnel to 127.0.0.1:${p}…`);
 
   const spec = sshCommandSpec(spark, {
+    // A forward has to live on its own connection: killing this process is how
+    // the tunnel gets torn down, and a channel on a shared master would outlive
+    // it.
+    multiplex: false,
     extraSshArgs: [
       "-N",
       "-o",

--- a/server/collectors/ssh.js
+++ b/server/collectors/ssh.js
@@ -7,7 +7,15 @@
  */
 import { execFile } from "child_process";
 import fs from "fs";
-import { COMFY_PORT, COMFY_PROBE_TIMEOUT_MS, SSH_CONNECT_TIMEOUT } from "../config.js";
+import os from "os";
+import path from "path";
+import {
+  COMFY_PORT,
+  COMFY_PROBE_TIMEOUT_MS,
+  SSH_CONNECT_TIMEOUT,
+  SSH_CONTROL_PERSIST,
+  SSH_MULTIPLEX,
+} from "../config.js";
 import { isAllowedTargetHost, isValidSshUser } from "../validate.js";
 import { llmProbeHost } from "./llmHost.js";
 
@@ -55,14 +63,48 @@ function sshpassAvailable() {
 }
 
 /**
+ * `-o` flags that let every poll ride an already-authenticated connection.
+ *
+ * Without them each collector tick pays for a fresh TCP connect, key exchange
+ * and authentication. At the default cadence a single remote Spark takes 217
+ * of those per minute, and on password auth the KDF alone dominates the cost —
+ * the login is far more expensive than the `cat /proc/meminfo` it carries.
+ * With a shared master, the first command connects and the rest open a channel
+ * on the socket that is already up.
+ *
+ * `%C` hashes (local host, user, host, port) into a fixed-length name, so the
+ * socket path can never grow past the ~104 byte sun_path limit no matter how
+ * long the hostname is. A master that died leaves a stale socket behind;
+ * `ControlMaster=auto` notices, reconnects, and replaces it.
+ *
+ * @returns {string[]}
+ */
+function multiplexOpts() {
+  if (!SSH_MULTIPLEX) return ["-o", "ControlMaster=no", "-o", "ControlPath=none"];
+  const controlPath = path.join(os.tmpdir(), "sparkdash-%C");
+  return [
+    "-o",
+    "ControlMaster=auto",
+    "-o",
+    `ControlPath=${controlPath}`,
+    "-o",
+    `ControlPersist=${SSH_CONTROL_PERSIST}`,
+  ];
+}
+
+/**
  * Build file/args/env for an ssh (or sshpass) invocation. No shell interpolation.
  *
  * `extraSshArgs` sit after the shared ConnectTimeout / StrictHostKeyChecking
  * options and before `-- user@host`. `remoteArgv` is the remote command (omit
  * for `-N` tunnels).
  *
+ * Pass `multiplex: false` for invocations that need a connection of their own
+ * — a `-N` port forward has to own its channel so that killing the process
+ * tears the forward down with it.
+ *
  * @param {object} spark
- * @param {{ extraSshArgs?: string[], remoteArgv?: string[] }} [opts]
+ * @param {{ extraSshArgs?: string[], remoteArgv?: string[], multiplex?: boolean }} [opts]
  * @returns {{ file: string, args: string[], env: NodeJS.ProcessEnv, targetHost: string }}
  */
 export function sshCommandSpec(spark, opts = {}) {
@@ -89,6 +131,9 @@ export function sshCommandSpec(spark, opts = {}) {
     `ConnectTimeout=${SSH_CONNECT_TIMEOUT}`,
     "-o",
     "StrictHostKeyChecking=accept-new",
+    ...(opts.multiplex === false
+      ? ["-o", "ControlMaster=no", "-o", "ControlPath=none"]
+      : multiplexOpts()),
   ];
 
   const remote = `${user}@${targetHost}`;

--- a/server/config.js
+++ b/server/config.js
@@ -24,6 +24,15 @@ const LLM_PROBE_TIMEOUT_MS = 3000;
 const COMFY_PROBE_TIMEOUT_MS = parseInt(process.env.COMFY_PROBE_TIMEOUT_MS || "3000", 10);
 const TAILSCALE_PROBE_TIMEOUT_MS = parseInt(process.env.TAILSCALE_PROBE_TIMEOUT_MS || "8000", 10);
 const SSH_CONNECT_TIMEOUT = 5; // seconds
+// Reuse one authenticated SSH connection per Spark instead of dialing a new one
+// for every collector tick. Set SSH_MULTIPLEX=0 to go back to one connection
+// per command (e.g. an sshd with `MaxSessions 1`).
+const SSH_MULTIPLEX = process.env.SSH_MULTIPLEX !== "0";
+// How long an idle master connection lingers, in seconds. Long enough that the
+// slowest loop (Hermes, 10 min) still finds it up would keep a socket open for
+// hours; 5 minutes covers every metric domain and lets a rebooted Spark drop
+// its socket quickly.
+const SSH_CONTROL_PERSIST = process.env.SSH_CONTROL_PERSIST || "300";
 
 // ─── Poll intervals (milliseconds) ───────────────────────
 const POLL_INTERVAL_GPU = parseInt(process.env.POLL_INTERVAL_GPU || "2000", 10);
@@ -101,6 +110,8 @@ export {
   COMFY_PROBE_TIMEOUT_MS,
   TAILSCALE_PROBE_TIMEOUT_MS,
   SSH_CONNECT_TIMEOUT,
+  SSH_MULTIPLEX,
+  SSH_CONTROL_PERSIST,
   POLL_INTERVAL_GPU,
   POLL_INTERVAL_CPU,
   POLL_INTERVAL_NETWORK,

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -6,7 +6,7 @@ import { ComfyProbe } from "../collectors/ComfyProbe.js";
 import { HermesProbe } from "../collectors/HermesProbe.js";
 import { TailscaleProbe } from "../collectors/TailscaleProbe.js";
 import { llmDaily } from "../collectors/LlmDaily.js";
-import { sshTest, sshExec } from "../collectors/ssh.js";
+import { sshExec } from "../collectors/ssh.js";
 import {
   POLL_INTERVAL_GPU,
   POLL_INTERVAL_CPU,
@@ -456,23 +456,28 @@ export class SparkMonitor {
     try {
       if (this.spark.isLocal) {
         await this.collector.pingHost();
+        if (!this._running) return;
+        this.online = true;
+        this.lastOnlineOk = Date.now();
+        // Non-fatal — uptime stays at its previous value or null
+        try {
+          this._uptimeSeconds = await this._readUptime();
+        } catch {
+          /* ignore */
+        }
       } else {
-        const result = await sshTest(this.spark);
+        // One SSH round trip, not two. Reading /proc/uptime already proves the
+        // session came up, so the separate `echo ok` probe told us nothing the
+        // uptime read doesn't — and on a remote Spark every probe is a full
+        // login, which is the expensive half of this loop.
+        const uptimeSeconds = await this._readUptime();
         // Re-check after the (up to 10s) SSH await — `stop()` may have fired
         // mid-flight (removeSpark / updateSpark). Bail before mutating state or
         // running into a stopped registry entry.
         if (!this._running) return;
-        if (!result.ok) throw new Error(result.message);
-      }
-      if (!this._running) return;
-      this.online = true;
-      this.lastOnlineOk = Date.now();
-
-      // Collect system uptime
-      try {
-        this._uptimeSeconds = await this._readUptime();
-      } catch {
-        // Non-fatal — uptime stays at previous value or null
+        this.online = true;
+        this.lastOnlineOk = Date.now();
+        this._uptimeSeconds = uptimeSeconds;
       }
     } catch {
       if (!this._running) return;


### PR DESCRIPTION
## The problem

Every collector poll opens a brand-new SSH connection. `sshExec` shells out to
`ssh`/`sshpass` per command, and nothing is reused between commands or between
ticks.

At the default cadence one remote Spark receives **217 logins per minute**:

| domain | interval | SSH per poll | per minute |
|---|---:|---:|---:|
| gpu | 2s | 1 | 30 |
| cpu | 2s | 1 | 30 |
| ram | 2s (shares `POLL_INTERVAL_CPU`) | 1 | 30 |
| network | 2s | **2** (main command + a second one for link speed) | 60 |
| memory / unified | 2s | 1 | 30 |
| storage | 5s | 1 | 12 |
| liveness | 5s | **2** (`echo ok`, then `cat /proc/uptime`) | 24 |
| NV_ERR journal scan | 60s | 1 | 1 |
| **total** | | | **217** |

Measured on a DGX Spark (Ubuntu 24.04, OpenSSH 9.6, 20 cores) monitored by a
Spark Dash instance with 10 units registered — `journalctl -u ssh` counted 1085
`Accepted` in 5 minutes, i.e. exactly 217/min, matching the table.

What that costs on the monitored Spark, sampled over 60s via cgroup CPU
accounting:

```
ssh.service      (preauth: KEX + the password KDF)   16.4 s/60s  = 0.27 core
user-1000.slice  (session sshd + PAM/logind + cmd)   58.4 s/60s  = 0.97 core
user@1000.service (desktop units, control)            0.34 s/60s ≈ 0
                                                     ─────────────────────
                                                      ~1.25 cores, constantly
```

The metric commands themselves are nowhere near that: the GPU command (three
`nvidia-smi` calls plus `/proc/meminfo`) measures 120 ms of CPU, unified memory
30 ms, the rest single-digit milliseconds — about **5.5 s/min of actual work
inside 75 s/min of cost**. Roughly 90% of what the polling loop burns is
connection setup, and password auth makes it worse because the KDF runs on
every single one of those 217 logins.

The dashboard host pays too: its container measured 106 s of CPU per 30 s
(3.5 cores) with 40–50 concurrent `ssh`/`sshpass` processes. And each login
writes ~3 lines to the target's journal — ~940k lines per Spark per day.

## The change

1. **Multiplex.** `sshCommandSpec` now adds `ControlMaster=auto`,
   `ControlPath=$TMPDIR/sparkdash-%C` and `ControlPersist=300`. The first
   command connects; the rest open a channel on a socket that is already
   authenticated. `%C` hashes (host, user, port) to a fixed-length name so the
   path can't exceed the ~104-byte `sun_path` limit. A master that died leaves
   a stale socket; `ControlMaster=auto` notices and replaces it.

   Opt out with `SSH_MULTIPLEX=0`; tune the idle lifetime with
   `SSH_CONTROL_PERSIST`. The `-N` tunnel in `llmTunnel.js` passes
   `multiplex: false` — a forward has to own its connection so that killing the
   process tears it down.

2. **Fold the network link-speed read into the network round trip.** It was a
   second `sshExec` for `/sys/class/net/<primary>/speed`, issued after parsing
   the route table. The command now dumps speeds for every interface alongside
   the operstate loop it already runs, and the primary is picked from that map.

3. **Fold the uptime read into the liveness check.** `_checkOnline()` ran
   `sshTest()` (`echo ok`) and then `_readUptime()` (`cat /proc/uptime`) — two
   logins to learn one thing. Reading `/proc/uptime` already proves the session
   came up, so it is now the liveness probe. The local-Spark path is unchanged.

Together 2 and 3 remove 42 of the 217 sessions on their own; multiplexing
removes essentially all of what remains.

## Results

Same Spark, same cadence, after the change:

Same Spark, same cadence, after the change (60s cgroup samples, sshd
`Accepted` counted from the journal):

| | before | after |
|---|---:|---:|
| logins per minute | 82 | **0** |
| `ssh.service` CPU / 60s | 4.1 s | **0 s** |
| `user-1000.slice` CPU / 60s | 15.9 s | **2.2 s** |
| **total on the Spark** | **0.33 core** | **0.037 core** |

(The "before" column is already at a slowed-down 5s cadence; against the stock
2s cadence it is 217 logins/min and 1.25 cores, so end to end this is 1.25 →
0.037.) A second Spark measured 0.93 → 0.051 core. The dashboard host went from
3.5 cores to 0.167, and from 40–50 short-lived `ssh` processes to ~20 mostly
idle masters.

`ssh.service` dropping to a flat zero is the direct evidence: preauth and the
password KDF stop happening entirely. What is left on the Spark is close to the
cost of the metric commands themselves. Only one `Accepted` shows up in three
minutes — the master being established.

Snapshot fields all still populate, including the two that moved:
`uptime`, `network.primaryInterface`, `network.linkSpeedMbps`, `network.wolMac`,
and `online` for 8 of 10 registered units (the other two are genuinely down).
The `/proc/stat` diffing still works at the slower cadence — busy units read
94% / 91% GPU, idle ones read 0.

## Tests

`npx tsc --noEmit` clean; `npm test` 192 passed / 0 failed (190 before, plus
two new cases in `server/collectors/__tests__/ssh.test.js` covering the shared
master and the `multiplex: false` opt-out).

## Risk

A wedged master would stall that host's collectors instead of just one poll.
The existing per-command timeouts (`execFile` 10s, 8s for the NV_ERR scan) are
the backstop, and `ControlPersist=300` keeps a socket from outliving a rebooted
Spark for long. `MaxSessions` (default 10) bounds concurrent channels; the
collector loop's in-flight guards keep it to a handful. `SSH_MULTIPLEX=0`
restores the previous behaviour without a rebuild.
