### PR TITLE
fix: add missing SPARKDASH_TOKEN to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       # Secure default: host-networked service listens only on loopback.
       # See docs/REMOTE-ACCESS.md; direct non-loopback binds fail closed.
       - BIND_HOST=${BIND_HOST:-127.0.0.1}
+      - SPARKDASH_TOKEN=${SPARKDASH_TOKEN:-}
       - PORT=5555
       - LLM_PORT=8888
       - NODE_ENV=production


### PR DESCRIPTION
Short PR to allow `SPARKDASH_TOKEN` env variable to be injected inside the `docker-compose.yml` service. Without that, adding the variable inside `.env` is not recognized, making it impossible to start.