### PR TITLE
fix(ssh): expand ControlPath %C ourselves — socket must fit sun_path

### DIFF
--- a/server/collectors/__tests__/ssh.test.js
+++ b/server/collectors/__tests__/ssh.test.js
@@ -48,7 +48,13 @@ test("sshCommandSpec: commands share one master connection", () => {
   const controlPath = spec.args.find((a) => a.startsWith("ControlPath="));
   const persist = spec.args.find((a) => a.startsWith("ControlPersist="));
   assert.ok(master >= 0 && master < dash);
-  assert.ok(controlPath && controlPath.endsWith("sparkdash-%C"));
+  // The literal must be a SHORT already-expanded path: execFile hands the
+  // value to ssh without shell/template expansion, and the LOCAL socket name
+  // must fit sun_path (~104 bytes on macOS). %C stays expanded-by-hand.
+  const cpValue = controlPath?.slice("ControlPath=".length);
+  assert.ok(cpValue && cpValue.startsWith("/tmp/sparkdash-"), `controlPath: ${controlPath}`);
+  assert.ok(!cpValue.includes("%"));
+  assert.ok(cpValue.length < 104, `control path too long: ${cpValue.length}`);
   assert.equal(persist, "ControlPersist=300");
 });
 

--- a/server/collectors/ssh.js
+++ b/server/collectors/ssh.js
@@ -160,16 +160,31 @@ function sshpassAvailable() {
  * With a shared master, the first command connects and the rest open a channel
  * on the socket that is already up.
  *
- * `%C` hashes (local host, user, host, port) into a fixed-length name, so the
- * socket path can never grow past the ~104 byte sun_path limit no matter how
- * long the hostname is. A master that died leaves a stale socket behind;
- * `ControlMaster=auto` notices, reconnects, and replaces it.
+ * Control-path length is the trap: the socket name is created LOCALLY, so the
+ * whole literal (directory + expanded hash) must stay under the ~104-byte
+ * sun_path limit (108 on Linux). macOS hands every process a ~60-char
+ * per-user $TMPDIR, so os.tmpdir() + the literal `%C` template — which execFile
+ * passes to ssh WITHOUT shell expansion, quotes and all — blew past the limit
+ * and every remote collector died with `unix_listener: path ... too long`.
  *
+ * Fix: expand %C ourselves — same formula OpenSSH uses (SHA1 of
+ * "local host:user:remote host:port", hex) — and hang the socket off a short
+ * fixed /tmp dir instead of $TMPDIR. A master that died leaves a stale socket
+ * behind; `ControlMaster=auto` notices, reconnects, and replaces it.
+ *
+ * @param {{ targetHost: string, user: string }} remote
  * @returns {string[]}
  */
-function multiplexOpts() {
+function multiplexOpts({ targetHost, user }) {
   if (!SSH_MULTIPLEX) return ["-o", "ControlMaster=no", "-o", "ControlPath=none"];
-  const controlPath = path.join(os.tmpdir(), "sparkdash-%C");
+  const localHost = os.hostname();
+  const hash = crypto
+    .createHash("sha1")
+    .update(`${localHost}:${user}:${targetHost}:22`)
+    .digest("hex");
+  // /tmp/sparkdash-<40 hex> = 60 chars — under the limit on every platform,
+  // including macOS's short-sun_path world.
+  const controlPath = path.join("/tmp", `sparkdash-${hash}`);
   return [
     "-o",
     "ControlMaster=auto",
@@ -236,7 +251,7 @@ export function sshCommandSpec(spark, opts = {}) {
   const controlOpts =
     opts.multiplex === false || !SSH_MULTIPLEX
       ? ["-o", "ControlMaster=no", "-o", "ControlPath=none"]
-      : multiplexOpts();
+      : multiplexOpts({ targetHost, user });
   // `--` stops option parsing before destination.
   let file;
   let args;


### PR DESCRIPTION
Follow-up to #84. Reproduced and fixed on macOS against a live Spark.

**Bug:** #84 passed `ControlPath=$TMPDIR/sparkdash-%C` through execFile. execFile does no %-expansion, and the socket is created locally — macOS $TMPDIR is a ~60-char per-user dir, so the literal is ~120 chars, past the ~104-byte sun_path limit. Result: `unix_listener: path ... too long` on EVERY remote collector; remote Sparks render offline with a log-spam per poll tick. Unit tests missed it because they asserted the template string, not the expanded literal.

**Fix:** compute OpenSSH's own %C formula (sha1 of localHost:user:remoteHost:port) and put the socket at /tmp/sparkdash-<hex> = 60 chars on every platform.

**Receipts (fresh clone of 950ac31/ef5b314, run on Mac against nyx-den):**
- Before: every collector erroring (GPU/CPU/RAM/Network/Storage), spark online:false, log spam each tick
- After: online:true, uptime 10,948s, control socket at /tmp/sparkdash-9db2..., zero errors over 70s of polling
- Suite: server 314/314, frontend 23/23, tsc 0 errors, build green
- Live LaunchAgent deploy was unaffected (launchd TMPDIR=/tmp) — this bit any non-launchd run on macOS.