### PR TITLE
feat: dedicated CPU panel with auto-aligned two-column Resources layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ sparkDash can **optionally** let you set CPU and GPU clock caps from the dashboa
 | **Hardware-bounded** | Bounds are discovered at runtime — CPU domains from `cpuinfo_min_freq`/`cpuinfo_max_freq` (grouped by domain: X925 big cores / A725 little cores), GPU ceiling from the `nvidia-smi -q -d CLOCK` *Default Applications Clock → Graphics* value. Nothing is hardcoded |
 | **Two CPU domains** | The big (X925) and little (A725) core groups can be capped independently — each core in a domain gets the same `max_perf` value |
 | **Remove the cap** | A "No cap" preset (or clearing the value) restores each core's own hardware maximum (CPU) or removes the `nvidia-smi` lock with `-rgc` (GPU) |
-| **Apply vs Save** | **Apply (this boot only)** writes the cap now and warns that it reverts on reboot; **Save** also rewrites the boot systemd unit (`cpu-clock-cap.service` / `gpu-clock-lock.service`) and runs `daemon-reload`, so it persists |
+| **Apply vs Save** | **Apply (this boot only)** writes the cap now and warns that it reverts on reboot; **Save** also rewrites the boot systemd unit (`cpu-clock-cap.service` / `gpu-clock-lock.service`) and runs `daemon-reload`, so it persists. Both CPU domains share one unit, so a single-domain Save regenerates the sibling domain's lines too (from its current live cap) rather than wiping them — byte-identical whether the host helper or the container path does the writing |
 | **Presets** | "No cap" (= the domain's hardware maximum) per domain; a boot-default revert is just saving the values the boot unit currently installs |
 | **Honest state** | A live-only apply is reported as such (with a "reverts on reboot" warning) and is shown in the UI until a fresh read converges — the dashboard never claims a persisted value it did not write |
 | **Rate limited** | Applies go through the same destructive-action rate limiter as job cancellation |
@@ -262,6 +262,8 @@ sudo ./scripts/install-clock-helper.sh
 ```
 
 The installer copies `scripts/sparkdash-set-clock` to `/usr/local/bin/` and adds `/etc/sudoers.d/sparkdash-clock`, validated with `visudo -c`, allowing **only** that binary to run without a password (`NOPASSWD: /usr/local/bin/sparkdash-set-clock`). It never touches `/etc/sudoers` and grants no other sudo rights.
+
+Because the sudoers rule allows the binary with **no arguments**, helper availability is probed by exercising exactly that granted command: the dashboard first checks the binary exists (`test -x` — missing → "not installed") and then runs `sudo -n <helper>` argumentless. The helper prints its usage line and exits 1, which proves sudo allowed the run; a sudo refusal exits 1 **without** the usage line and is reported as "passwordless sudo not configured" (HTTP 423 with the installer hint). The API always names the real cause.
 
 On a **local** Spark (dashboard container running privileged on the same machine), sparkDash falls back to the container's own root path: live caps go through the container's rw `/sys` and `nvidia-smi`, and persistence goes through `nsenter` into the host mount namespace. Which path was used is reported in the API response (`source`: `helper` or `container`).
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ It also supports **non-Spark units**: any Linux machine with an NVIDIA GPU (e.g.
 - [ComfyUI monitoring](#comfyui-monitoring)
 - [Hermes Agent monitoring](#hermes-agent-monitoring)
 - [Tailnet monitoring](#tailnet-monitoring)
+- [Clock control](#clock-control)
 - [Full changelog](./CHANGELOG.md)
 - [Quick start](#quick-start)
 - [Architecture](#architecture)
@@ -79,6 +80,7 @@ Full history: [CHANGELOG.md](./CHANGELOG.md)
 | **GPU processes** | See the top GPU processes by VRAM usage directly in the GPU panel, including process name and memory allocation |
 | **Spark uptime** | System uptime displayed inline on each Spark header for at-a-glance availability |
 | **Power controls** | Graceful shutdown (SSH host script) and Wake-on-LAN; batch actions on Overview |
+| **Clock control** | Opt-in per unit: click the Clock Cap row in the GPU/CPU panels to set a CPU (X925 / A725) or GPU cap within the discovered hardware range; apply live or persist to the boot unit. One-time helper install, no password in the UI |
 | **Spark roles** | **Head** / **Worker** / **Standalone** — worker label + head link; standalone can disable LLM monitoring; optional hide workers from Overview and tabs |
 | **Unified memory** | GB10 128 GB LPDDR5X pool (~273 GB/s), GPU/CPU split, bandwidth via `nvidia-smi dmon`. Non-Spark hosts show discrete **VRAM** (nvidia-smi) and system **RAM** separately |
 | **Themes** | Dark, light, cool white, OLED — neutral palettes, persisted in `localStorage` |
@@ -233,6 +235,53 @@ Env (optional): `POLL_INTERVAL_TAILSCALE` (default `30000`), `TAILSCALE_PROBE_TI
 
 ---
 
+## Clock control
+
+sparkDash can **optionally** let you set CPU and GPU clock caps from the dashboard. The **Clock Cap** rows in the GPU and CPU panels become clickable: pick a value inside the hardware-legal range (slider + number input, presets included), then either apply it for this boot only or save it to the boot unit so it survives reboot.
+
+### What is supported
+
+| Capability | Details |
+|------------|---------|
+| **Opt-in per Spark** | `clockControlEnabled` (default **off**) in **Edit Spark**; the routes answer 403 while off |
+| **Hardware-bounded** | Bounds are discovered at runtime — CPU domains from `cpuinfo_min_freq`/`cpuinfo_max_freq` (grouped by domain: X925 big cores / A725 little cores), GPU ceiling from the `nvidia-smi -q -d CLOCK` *Default Applications Clock → Graphics* value. Nothing is hardcoded |
+| **Two CPU domains** | The big (X925) and little (A725) core groups can be capped independently — each core in a domain gets the same `max_perf` value |
+| **Remove the cap** | A "No cap" preset (or clearing the value) restores each core's own hardware maximum (CPU) or removes the `nvidia-smi` lock with `-rgc` (GPU) |
+| **Apply vs Save** | **Apply (this boot only)** writes the cap now and warns that it reverts on reboot; **Save** also rewrites the boot systemd unit (`cpu-clock-cap.service` / `gpu-clock-lock.service`) and runs `daemon-reload`, so it persists |
+| **Presets** | "No cap" (= the domain's hardware maximum) per domain; a boot-default revert is just saving the values the boot unit currently installs |
+| **Honest state** | A live-only apply is reported as such (with a "reverts on reboot" warning) and is shown in the UI until a fresh read converges — the dashboard never claims a persisted value it did not write |
+| **Rate limited** | Applies go through the same destructive-action rate limiter as job cancellation |
+
+### Privilege model (no password in the UI)
+
+sparkDash never asks for a password or sudo prompt. Privileged work happens through a tiny root helper on the Spark host, invoked over SSH with a **scoped** passwordless-sudo rule — the same shape as the shutdown feature:
+
+```bash
+# One-time, on the Spark host (as a sudo-capable user):
+sudo ./scripts/install-clock-helper.sh
+```
+
+The installer copies `scripts/sparkdash-set-clock` to `/usr/local/bin/` and adds `/etc/sudoers.d/sparkdash-clock`, validated with `visudo -c`, allowing **only** that binary to run without a password (`NOPASSWD: /usr/local/bin/sparkdash-set-clock`). It never touches `/etc/sudoers` and grants no other sudo rights.
+
+On a **local** Spark (dashboard container running privileged on the same machine), sparkDash falls back to the container's own root path: live caps go through the container's rw `/sys` and `nvidia-smi`, and persistence goes through `nsenter` into the host mount namespace. Which path was used is reported in the API response (`source`: `helper` or `container`).
+
+### Config fields (persisted on the Spark)
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `clockControlEnabled` | `false` | Make the Clock Cap rows editable and enable the clock API routes for this unit |
+
+Env (optional): `SPARKDASH_CLOCK_BIN` (default `/usr/local/bin/sparkdash-set-clock`), `GPU_CLOCK_MAX_MHZ` (last-resort GPU ceiling used only when `-q -d CLOCK` is unparseable; the parsed value always wins), `GPU_CLOCK_LOCK_UNIT`.
+
+### Related API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/sparks/:id/clocks/bounds` | Discovered per-domain ranges, current caps, presets, and helper availability |
+| POST | `/api/sparks/:id/clocks` | Apply/persist a cap: `{ "domain": "gpu", "maxMHz": 2200, "persist": true }` — `maxMHz: null` removes the cap |
+
+---
+
 ## Quick start
 
 ```bash
@@ -356,6 +405,8 @@ sparkDash/
 | POST | `/api/sparks/test` | Ephemeral SSH + LLM (+ Comfy if enabled) test (no persist) |
 | POST | `/api/sparks/:id/test` | Connectivity test (can save password) |
 | POST | `/api/sparks/:id/comfy/cancel` | Cancel ComfyUI job by `promptId` |
+| GET | `/api/sparks/:id/clocks/bounds` | Clock-cap domains with discovered hardware ranges (opt-in) |
+| POST | `/api/sparks/:id/clocks` | Apply / persist a CPU or GPU clock cap (opt-in) |
 | PUT | `/api/sparks/:id/password` | Save SSH password (works offline) |
 | PUT | `/api/sparks/:id/disabled-devices` | Hide storage devices (hot) |
 | PUT | `/api/sparks/:id/disabled-interfaces` | Hide network interfaces (hot) |
@@ -499,6 +550,7 @@ Choice is stored in `localStorage`.
 | `npm run docker:dev` | Dev Compose |
 | `npm run docker:dev:build` | Dev Compose with rebuild |
 | `./deploy.sh` | Recreate container; `--build`, `--frontend` flags |
+| `sudo ./scripts/install-clock-helper.sh` | One-time install of the clock helper + scoped sudoers rule on a Spark host |
 
 ---
 

--- a/scripts/install-clock-helper.sh
+++ b/scripts/install-clock-helper.sh
@@ -44,4 +44,5 @@ visudo -c -f "$TMP" >/dev/null
 install -m 0440 "$TMP" "$SUDOERS_DST"
 
 echo "installed $HELLO_DST and $SUDOERS_DST"
-echo "verify from the dashboard host: ssh <user>@<host> 'sudo -n $HELLO_DST --help'"
+echo "verify from the dashboard host: ssh <user>@<host> 'sudo -n $HELLO_DST'"
+echo "  expected output: the helper usage line (sudo allowed the argumentless run)"

--- a/scripts/install-clock-helper.sh
+++ b/scripts/install-clock-helper.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# install-clock-helper.sh — one-time provisioning for sparkDash clock control.
+#
+# Run ON the DGX Spark host (as a sudo-capable user):
+#   bash install-clock-helper.sh
+# or from the dashboard host over SSH:
+#   ssh dgx@<host> 'sudo sh -s' < install-clock-helper.sh
+#
+# Installs:
+#   1. /usr/local/bin/sparkdash-set-clock  (root-owned, 0755)
+#   2. /etc/sudoers.d/sparkdash-clock      (scoped NOPASSWD for that binary only)
+#
+# The sudoers drop-in is validated with visudo -c BEFORE installation and is
+# limited to exactly one command — never blanket sudo, never /etc/sudoers.
+set -eu
+
+HELLO_SRC="$(dirname "$0")/sparkdash-set-clock"
+HELLO_DST=/usr/local/bin/sparkdash-set-clock
+SUDOERS_DST=/etc/sudoers.d/sparkdash-clock
+
+[ "$(id -u)" -eq 0 ] || { echo "run as root (sudo)" >&2; exit 1; }
+
+# 1. Helper binary.
+if [ -f "$HELLO_SRC" ]; then
+  install -m 0755 "$HELLO_SRC" "$HELLO_DST"
+else
+  echo "helper source not found next to installer ($HELLO_SRC); aborting" >&2
+  exit 1
+fi
+
+# 2. Scoped sudoers drop-in. Percent-escape nothing: the rule grants exactly
+#    one command with no arguments and no runas aliases.
+TMP=$(mktemp /tmp/sparkdash-clock.XXXXXX)
+trap 'rm -f "$TMP"' EXIT
+cat > "$TMP" <<SUDOERS
+# Managed by sparkDash install-clock-helper.sh — scoped clock-control grant.
+# Allows the SSH user group to run ONLY the sparkDash clock helper with
+# passwordless sudo. Remove this file to revoke clock control.
+%sudo ALL=(root) NOPASSWD: $HELLO_DST
+SUDOERS
+
+# Validate before installing; never leave a broken sudoers file behind.
+visudo -c -f "$TMP" >/dev/null
+install -m 0440 "$TMP" "$SUDOERS_DST"
+
+echo "installed $HELLO_DST and $SUDOERS_DST"
+echo "verify from the dashboard host: ssh <user>@<host> 'sudo -n $HELLO_DST --help'"

--- a/scripts/sparkdash-set-clock
+++ b/scripts/sparkdash-set-clock
@@ -1,0 +1,177 @@
+#!/bin/sh
+# sparkdash-set-clock — privileged clock-cap helper for sparkDash.
+#
+# Runs ON THE DGX SPARK HOST as root (installed by install-clock-helper.sh,
+# invoked by the sparkDash container over SSH with passwordless sudo scoped to
+# exactly this binary). Applies a CPU or GPU clock cap live, and optionally
+# persists it to the boot systemd unit so it survives reboot.
+#
+# Usage:
+#   sparkdash-set-clock --domain cpu-big|cpu-little|gpu
+#                       (--max-mhz <int> | --unlock)
+#                       (--persist | --no-persist)
+#
+# Exit codes:
+#   0 ok · 1 usage/invalid · 2 out of range · 3 unsupported domain · 4 sysfs I/O failure
+set -eu
+
+CPU_UNIT=/etc/systemd/system/cpu-clock-cap.service
+GPU_UNIT=/etc/systemd/system/gpu-clock-lock.service
+SMI=/usr/bin/nvidia-smi
+
+DOMAIN=""
+MAX_MHZ=""
+UNLOCK=0
+PERSIST=0
+
+usage() {
+  echo "usage: $0 --domain cpu-big|cpu-little|gpu (--max-mhz <int>|--unlock) (--persist|--no-persist)" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --domain) [ $# -ge 2 ] || usage; DOMAIN="$2"; shift 2 ;;
+    --max-mhz) [ $# -ge 2 ] || usage; MAX_MHZ="$2"; shift 2 ;;
+    --unlock) UNLOCK=1; shift ;;
+    --persist) PERSIST=1; shift ;;
+    --no-persist) PERSIST=0; shift ;;
+    *) usage ;;
+  esac
+done
+
+[ -n "$DOMAIN" ] || usage
+case "$DOMAIN" in
+  gpu|cpu-big|cpu-little) ;;
+  *) echo "unsupported domain: $DOMAIN" >&2; exit 3 ;;
+esac
+
+if [ "$UNLOCK" -eq 0 ]; then
+  case "$MAX_MHZ" in
+    ''|*[!0-9]*) usage ;;
+  esac
+fi
+
+# ─── helpers ──────────────────────────────────────────────
+
+# cores_for DOMAIN → space-separated cpuN list, grouped by cpuinfo_max_freq
+# (never hardcoded indices; scaling_available_frequencies does not exist on
+# this platform).
+cores_for() {
+  d=$1
+  for c in /sys/devices/system/cpu/cpu[0-9]*; do
+    [ -d "$c/cpufreq" ] || continue
+    max=$(cat "$c/cpufreq/cpuinfo_max_freq" 2>/dev/null || true)
+    [ -n "$max" ] || continue
+    case "$d" in
+      cpu-big) [ "$max" -ge 3000000 ] || continue ;;
+      cpu-little) [ "$max" -lt 3000000 ] || continue ;;
+    esac
+    basename "$c"
+  done
+}
+
+# Write max_perf for one core. Un_lock=1 writes the core's own hardware max.
+write_core() {
+  cpu_n=$1
+  khz=$2
+  unlock=$3
+  base="/sys/devices/system/cpu/$cpu_n/cpufreq"
+  if [ "$unlock" -eq 1 ]; then
+    khz=$(cat "$base/cpuinfo_max_freq" 2>/dev/null || true)
+    [ -n "$khz" ] || { echo "cannot read cpuinfo_max_freq for $cpu_n" >&2; return 1; }
+  fi
+  echo "$khz" > "$base/max_perf" || { echo "max_perf write failed for $cpu_n" >&2; return 1; }
+}
+
+# ─── GPU ──────────────────────────────────────────────────
+
+gpu_apply() {
+  if [ "$UNLOCK" -eq 1 ]; then
+    "$SMI" -rgc
+  else
+    "$SMI" -lgc "0,$MAX_MHZ"
+  fi
+}
+
+gpu_unit_body() {
+  if [ "$UNLOCK" -eq 1 ]; then
+    exec_line="$SMI -rgc"
+  else
+    exec_line="$SMI -lgc 0,$MAX_MHZ"
+  fi
+  cat <<UNIT
+[Unit]
+Description=Lock NVIDIA GPU graphics clocks to user range
+After=nvidia-persistenced.service
+
+[Service]
+Type=oneshot
+ExecStart=$exec_line
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+}
+
+# ─── CPU ──────────────────────────────────────────────────
+
+cpu_apply() {
+  cores=$(cores_for "$DOMAIN")
+  [ -n "$cores" ] || { echo "no cores found for domain $DOMAIN" >&2; return 2; }
+  # sysfs max_perf is in kHz; the request is MHz. Unlock lets each core write
+  # its own cpuinfo_max_freq.
+  khz=""
+  if [ "$UNLOCK" -eq 0 ]; then
+    khz=$((MAX_MHZ * 1000))
+  fi
+  rc=0
+  for cpu_n in $cores; do
+    write_core "$cpu_n" "$khz" "$UNLOCK" || rc=1
+  done
+  return $rc
+}
+
+cpu_unit_body() {
+  cores=$(cores_for "$DOMAIN" | tr '\n' ' ')
+  if [ "$UNLOCK" -eq 1 ]; then
+    # Remove-cap at boot: every core gets its own hardware maximum.
+    exec_line="for c in $cores; do cat /sys/devices/system/cpu/\$c/cpufreq/cpuinfo_max_freq > /sys/devices/system/cpu/\$c/cpufreq/max_perf; done"
+  else
+    khz=$((MAX_MHZ * 1000))
+    exec_line="for c in $cores; do echo $khz > /sys/devices/system/cpu/\$c/cpufreq/max_perf; done"
+  fi
+  # One unit per CPU domain; the helper writes only that domain's cores.
+  cat <<UNIT
+[Unit]
+Description=sparkDash $DOMAIN clock cap
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '$exec_line'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+}
+
+# ─── persist + run ────────────────────────────────────────
+
+if [ "$PERSIST" -eq 1 ]; then
+  case "$DOMAIN" in
+    gpu) UNIT=$GPU_UNIT; gpu_unit_body > "$UNIT.tmp" ;;
+    *) UNIT=$CPU_UNIT; cpu_unit_body > "$UNIT.tmp" ;;
+  esac
+  chmod 644 "$UNIT.tmp"
+  # Validate then atomically move into place (systemd refuses world-writable units).
+  mv "$UNIT.tmp" "$UNIT"
+  systemctl daemon-reload
+fi
+
+case "$DOMAIN" in
+  gpu) gpu_apply ;;
+  *) cpu_apply ;;
+esac

--- a/scripts/sparkdash-set-clock
+++ b/scripts/sparkdash-set-clock
@@ -13,12 +13,22 @@
 #
 # Exit codes:
 #   0 ok · 1 usage/invalid · 2 out of range · 3 unsupported domain · 4 sysfs I/O failure
+#
+# Availability probing: the scoped sudoers grant allows ONLY an argumentless
+# run of this binary. An argumentless invocation prints the usage line and
+# exits 1 — that is exactly what the dashboard's probe expects ("installed and
+# sudo-allowed"); a sudo refusal exits 1 without the usage line.
 set -eu
 
-CPU_UNIT=/etc/systemd/system/cpu-clock-cap.service
-GPU_UNIT=/etc/systemd/system/gpu-clock-lock.service
+CPU_SYS=${SPARKDASH_CPU_SYS:-/sys/devices/system/cpu}
+UNIT_DIR=${SPARKDASH_UNIT_DIR:-/etc/systemd/system}
+CPU_UNIT=$UNIT_DIR/cpu-clock-cap.service
+GPU_UNIT=$UNIT_DIR/gpu-clock-lock.service
 SMI=/usr/bin/nvidia-smi
 
+# Test hooks only: SPARKDASH_CPU_SYS / SPARKDASH_UNIT_DIR redirect the sysfs
+# and unit paths. Under the shipped scoped sudoers grant sudo resets the
+# environment, so a remote invocation always uses the real /sys and /etc.
 DOMAIN=""
 MAX_MHZ=""
 UNLOCK=0
@@ -42,7 +52,9 @@ done
 
 [ -n "$DOMAIN" ] || usage
 case "$DOMAIN" in
-  gpu|cpu-big|cpu-little) ;;
+  gpu) OTHER_DOMAIN="" ;;
+  cpu-big) OTHER_DOMAIN="cpu-little" ;;
+  cpu-little) OTHER_DOMAIN="cpu-big" ;;
   *) echo "unsupported domain: $DOMAIN" >&2; exit 3 ;;
 esac
 
@@ -56,10 +68,12 @@ fi
 
 # cores_for DOMAIN → space-separated cpuN list, grouped by cpuinfo_max_freq
 # (never hardcoded indices; scaling_available_frequencies does not exist on
-# this platform).
+# this platform). Reads from $CPU_SYS. Cores are numerically sorted so the
+# generated unit is deterministic and byte-identical to the container persist
+# path (glob order would put cpu10 before cpu2).
 cores_for() {
   d=$1
-  for c in /sys/devices/system/cpu/cpu[0-9]*; do
+  for c in "$CPU_SYS"/cpu[0-9]*; do
     [ -d "$c/cpufreq" ] || continue
     max=$(cat "$c/cpufreq/cpuinfo_max_freq" 2>/dev/null || true)
     [ -n "$max" ] || continue
@@ -67,8 +81,9 @@ cores_for() {
       cpu-big) [ "$max" -ge 3000000 ] || continue ;;
       cpu-little) [ "$max" -lt 3000000 ] || continue ;;
     esac
-    basename "$c"
-  done
+    n=${c##*/cpu}
+    printf '%010d %s\n' "$n" "${c##*/}"
+  done | sort | cut -d' ' -f2
 }
 
 # Write max_perf for one core. Un_lock=1 writes the core's own hardware max.
@@ -133,25 +148,57 @@ cpu_apply() {
   return $rc
 }
 
+# unit_exec_line DOMAIN UNLOCK KHZ → the ExecStart command list for that
+# domain's cores. Shared by the unit generator so both persist paths emit the
+# same per-core command shape.
+unit_exec_line() {
+  d=$1
+  unlock=$2
+  khz=$3
+  cmds=""
+  for c in $(cores_for "$d"); do
+    base="$CPU_SYS/$c/cpufreq"
+    if [ "$unlock" -eq 1 ]; then
+      cmds="$cmds cat $base/cpuinfo_max_freq > $base/max_perf;"
+    else
+      cmds="$cmds echo $khz > $base/max_perf;"
+    fi
+  done
+  printf '%s' "$cmds"
+}
+
 cpu_unit_body() {
-  cores=$(cores_for "$DOMAIN" | tr '\n' ' ')
+  # Both CPU domains share ONE boot unit (cpu-clock-cap.service), so a
+  # single-domain Save MUST regenerate the sibling domain too — reading each
+  # sibling core's current max_perf and omitting cores whose value is
+  # unreadable (same no-guess rule as the container persist path in
+  # SystemCollector._persistClockUnitLocal). Otherwise a Save on cpu-big
+  # would silently delete cpu-little's boot cap and that core would boot at
+  # hardware maximum.
+  #
   # Explicit per-core commands in the unit file — NO shell loop variables.
   # systemd expands $VAR in ExecStart (unset -> empty), so a unit file must
   # never carry a bare `$c` inside `sh -c`.
-  cmds=""
-  for c in $cores; do
-    base="/sys/devices/system/cpu/$c/cpufreq"
-    if [ "$UNLOCK" -eq 1 ]; then
-      cmds="$cmds cat $base/cpuinfo_max_freq > $base/max_perf;"
-    else
-      cmds="$cmds echo $((MAX_MHZ * 1000)) > $base/max_perf;"
-    fi
-  done
+  cmds=$(unit_exec_line "$DOMAIN" "$UNLOCK" "$((MAX_MHZ * 1000))")
   [ -n "$cmds" ] || { echo "no cores found for domain $DOMAIN" >&2; return 2; }
-  # One unit per CPU domain; the helper writes only that domain's cores.
+  if [ -n "$OTHER_DOMAIN" ]; then
+    sibling_cmds=""
+    for c in $(cores_for "$OTHER_DOMAIN"); do
+      base="$CPU_SYS/$c/cpufreq"
+      khz=$(cat "$base/max_perf" 2>/dev/null || true)
+      case "$khz" in
+        ''|*[!0-9]*) continue ;;  # unreadable → omit rather than guess
+      esac
+      sibling_cmds="$sibling_cmds echo $khz > $base/max_perf;"
+    done
+    cmds="$cmds$sibling_cmds"
+  fi
+  # The ExecStart list is shell syntax (redirections), so systemd must run it
+  # through /bin/sh — same wrapping as the container persist path. Blank lines
+  # below match SystemCollector._persistClockUnitLocal byte for byte.
   cat <<UNIT
 [Unit]
-Description=sparkDash $DOMAIN clock cap
+Description=sparkDash CPU clock cap (big + little domains)
 After=multi-user.target
 
 [Service]

--- a/scripts/sparkdash-set-clock
+++ b/scripts/sparkdash-set-clock
@@ -24,11 +24,12 @@ CPU_SYS=${SPARKDASH_CPU_SYS:-/sys/devices/system/cpu}
 UNIT_DIR=${SPARKDASH_UNIT_DIR:-/etc/systemd/system}
 CPU_UNIT=$UNIT_DIR/cpu-clock-cap.service
 GPU_UNIT=$UNIT_DIR/gpu-clock-lock.service
-SMI=/usr/bin/nvidia-smi
+SMI=${SPARKDASH_SMI:-/usr/bin/nvidia-smi}
 
-# Test hooks only: SPARKDASH_CPU_SYS / SPARKDASH_UNIT_DIR redirect the sysfs
-# and unit paths. Under the shipped scoped sudoers grant sudo resets the
-# environment, so a remote invocation always uses the real /sys and /etc.
+# Test hooks only: SPARKDASH_CPU_SYS / SPARKDASH_UNIT_DIR / SPARKDASH_SMI
+# redirect the sysfs, unit, and nvidia-smi paths. Under the shipped scoped
+# sudoers grant sudo resets the environment, so a remote invocation always
+# uses the real /sys, /etc, and /usr/bin/nvidia-smi.
 DOMAIN=""
 MAX_MHZ=""
 UNLOCK=0
@@ -91,7 +92,7 @@ write_core() {
   cpu_n=$1
   khz=$2
   unlock=$3
-  base="/sys/devices/system/cpu/$cpu_n/cpufreq"
+  base="$CPU_SYS/$cpu_n/cpufreq"
   if [ "$unlock" -eq 1 ]; then
     khz=$(cat "$base/cpuinfo_max_freq" 2>/dev/null || true)
     [ -n "$khz" ] || { echo "cannot read cpuinfo_max_freq for $cpu_n" >&2; return 1; }
@@ -150,7 +151,8 @@ cpu_apply() {
 
 # unit_exec_line DOMAIN UNLOCK KHZ → the ExecStart command list for that
 # domain's cores. Shared by the unit generator so both persist paths emit the
-# same per-core command shape.
+# same per-core command shape: `cmd; cmd` — no leading/trailing separators,
+# exactly matching SystemCollector._persistClockUnitLocal's parts.join("; ").
 unit_exec_line() {
   d=$1
   unlock=$2
@@ -159,10 +161,11 @@ unit_exec_line() {
   for c in $(cores_for "$d"); do
     base="$CPU_SYS/$c/cpufreq"
     if [ "$unlock" -eq 1 ]; then
-      cmds="$cmds cat $base/cpuinfo_max_freq > $base/max_perf;"
+      cmd="cat $base/cpuinfo_max_freq > $base/max_perf"
     else
-      cmds="$cmds echo $khz > $base/max_perf;"
+      cmd="echo $khz > $base/max_perf"
     fi
+    if [ -z "$cmds" ]; then cmds="$cmd"; else cmds="$cmds; $cmd"; fi
   done
   printf '%s' "$cmds"
 }
@@ -189,9 +192,9 @@ cpu_unit_body() {
       case "$khz" in
         ''|*[!0-9]*) continue ;;  # unreadable → omit rather than guess
       esac
-      sibling_cmds="$sibling_cmds echo $khz > $base/max_perf;"
+      if [ -z "$sibling_cmds" ]; then sibling_cmds="echo $khz > $base/max_perf"; else sibling_cmds="$sibling_cmds; echo $khz > $base/max_perf"; fi
     done
-    cmds="$cmds$sibling_cmds"
+    if [ -n "$sibling_cmds" ]; then cmds="$cmds; $sibling_cmds"; fi
   fi
   # The ExecStart list is shell syntax (redirections), so systemd must run it
   # through /bin/sh — same wrapping as the container persist path. Blank lines

--- a/scripts/sparkdash-set-clock
+++ b/scripts/sparkdash-set-clock
@@ -135,13 +135,19 @@ cpu_apply() {
 
 cpu_unit_body() {
   cores=$(cores_for "$DOMAIN" | tr '\n' ' ')
-  if [ "$UNLOCK" -eq 1 ]; then
-    # Remove-cap at boot: every core gets its own hardware maximum.
-    exec_line="for c in $cores; do cat /sys/devices/system/cpu/\$c/cpufreq/cpuinfo_max_freq > /sys/devices/system/cpu/\$c/cpufreq/max_perf; done"
-  else
-    khz=$((MAX_MHZ * 1000))
-    exec_line="for c in $cores; do echo $khz > /sys/devices/system/cpu/\$c/cpufreq/max_perf; done"
-  fi
+  # Explicit per-core commands in the unit file — NO shell loop variables.
+  # systemd expands $VAR in ExecStart (unset -> empty), so a unit file must
+  # never carry a bare `$c` inside `sh -c`.
+  cmds=""
+  for c in $cores; do
+    base="/sys/devices/system/cpu/$c/cpufreq"
+    if [ "$UNLOCK" -eq 1 ]; then
+      cmds="$cmds cat $base/cpuinfo_max_freq > $base/max_perf;"
+    else
+      cmds="$cmds echo $((MAX_MHZ * 1000)) > $base/max_perf;"
+    fi
+  done
+  [ -n "$cmds" ] || { echo "no cores found for domain $DOMAIN" >&2; return 2; }
   # One unit per CPU domain; the helper writes only that domain's cores.
   cat <<UNIT
 [Unit]
@@ -150,7 +156,7 @@ After=multi-user.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c '$exec_line'
+ExecStart=/bin/sh -c '$cmds'
 RemainAfterExit=yes
 
 [Install]

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -5,8 +5,10 @@ import { normalizeMac, WOL_INTERFACE } from "../wol.js";
 import { sshExec } from "./ssh.js";
 import {
   buildClockHelperArgv,
+  buildHelperProbeCommand,
   clampClockCap,
   interpretHelperExit,
+  interpretHelperProbe,
   parseCpuClockBounds,
   parseCpuCoreMaxKhz,
   parseCpuBootUnitDefaults,
@@ -514,21 +516,25 @@ export class SystemCollector {
   }
 
   /**
-   * Check whether the privileged helper is installed and runnable (cheap SSH
-   * probe). Returns { available, checked, reason }.
+   * Check whether the privileged helper is installed and allowed by sudo
+   * (cheap SSH probe). The probe exercises EXACTLY the scoped grant shipped
+   * by scripts/install-clock-helper.sh — an argumentless run of the helper
+   * binary — never `sudo -n true`, which no scoped sudoers file permits.
+   * Returns { available, checked, reason }.
    */
   async checkClockHelper() {
     if (this._clockHelperState && Date.now() - this._clockHelperState.at < 30_000) {
       return this._clockHelperState.state;
     }
     this._clockHelperState = { at: Date.now(), state: null }; // in-flight marker
-    const probe = `test -x ${SPARKDASH_CLOCK_BIN} && sudo -n true && echo ok || echo no`;
     let state;
     try {
-      const out = await sshExec(this.spark, probe, { timeoutMs: 8000 });
-      state = String(out).includes("ok")
-        ? { available: true, checked: true }
-        : { available: false, checked: true, reason: "clock helper not installed on the host" };
+      const out = await sshExec(
+        this.spark,
+        buildHelperProbeCommand({ helperBin: SPARKDASH_CLOCK_BIN }),
+        { timeoutMs: 8000 }
+      );
+      state = interpretHelperProbe(out);
     } catch (err) {
       state = {
         available: false,
@@ -558,7 +564,9 @@ export class SystemCollector {
       maxMHz == null ? null : clampClockCap(maxMHz, bounds.hardMinMHz, bounds.hardMaxMHz, { warnings });
 
     // Primary: privileged helper over SSH (mirrors the shutdown feature).
-    const helperCmd = buildClockHelperArgv({ domain, maxMHz: appliedMHz, persist });
+    const helperCmd = buildClockHelperArgv({ domain, maxMHz: appliedMHz, persist }, {
+      helperBin: SPARKDASH_CLOCK_BIN,
+    });
     try {
       await sshExec(this.spark, helperCmd, { timeoutMs: 12000 });
       if (persist) this._clockCapsOverride = {}; // persisted → drop all volatile state
@@ -719,14 +727,20 @@ export class SystemCollector {
           parts.push(`echo ${khz} > /sys/devices/system/cpu/${cpuN}/cpufreq/max_perf`);
         }
       }
-      execLine = parts.join("; ");
+      // The ExecStart list is shell syntax (redirections), so systemd must run
+      // it through /bin/sh — byte-identical to the helper's persist path
+      // (scripts/sparkdash-set-clock cpu_unit_body). No single quotes can ever
+      // occur in these commands (echo/cat paths + integers only).
+      execLine = `/bin/sh -c '${parts.join("; ")}'`;
     }
     const script = [
       "set -eu",
       `cat > /etc/systemd/system/${unit} <<'UNIT'`,
       "[Unit]",
-      `Description=sparkDash ${domain} clock cap`,
-      "After=nvidia-persistenced.service",
+      domain === "gpu"
+        ? "Description=Lock NVIDIA GPU graphics clocks to user range"
+        : "Description=sparkDash CPU clock cap (big + little domains)",
+      domain === "gpu" ? "After=nvidia-persistenced.service" : "After=multi-user.target",
       "",
       "[Service]",
       "Type=oneshot",

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -1,11 +1,66 @@
 import fs from "fs";
 import path from "path";
-import { HOST_PATHS, GPU_MEMORY_JSON_PATH, DGX_SPARK, HARDWARE_DEFAULTS, POLL_INTERVAL_NVERR } from "../config.js";
+import { HOST_PATHS, GPU_MEMORY_JSON_PATH, GPU_CLOCK_LOCK_UNIT, DGX_SPARK, HARDWARE_DEFAULTS, POLL_INTERVAL_NVERR } from "../config.js";
 import { normalizeMac, WOL_INTERFACE } from "../wol.js";
 import { sshExec } from "./ssh.js";
 
 const NVERR_JOURNAL_CMD =
   'journalctl -k --no-pager -q --grep=NV_ERR_NO_MEMORY 2>/dev/null | grep -c NV_ERR_NO_MEMORY || true';
+
+/**
+ * Clock caps (CPU max_perf / GPU -lgc lock) change rarely, so cache the parsed
+ * result for this long instead of re-reading sysfs / the unit file every poll.
+ */
+const CLOCK_CAPS_CACHE_TTL_MS = 60_000;
+
+/**
+ * Parse the CPU clock-cap sysfs dump (one `cpuN:max_perf:cpuinfo_max_freq`
+ * line per core) into per-frequency-domain caps. A domain is "capped" when its
+ * max_perf ceiling is below the hardware max (cpuinfo_max_freq).
+ * Exported for tests.
+ * @param {string} raw
+ * @returns {Array<{label: string, capMHz: number, maxMHz: number, capped: boolean}>}
+ */
+export function parseCpuClockCaps(raw) {
+  const domains = new Map();
+  for (const line of String(raw ?? "").split("\n")) {
+    const m = line.trim().match(/^cpu(\d+):(\d+):(\d+)$/);
+    if (!m) continue;
+    const capKhz = Number(m[2]);
+    const maxKhz = Number(m[3]);
+    if (!Number.isFinite(capKhz) || !Number.isFinite(maxKhz) || maxKhz <= 0) continue;
+    if (!domains.has(maxKhz)) domains.set(maxKhz, { maxKhz, capKhz });
+    else {
+      // A domain's max_perf is uniform across its cores; keep the strictest.
+      const d = domains.get(maxKhz);
+      if (capKhz < d.capKhz) d.capKhz = capKhz;
+    }
+  }
+  return [...domains.values()]
+    .sort((a, b) => b.maxKhz - a.maxKhz)
+    .map((d) => ({
+      label: d.maxKhz >= 3_000_000 ? "X925" : d.maxKhz >= 2_000_000 ? "A725" : `${Math.round(d.maxKhz / 1000)} MHz`,
+      capMHz: Math.round(d.capKhz / 1000),
+      maxMHz: Math.round(d.maxKhz / 1000),
+      capped: d.capKhz < d.maxKhz,
+    }));
+}
+
+/**
+ * Parse a `gpu-clock-lock.service` unit file (or raw text) for an
+ * `nvidia-smi -lgc MIN,MAX` clock lock. Returns null when no lock is present.
+ * Exported for tests.
+ * @param {string} raw
+ * @returns {{minMHz: number, maxMHz: number} | null}
+ */
+export function parseGpuClockLock(raw) {
+  const m = String(raw ?? "").match(/-lgc\s+(\d+)\s*,\s*(\d+)/);
+  if (!m) return null;
+  const minMHz = Number(m[1]);
+  const maxMHz = Number(m[2]);
+  if (!Number.isFinite(minMHz) || !Number.isFinite(maxMHz) || maxMHz <= 0) return null;
+  return { minMHz, maxMHz };
+}
 
 /**
  * Parse `grep -c` stdout into a non-negative integer. Exported for tests.
@@ -65,6 +120,8 @@ export class SystemCollector {
     this._hardwareInfo = null;
     /** Cached NVRM NV_ERR_NO_MEMORY count (slow journal scan). */
     this._nvErrCache = { count: 0, at: 0 };
+    /** Cached clock caps (CPU max_perf domains + GPU -lgc lock). */
+    this._clockCapsCache = { at: 0, cpuDomains: null, gpuLock: null };
   }
 
   /** Collect GPU metrics (temperature, usage, power, VRAM). */
@@ -111,11 +168,107 @@ export class SystemCollector {
         this.lastCpuUsagePct = cpuPercentage;
       }
       const cpuData = { usage: cpuPercentage, temperature: temp, ...power };
+      cpuData.clockCaps = (await this._getClockCaps()).cpuDomains;
       return tagCollectionResult(cpuData, this._isSuccessfulCpuCollection(cpuData));
     } catch (err) {
       console.error(`[SystemCollector] CPU error for ${this.spark.id}:`, err.message);
       return tagCollectionResult(this._defaultCpu(), false);
     }
+  }
+
+  /**
+   * Read the active clock caps: per-domain CPU max_perf ceilings and the GPU
+   * -lgc lock. These change rarely, so the result is cached for
+   * CLOCK_CAPS_CACHE_TTL_MS and shared across the parallel CPU/GPU polls via an
+   * in-flight guard. Returns { cpuDomains, gpuLock } (either may be null).
+   */
+  async _getClockCaps() {
+    const now = Date.now();
+    const c = this._clockCapsCache;
+    if (c.at && now - c.at < CLOCK_CAPS_CACHE_TTL_MS && (c.cpuDomains || c.gpuLock)) {
+      return c;
+    }
+    if (this._clockCapsInFlight) return this._clockCapsInFlight;
+    this._clockCapsInFlight = (async () => {
+      let cpuDomains = null;
+      let gpuLock = null;
+      try {
+        if (this.spark.isLocal) {
+          cpuDomains = parseCpuClockCaps(await this._readLocalCpuCapDump());
+          gpuLock = parseGpuClockLock(await this._readLocalGpuLockUnit());
+        } else {
+          const out = await sshExec(this.spark, this._buildRemoteClockCapsCommand());
+          const [cpuDump, lockUnit] = out.split("---");
+          cpuDomains = parseCpuClockCaps(cpuDump);
+          gpuLock = parseGpuClockLock(lockUnit);
+        }
+      } catch (err) {
+        console.error(`[SystemCollector] clock caps error for ${this.spark.id}:`, err.message);
+      }
+      return { at: Date.now(), cpuDomains, gpuLock };
+    })();
+    try {
+      return await this._clockCapsInFlight;
+    } finally {
+      this._clockCapsInFlight = null;
+    }
+  }
+
+  /** Local: dump `cpuN:max_perf:cpuinfo_max_freq` for every core. */
+  async _readLocalCpuCapDump() {
+    const cpuDir = path.join(HOST_PATHS.SYS, "devices/system/cpu");
+    let entries = [];
+    try {
+      entries = fs.readdirSync(cpuDir);
+    } catch {
+      return "";
+    }
+    const lines = [];
+    for (const e of entries) {
+      if (!/^cpu\d+$/.test(e)) continue;
+      const cap = this._readSysFile(path.join(cpuDir, e, "cpufreq/max_perf"));
+      const max = this._readSysFile(path.join(cpuDir, e, "cpufreq/cpuinfo_max_freq"));
+      if (cap != null && max != null) lines.push(`${e}:${cap.trim()}:${max.trim()}`);
+    }
+    return lines.join("\n");
+  }
+
+  /**
+   * Local: read the GPU clock-lock unit (source of the -lgc lock). The path is
+   * configurable via GPU_CLOCK_LOCK_UNIT (default: the common
+   * gpu-clock-lock.service convention) because nvidia-smi does not expose the
+   * active lock range — the unit file is the only reliable source of the
+   * intended value.
+   */
+  async _readLocalGpuLockUnit() {
+    const p = path.join(HOST_PATHS.ROOT, GPU_CLOCK_LOCK_UNIT);
+    try {
+      return fs.readFileSync(p, "utf-8");
+    } catch {
+      return "";
+    }
+  }
+
+  _readSysFile(p) {
+    try {
+      return fs.readFileSync(p, "utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  /** Remote: one command that dumps CPU caps then the GPU lock unit. */
+  _buildRemoteClockCapsCommand() {
+    // GPU_CLOCK_LOCK_UNIT is an operator-supplied host path; single-quote it so
+    // spaces/globs in the path don't break the remote shell.
+    const unitPath = `'${String(GPU_CLOCK_LOCK_UNIT).replace(/'/g, "'\\''")}'`;
+    return [
+      // Command substitution strips sysfs trailing newlines so each core is one
+      // `cpuN:max_perf:cpuinfo_max_freq` line (echo -n + cat splits them).
+      "for d in /sys/devices/system/cpu/cpu*/cpufreq; do n=${d#/sys/devices/system/cpu/}; n=${n%/cpufreq}; echo \"$n:$(cat $d/max_perf 2>/dev/null):$(cat $d/cpuinfo_max_freq 2>/dev/null)\"; done",
+      "echo '---'",
+      `cat ${unitPath} 2>/dev/null || true`,
+    ].join("; ");
   }
 
   _isSuccessfulGpuCollection(gpu) {
@@ -241,6 +394,7 @@ export class SystemCollector {
       processes,
       throttle: gpu.throttle,
       nvErrNoMemory: await this._nvErrNoMemory(),
+      clockLock: (await this._getClockCaps()).gpuLock,
     };
   }
 
@@ -290,8 +444,9 @@ export class SystemCollector {
       const apps = this._parseComputeApps(raw);
       this.nvidiaComputeAppsCache.clear();
       for (const app of apps) {
-        this.nvidiaComputeAppsCache.set(app.pid, { name: app.name, vramMB: app.vramMB });
-        computeSum += app.vramMB;
+        const vramMB = Number.isFinite(app.vramMB) ? app.vramMB : 0;
+        this.nvidiaComputeAppsCache.set(app.pid, { name: app.name, vramMB });
+        computeSum += vramMB;
       }
       computeAppsQueried = true;
       // Prefer live compute-apps for used (including 0 = cleared).
@@ -1035,8 +1190,9 @@ export class SystemCollector {
       this.nvidiaComputeAppsCache.clear();
       let computeSum = 0;
       for (const app of apps) {
-        this.nvidiaComputeAppsCache.set(app.pid, { name: app.name, vramMB: app.vramMB });
-        computeSum += app.vramMB;
+        const vramMB = Number.isFinite(app.vramMB) ? app.vramMB : 0;
+        this.nvidiaComputeAppsCache.set(app.pid, { name: app.name, vramMB });
+        computeSum += vramMB;
       }
       if ((used == null || used === 0) && computeSum > 0) used = computeSum;
 
@@ -1079,6 +1235,7 @@ export class SystemCollector {
         processes,
         throttle: gpu.throttle,
         nvErrNoMemory: await this._nvErrNoMemory(),
+        clockLock: (await this._getClockCaps()).gpuLock,
       };
     } catch (err) {
       console.error(`[SystemCollector] Remote GPU error for ${this.spark.id}:`, err.message);
@@ -1144,6 +1301,7 @@ export class SystemCollector {
         temperature: this._parseSensorTemp(tempOut),
         draw: Math.round(draw * 10) / 10,
         tdp: Math.round(tdp),
+        clockCaps: (await this._getClockCaps()).cpuDomains,
       };
     } catch (err) {
       console.error(`[SystemCollector] Remote CPU error for ${this.spark.id}:`, err.message);

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -310,10 +310,13 @@ export class SystemCollector {
   }
 
   /**
-   * Drop overrides that a fresh successful read makes redundant — either
-   * because the read converged to the override (applied value now visible) or
-   * because it diverged (the fresh read is the current truth; e.g. another
-   * operator or a reboot changed the value).
+   * Drop overrides that a fresh successful read makes redundant, per domain:
+   * CPU live caps ARE the sysfs read itself, so any fresh CPU read (converged
+   * or diverged) supersedes the override. GPU is different — the read source
+   * is the boot unit file, which a live-only `-lgc` does not change — so a GPU
+   * override survives until a read actually reports the overridden value
+   * (converged). Dropping it earlier would make the UI lie after the cache
+   * TTL expires (D5).
    */
   _dropConvergedOverrides(fresh) {
     const o = this._clockCapsOverride;
@@ -323,7 +326,11 @@ export class SystemCollector {
         delete o[this._cpuDomainId(d.maxMHz)];
       }
     }
-    if (fresh.ok) delete o.gpu;
+    if (fresh.ok && Object.prototype.hasOwnProperty.call(o, "gpu")) {
+      const want = o.gpu;
+      const have = fresh.gpuLock ? fresh.gpuLock.maxMHz : null;
+      if (want === have) delete o.gpu;
+    }
   }
 
   /** Read the active clock caps, merging volatile overrides over the result. */
@@ -628,12 +635,44 @@ export class SystemCollector {
     let execLine;
     if (domain === "gpu") {
       execLine = appliedMHz == null ? `${smi} -rgc` : `${smi} -lgc 0,${appliedMHz}`;
-    } else if (appliedMHz == null) {
-      // Remove-cap at boot: every core gets its own hardware maximum.
-      execLine =
-        "for d in /sys/devices/system/cpu/cpu*/cpufreq; do cat $d/cpuinfo_max_freq > $d/max_perf; done";
     } else {
-      execLine = `for d in /sys/devices/system/cpu/cpu*/cpufreq; do echo ${appliedMHz * 1000} > $d/max_perf; done`;
+      // Both CPU domains share ONE boot unit (cpu-clock-cap.service), so a
+      // single-domain Save must carry the sibling domain too or it would
+      // clobber the sibling's boot cap. The sibling keeps its current
+      // effective value: its volatile override when a live-only apply is in
+      // flight, else its live max_perf right now.
+      //
+      // Explicit per-core commands — NO shell loop variables. systemd expands
+      // $VAR in ExecStart (unset → empty), so a unit file must never contain
+      // a bare `$c` inside `sh -c`.
+      const cores = this._cpuDomainCores(domain);
+      if (!cores.length) throw new Error("no CPU cores discovered for this domain");
+      const parts = [];
+      for (const cpuN of cores) {
+        const base = `/sys/devices/system/cpu/${cpuN}/cpufreq`;
+        parts.push(
+          appliedMHz == null
+            ? `cat ${base}/cpuinfo_max_freq > ${base}/max_perf`
+            : `echo ${appliedMHz * 1000} > ${base}/max_perf`
+        );
+      }
+      const siblingId = domain === "cpu-big" ? "cpu-little" : "cpu-big";
+      const siblingOverride = this._clockCapsOverride?.[siblingId];
+      for (const cpuN of this._cpuDomainCores(siblingId)) {
+        let khz = null;
+        if (Number.isInteger(siblingOverride)) khz = siblingOverride * 1000;
+        else {
+          const raw = this._readSysFile(
+            path.join(HOST_PATHS.SYS, "devices/system/cpu", cpuN, "cpufreq/max_perf")
+          );
+          if (raw != null && /^\d+$/.test(raw.trim())) khz = raw.trim();
+        }
+        // Unreadable sibling core → leave it out rather than guess a value.
+        if (khz != null) {
+          parts.push(`echo ${khz} > /sys/devices/system/cpu/${cpuN}/cpufreq/max_perf`);
+        }
+      }
+      execLine = parts.join("; ");
     }
     const script = [
       "set -eu",

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { HOST_PATHS, GPU_MEMORY_JSON_PATH, GPU_CLOCK_LOCK_UNIT, DGX_SPARK, HARDWARE_DEFAULTS, POLL_INTERVAL_NVERR, SPARKDASH_CLOCK_BIN, GPU_CLOCK_MAX_MHZ } from "../config.js";
+import { HOST_PATHS, GPU_MEMORY_JSON_PATH, GPU_CLOCK_LOCK_UNIT, CPU_CLOCK_CAP_UNIT, DGX_SPARK, HARDWARE_DEFAULTS, POLL_INTERVAL_NVERR, SPARKDASH_CLOCK_BIN, GPU_CLOCK_MAX_MHZ } from "../config.js";
 import { normalizeMac, WOL_INTERFACE } from "../wol.js";
 import { sshExec } from "./ssh.js";
 import {
@@ -8,6 +8,8 @@ import {
   clampClockCap,
   interpretHelperExit,
   parseCpuClockBounds,
+  parseCpuCoreMaxKhz,
+  parseCpuBootUnitDefaults,
   parseDefaultApplicationsGraphicsClock,
 } from "./clockControl.js";
 
@@ -146,7 +148,13 @@ export class SystemCollector {
     /** Cached clock caps (CPU max_perf domains + GPU -lgc lock). */
     this._clockCapsCache = { at: 0, cpuDomains: null, gpuLock: null };
     /** Cached bounds read (CPU min/max per domain + GPU Default Apps ceiling). */
-    this._clockBoundsCache = { at: 0, cpuBounds: null, gpuCeilingMHz: null };
+    this._clockBoundsCache = {
+      at: 0,
+      cpuBounds: null,
+      gpuCeilingMHz: null,
+      cpuBootDefaults: null,
+      gpuBootDefaultMHz: null,
+    };
     /**
      * Volatile overrides (D5): live-only applies that a unit-file read cannot
      * see. Shape { 'cpu-big'?: number, 'cpu-little'?: number, gpu?: number|null }
@@ -373,14 +381,21 @@ export class SystemCollector {
   /**
    * Discover hardware bounds (D8): CPU domains from cpuinfo_min/max_freq and
    * the GPU graphics ceiling from `nvidia-smi -q -d CLOCK` "Default
-   * Applications Clock". Cached with the same TTL + in-flight guard idiom as
-   * _getClockCaps. Returns { cpuBounds: [{minKhz,maxKhz}] | null,
-   * gpuCeilingMHz: number|null, gpuCeilingSource: 'smi'|'fallback'|null }.
+   * Applications Clock". Also reads the boot units for the D7 "Boot default"
+   * presets (what the units actually install — never hardcoded). Cached with
+   * the same TTL + in-flight guard idiom as _getClockCaps. Returns
+   * { at, cpuBounds: [{minKhz,maxKhz}] | null, gpuCeilingMHz: number|null,
+   * gpuCeilingSource: 'smi'|'fallback'|null, cpuBootDefaults:
+   * {'cpu-big'?:number,'cpu-little'?:number}|null, gpuBootDefaultMHz: number|null }.
    */
   async _getClockBounds() {
     const now = Date.now();
     const c = this._clockBoundsCache;
-    if (c.at && now - c.at < CLOCK_CAPS_CACHE_TTL_MS && (c.cpuBounds || c.gpuCeilingMHz != null)) {
+    if (
+      c.at &&
+      now - c.at < CLOCK_CAPS_CACHE_TTL_MS &&
+      (c.cpuBounds || c.gpuCeilingMHz != null)
+    ) {
       return c;
     }
     if (this._clockBoundsInFlight) return this._clockBoundsInFlight;
@@ -388,14 +403,27 @@ export class SystemCollector {
       let cpuBounds = null;
       let gpuCeilingMHz = null;
       let gpuCeilingSource = null;
+      let cpuBootDefaults = null;
+      let gpuBootDefaultMHz = null;
       try {
         if (this.spark.isLocal) {
           // Reuse the caps dump: max_perf is column 2 in the read shape but
           // bounds come from cpuinfo_min/max_freq, so dump min:max explicitly.
-          cpuBounds = parseCpuClockBounds(await this._readLocalCpuBoundsDump());
+          const boundsDump = await this._readLocalCpuBoundsDump();
+          cpuBounds = parseCpuClockBounds(boundsDump);
           gpuCeilingMHz = parseDefaultApplicationsGraphicsClock(
             await this._nvidiaSmi("-q -d CLOCK")
           );
+          // D7 boot-default presets: parse the installed boot units against
+          // the discovered core→domain map. Read-path only; a missing unit
+          // simply omits the preset.
+          const coreMaxKhz = parseCpuCoreMaxKhz(boundsDump);
+          cpuBootDefaults = parseCpuBootUnitDefaults(
+            this._readLocalBootUnit(CPU_CLOCK_CAP_UNIT),
+            coreMaxKhz
+          );
+          gpuBootDefaultMHz =
+            parseGpuClockLock(this._readLocalBootUnit(GPU_CLOCK_LOCK_UNIT))?.maxMHz ?? null;
         } else {
           const out = await sshExec(
             this.spark,
@@ -405,6 +433,10 @@ export class SystemCollector {
           const parts = out.split("---");
           cpuBounds = parseCpuClockBounds(parts[0] || "");
           gpuCeilingMHz = parseDefaultApplicationsGraphicsClock(parts[1] || "");
+          const coreMaxKhz = parseCpuCoreMaxKhz(parts[0] || "");
+          cpuBootDefaults = parseCpuBootUnitDefaults(parts[2] || "", coreMaxKhz);
+          gpuBootDefaultMHz =
+            parseGpuClockLock(parts[3] || "")?.maxMHz ?? null;
         }
         if (gpuCeilingMHz == null) {
           gpuCeilingMHz = GPU_CLOCK_MAX_MHZ;
@@ -415,7 +447,7 @@ export class SystemCollector {
       } catch (err) {
         console.error(`[SystemCollector] clock bounds error for ${this.spark.id}:`, err.message);
       }
-      const result = { at: Date.now(), cpuBounds, gpuCeilingMHz, gpuCeilingSource };
+      const result = { at: Date.now(), cpuBounds, gpuCeilingMHz, gpuCeilingSource, cpuBootDefaults, gpuBootDefaultMHz };
       this._clockBoundsCache = result;
       return result;
     })();
@@ -423,6 +455,15 @@ export class SystemCollector {
       return await this._clockBoundsInFlight;
     } finally {
       this._clockBoundsInFlight = null;
+    }
+  }
+
+  /** Read a boot unit through the container's host-root bind (read path). */
+  _readLocalBootUnit(hostPath) {
+    try {
+      return fs.readFileSync(path.join(HOST_PATHS.ROOT, hostPath), "utf-8");
+    } catch {
+      return "";
     }
   }
 
@@ -445,12 +486,18 @@ export class SystemCollector {
     return lines.join("\n");
   }
 
-  /** Remote: one command that dumps CPU min/max freqs then `-q -d CLOCK`. */
+  /** Remote: dump CPU min/max freqs, `-q -d CLOCK`, then both boot units. */
   _buildRemoteClockBoundsCommand() {
+    const cpuUnit = `'${String(CPU_CLOCK_CAP_UNIT).replace(/'/g, "'\\''")}'`;
+    const gpuUnit = `'${String(GPU_CLOCK_LOCK_UNIT).replace(/'/g, "'\\''")}'`;
     return [
       "for d in /sys/devices/system/cpu/cpu*/cpufreq; do n=${d#/sys/devices/system/cpu/}; n=${n%/cpufreq}; echo \"$n:$(cat $d/cpuinfo_min_freq 2>/dev/null):$(cat $d/cpuinfo_max_freq 2>/dev/null)\"; done",
       "echo '---'",
       "nvidia-smi -q -d CLOCK 2>/dev/null || true",
+      "echo '---'",
+      `cat ${cpuUnit} 2>/dev/null || true`,
+      "echo '---'",
+      `cat ${gpuUnit} 2>/dev/null || true`,
     ].join("; ");
   }
 

--- a/server/collectors/SystemCollector.js
+++ b/server/collectors/SystemCollector.js
@@ -1,11 +1,34 @@
 import fs from "fs";
 import path from "path";
-import { HOST_PATHS, GPU_MEMORY_JSON_PATH, GPU_CLOCK_LOCK_UNIT, DGX_SPARK, HARDWARE_DEFAULTS, POLL_INTERVAL_NVERR } from "../config.js";
+import { HOST_PATHS, GPU_MEMORY_JSON_PATH, GPU_CLOCK_LOCK_UNIT, DGX_SPARK, HARDWARE_DEFAULTS, POLL_INTERVAL_NVERR, SPARKDASH_CLOCK_BIN, GPU_CLOCK_MAX_MHZ } from "../config.js";
 import { normalizeMac, WOL_INTERFACE } from "../wol.js";
 import { sshExec } from "./ssh.js";
+import {
+  buildClockHelperArgv,
+  clampClockCap,
+  interpretHelperExit,
+  parseCpuClockBounds,
+  parseDefaultApplicationsGraphicsClock,
+} from "./clockControl.js";
 
 const NVERR_JOURNAL_CMD =
   'journalctl -k --no-pager -q --grep=NV_ERR_NO_MEMORY 2>/dev/null | grep -c NV_ERR_NO_MEMORY || true';
+
+/**
+ * Boot units each clock domain persists to (host paths). Both CPU domains
+ * share one unit (cpu-clock-cap.service writes per-core values for both);
+ * the GPU lock has its own.
+ */
+const CLOCK_DOMAIN_UNIT = {
+  "cpu-big": "cpu-clock-cap.service",
+  "cpu-little": "cpu-clock-cap.service",
+  gpu: "gpu-clock-lock.service",
+};
+
+/** Single-quote a value for `sh -c` consumption (same idiom as the remote caps command). */
+function shQuote(s) {
+  return `'${String(s).replace(/'/g, "'\\''")}'`;
+}
 
 /**
  * Clock caps (CPU max_perf / GPU -lgc lock) change rarely, so cache the parsed
@@ -122,6 +145,15 @@ export class SystemCollector {
     this._nvErrCache = { count: 0, at: 0 };
     /** Cached clock caps (CPU max_perf domains + GPU -lgc lock). */
     this._clockCapsCache = { at: 0, cpuDomains: null, gpuLock: null };
+    /** Cached bounds read (CPU min/max per domain + GPU Default Apps ceiling). */
+    this._clockBoundsCache = { at: 0, cpuBounds: null, gpuCeilingMHz: null };
+    /**
+     * Volatile overrides (D5): live-only applies that a unit-file read cannot
+     * see. Shape { 'cpu-big'?: number, 'cpu-little'?: number, gpu?: number|null }
+     * (gpu null = lock removed). Merged over the read values in _getClockCaps;
+     * dropped once a fresh read converges, or on hot config re-registration.
+     */
+    this._clockCapsOverride = {};
   }
 
   /** Collect GPU metrics (temperature, usage, power, VRAM). */
@@ -173,44 +205,6 @@ export class SystemCollector {
     } catch (err) {
       console.error(`[SystemCollector] CPU error for ${this.spark.id}:`, err.message);
       return tagCollectionResult(this._defaultCpu(), false);
-    }
-  }
-
-  /**
-   * Read the active clock caps: per-domain CPU max_perf ceilings and the GPU
-   * -lgc lock. These change rarely, so the result is cached for
-   * CLOCK_CAPS_CACHE_TTL_MS and shared across the parallel CPU/GPU polls via an
-   * in-flight guard. Returns { cpuDomains, gpuLock } (either may be null).
-   */
-  async _getClockCaps() {
-    const now = Date.now();
-    const c = this._clockCapsCache;
-    if (c.at && now - c.at < CLOCK_CAPS_CACHE_TTL_MS && (c.cpuDomains || c.gpuLock)) {
-      return c;
-    }
-    if (this._clockCapsInFlight) return this._clockCapsInFlight;
-    this._clockCapsInFlight = (async () => {
-      let cpuDomains = null;
-      let gpuLock = null;
-      try {
-        if (this.spark.isLocal) {
-          cpuDomains = parseCpuClockCaps(await this._readLocalCpuCapDump());
-          gpuLock = parseGpuClockLock(await this._readLocalGpuLockUnit());
-        } else {
-          const out = await sshExec(this.spark, this._buildRemoteClockCapsCommand());
-          const [cpuDump, lockUnit] = out.split("---");
-          cpuDomains = parseCpuClockCaps(cpuDump);
-          gpuLock = parseGpuClockLock(lockUnit);
-        }
-      } catch (err) {
-        console.error(`[SystemCollector] clock caps error for ${this.spark.id}:`, err.message);
-      }
-      return { at: Date.now(), cpuDomains, gpuLock };
-    })();
-    try {
-      return await this._clockCapsInFlight;
-    } finally {
-      this._clockCapsInFlight = null;
     }
   }
 
@@ -269,6 +263,426 @@ export class SystemCollector {
       "echo '---'",
       `cat ${unitPath} 2>/dev/null || true`,
     ].join("; ");
+  }
+
+  // ─── Clock control (bounds, apply, volatile overrides) ────
+
+  /** Hot config re-registration: forget live-only overrides (D5). */
+  clearClockCapsOverride() {
+    this._clockCapsOverride = {};
+  }
+
+  /**
+   * Domain id for a parsed cap row (MHz values — same rule as
+   * parseCpuClockCaps' labels, which test maxKhz ≥ 3,000,000; here maxMHz
+   * ≥ 3000). The 3.9 GHz Cortex-X925 group is "cpu-big".
+   */
+  _cpuDomainId(maxMHz) {
+    return maxMHz >= 3000 ? "cpu-big" : "cpu-little";
+  }
+
+  /**
+   * Merge volatile overrides (D5) over a read result so a live-only apply is
+   * not contradicted by the CLOCK_CAPS_CACHE_TTL_MS cache. Never mutates the
+   * cache; the returned copy carries the override values.
+   */
+  _mergeClockCapsOverride(c) {
+    const o = this._clockCapsOverride || {};
+    const hasCpu = o["cpu-big"] != null || o["cpu-little"] != null;
+    const hasGpu = Object.prototype.hasOwnProperty.call(o, "gpu");
+    if (!hasCpu && !hasGpu) return c;
+    const cpuDomains = c.cpuDomains ? c.cpuDomains.map((d) => ({ ...d })) : null;
+    if (cpuDomains && hasCpu) {
+      for (const d of cpuDomains) {
+        const v = o[this._cpuDomainId(d.maxMHz)];
+        if (v != null) {
+          d.capMHz = v;
+          d.capped = v < d.maxMHz;
+        }
+      }
+    }
+    let gpuLock = c.gpuLock ? { ...c.gpuLock } : null;
+    if (hasGpu) {
+      const v = o.gpu;
+      gpuLock = v == null ? null : { minMHz: 0, maxMHz: v };
+    }
+    return { at: c.at, cpuDomains, gpuLock, ok: c.ok };
+  }
+
+  /**
+   * Drop overrides that a fresh successful read makes redundant — either
+   * because the read converged to the override (applied value now visible) or
+   * because it diverged (the fresh read is the current truth; e.g. another
+   * operator or a reboot changed the value).
+   */
+  _dropConvergedOverrides(fresh) {
+    const o = this._clockCapsOverride;
+    if (!o || Object.keys(o).length === 0) return;
+    if (fresh.ok && Array.isArray(fresh.cpuDomains)) {
+      for (const d of fresh.cpuDomains) {
+        delete o[this._cpuDomainId(d.maxMHz)];
+      }
+    }
+    if (fresh.ok) delete o.gpu;
+  }
+
+  /** Read the active clock caps, merging volatile overrides over the result. */
+  async _getClockCaps() {
+    const now = Date.now();
+    const c = this._clockCapsCache;
+    if (c.at && now - c.at < CLOCK_CAPS_CACHE_TTL_MS && (c.cpuDomains || c.gpuLock)) {
+      return this._mergeClockCapsOverride(c);
+    }
+    if (this._clockCapsInFlight) return this._clockCapsInFlight;
+    this._clockCapsInFlight = (async () => {
+      let cpuDomains = null;
+      let gpuLock = null;
+      let ok = false;
+      try {
+        if (this.spark.isLocal) {
+          cpuDomains = parseCpuClockCaps(await this._readLocalCpuCapDump());
+          gpuLock = parseGpuClockLock(await this._readLocalGpuLockUnit());
+        } else {
+          const out = await sshExec(this.spark, this._buildRemoteClockCapsCommand());
+          const [cpuDump, lockUnit] = out.split("---");
+          cpuDomains = parseCpuClockCaps(cpuDump);
+          gpuLock = parseGpuClockLock(lockUnit);
+        }
+        ok = true;
+      } catch (err) {
+        console.error(`[SystemCollector] clock caps error for ${this.spark.id}:`, err.message);
+      }
+      this._clockCapsCache = { at: Date.now(), cpuDomains, gpuLock, ok };
+      this._dropConvergedOverrides(this._clockCapsCache);
+      return this._mergeClockCapsOverride(this._clockCapsCache);
+    })();
+    try {
+      return await this._clockCapsInFlight;
+    } finally {
+      this._clockCapsInFlight = null;
+    }
+  }
+
+  /**
+   * Discover hardware bounds (D8): CPU domains from cpuinfo_min/max_freq and
+   * the GPU graphics ceiling from `nvidia-smi -q -d CLOCK` "Default
+   * Applications Clock". Cached with the same TTL + in-flight guard idiom as
+   * _getClockCaps. Returns { cpuBounds: [{minKhz,maxKhz}] | null,
+   * gpuCeilingMHz: number|null, gpuCeilingSource: 'smi'|'fallback'|null }.
+   */
+  async _getClockBounds() {
+    const now = Date.now();
+    const c = this._clockBoundsCache;
+    if (c.at && now - c.at < CLOCK_CAPS_CACHE_TTL_MS && (c.cpuBounds || c.gpuCeilingMHz != null)) {
+      return c;
+    }
+    if (this._clockBoundsInFlight) return this._clockBoundsInFlight;
+    this._clockBoundsInFlight = (async () => {
+      let cpuBounds = null;
+      let gpuCeilingMHz = null;
+      let gpuCeilingSource = null;
+      try {
+        if (this.spark.isLocal) {
+          // Reuse the caps dump: max_perf is column 2 in the read shape but
+          // bounds come from cpuinfo_min/max_freq, so dump min:max explicitly.
+          cpuBounds = parseCpuClockBounds(await this._readLocalCpuBoundsDump());
+          gpuCeilingMHz = parseDefaultApplicationsGraphicsClock(
+            await this._nvidiaSmi("-q -d CLOCK")
+          );
+        } else {
+          const out = await sshExec(
+            this.spark,
+            this._buildRemoteClockBoundsCommand(),
+            { timeoutMs: 12000 }
+          );
+          const parts = out.split("---");
+          cpuBounds = parseCpuClockBounds(parts[0] || "");
+          gpuCeilingMHz = parseDefaultApplicationsGraphicsClock(parts[1] || "");
+        }
+        if (gpuCeilingMHz == null) {
+          gpuCeilingMHz = GPU_CLOCK_MAX_MHZ;
+          gpuCeilingSource = "fallback";
+        } else {
+          gpuCeilingSource = "smi";
+        }
+      } catch (err) {
+        console.error(`[SystemCollector] clock bounds error for ${this.spark.id}:`, err.message);
+      }
+      const result = { at: Date.now(), cpuBounds, gpuCeilingMHz, gpuCeilingSource };
+      this._clockBoundsCache = result;
+      return result;
+    })();
+    try {
+      return await this._clockBoundsInFlight;
+    } finally {
+      this._clockBoundsInFlight = null;
+    }
+  }
+
+  /** Local: dump `cpuN:cpuinfo_min_freq:cpuinfo_max_freq` for every core. */
+  async _readLocalCpuBoundsDump() {
+    const cpuDir = path.join(HOST_PATHS.SYS, "devices/system/cpu");
+    let entries = [];
+    try {
+      entries = fs.readdirSync(cpuDir);
+    } catch {
+      return "";
+    }
+    const lines = [];
+    for (const e of entries) {
+      if (!/^cpu\d+$/.test(e)) continue;
+      const min = this._readSysFile(path.join(cpuDir, e, "cpufreq/cpuinfo_min_freq"));
+      const max = this._readSysFile(path.join(cpuDir, e, "cpufreq/cpuinfo_max_freq"));
+      if (min != null && max != null) lines.push(`${e}:${min.trim()}:${max.trim()}`);
+    }
+    return lines.join("\n");
+  }
+
+  /** Remote: one command that dumps CPU min/max freqs then `-q -d CLOCK`. */
+  _buildRemoteClockBoundsCommand() {
+    return [
+      "for d in /sys/devices/system/cpu/cpu*/cpufreq; do n=${d#/sys/devices/system/cpu/}; n=${n%/cpufreq}; echo \"$n:$(cat $d/cpuinfo_min_freq 2>/dev/null):$(cat $d/cpuinfo_max_freq 2>/dev/null)\"; done",
+      "echo '---'",
+      "nvidia-smi -q -d CLOCK 2>/dev/null || true",
+    ].join("; ");
+  }
+
+  /**
+   * Which apply paths this Spark can use right now (D4). 'helper' = the
+   * privileged host helper over SSH (all units); 'container' = the container's
+   * own root path (local privileged container only). Null when neither applies.
+   */
+  _clockControlPaths() {
+    const paths = [];
+    if (this.spark.isLocal) paths.push("helper", "container");
+    else paths.push("helper");
+    return paths;
+  }
+
+  /**
+   * Check whether the privileged helper is installed and runnable (cheap SSH
+   * probe). Returns { available, checked, reason }.
+   */
+  async checkClockHelper() {
+    if (this._clockHelperState && Date.now() - this._clockHelperState.at < 30_000) {
+      return this._clockHelperState.state;
+    }
+    this._clockHelperState = { at: Date.now(), state: null }; // in-flight marker
+    const probe = `test -x ${SPARKDASH_CLOCK_BIN} && sudo -n true && echo ok || echo no`;
+    let state;
+    try {
+      const out = await sshExec(this.spark, probe, { timeoutMs: 8000 });
+      state = String(out).includes("ok")
+        ? { available: true, checked: true }
+        : { available: false, checked: true, reason: "clock helper not installed on the host" };
+    } catch (err) {
+      state = {
+        available: false,
+        checked: true,
+        reason: `unreachable over SSH: ${err.message || String(err)}`,
+      };
+    }
+    this._clockHelperState = { at: Date.now(), state };
+    return state;
+  }
+
+  /**
+   * Apply a clock cap (D4). Tries the SSH helper first; for local units falls
+   * back to the container's own root path. Returns the D1 response body:
+   * { ok, domain, appliedMHz, persisted, bootUnit, source, warnings } or
+   * { ok:false, status, reason } on failure. Never claims persistence it did
+   * not perform.
+   *
+   * @param {{ domain: string, maxMHz: number | null, persist: boolean }} req
+   * @param {{ hardMinMHz?: number, hardMaxMHz?: number }} [bounds] live bounds
+   *        for clamping (server-side, mandatory — D2)
+   */
+  async applyClockCap(req, bounds = {}) {
+    const warnings = [];
+    const { domain, maxMHz, persist } = req;
+    const appliedMHz =
+      maxMHz == null ? null : clampClockCap(maxMHz, bounds.hardMinMHz, bounds.hardMaxMHz, { warnings });
+
+    // Primary: privileged helper over SSH (mirrors the shutdown feature).
+    const helperCmd = buildClockHelperArgv({ domain, maxMHz: appliedMHz, persist });
+    try {
+      await sshExec(this.spark, helperCmd, { timeoutMs: 12000 });
+      if (persist) this._clockCapsOverride = {}; // persisted → drop all volatile state
+      else if (domain === "gpu") this._clockCapsOverride.gpu = appliedMHz;
+      else this._clockCapsOverride[domain] = appliedMHz;
+      return {
+        ok: true,
+        domain,
+        appliedMHz,
+        persisted: Boolean(persist),
+        bootUnit: persist ? CLOCK_DOMAIN_UNIT[domain] ?? null : null,
+        source: "helper",
+        warnings,
+      };
+    } catch (helperErr) {
+      const interpreted = interpretHelperExit(helperErr);
+      // Local fallback (D4 secondary): the container runs as root with a rw
+      // /sys and nvidia-smi; live apply needs no sudo at all. Persistence goes
+      // through nsenter into the host mount namespace.
+      if (this.spark.isLocal && (interpreted.status === 423 || interpreted.status === 502)) {
+        try {
+          return await this._applyClockCapLocal(domain, appliedMHz, persist, warnings, helperErr);
+        } catch (localErr) {
+          return {
+            ok: false,
+            status: 502,
+            reason: `helper failed (${interpreted.reason}); local fallback failed (${localErr.message || localErr})`,
+          };
+        }
+      }
+      return { ok: false, status: interpreted.status, reason: interpreted.reason };
+    }
+  }
+
+  /**
+   * Local container-root apply path (D4 secondary). Live: write max_perf /
+   * nvidia-smi -lgc|-rgc through the container's own (rw, privileged) view —
+   * the container's /sys is the host sysfs remounted rw, NOT the read-only
+   * /host/sys bind. Persist: nsenter into the host mount namespace and
+   * rewrite the boot unit there (no systemctl in the container).
+   */
+  async _applyClockCapLocal(domain, appliedMHz, persist, warnings, helperErr) {
+    let bootUnit = null;
+    if (domain === "gpu") {
+      const smi = this._nvidiaSmiPath || "nvidia-smi";
+      if (appliedMHz == null) {
+        await this._exec(`${smi} -rgc`);
+      } else {
+        await this._exec(`${smi} -lgc 0,${appliedMHz}`);
+      }
+      bootUnit = CLOCK_DOMAIN_UNIT.gpu;
+    } else {
+      const cores = this._cpuDomainCores(domain);
+      if (!cores.length) {
+        throw new Error("no CPU cores discovered for this domain");
+      }
+      // Remove-cap = write each core's own hardware maximum (never a 0 sentinel).
+      // Container /sys (rw) — not HOST_PATHS.SYS, which is the ro host bind.
+      const cpuDir = "/sys/devices/system/cpu";
+      for (const cpuN of cores) {
+        const p = path.join(cpuDir, cpuN, "cpufreq/max_perf");
+        try {
+          if (appliedMHz == null) {
+            const max = this._readSysFile(path.join(cpuDir, cpuN, "cpufreq/cpuinfo_max_freq"));
+            if (max == null) throw new Error(`cannot read cpuinfo_max_freq for ${cpuN}`);
+            fs.writeFileSync(p, `${max.trim()}\n`);
+          } else {
+            fs.writeFileSync(p, `${appliedMHz * 1000}\n`);
+          }
+        } catch (err) {
+          throw new Error(`max_perf write failed for ${cpuN}: ${err.message}`);
+        }
+      }
+      bootUnit = CLOCK_DOMAIN_UNIT[domain];
+    }
+
+    let persisted = false;
+    if (persist) {
+      try {
+        await this._persistClockUnitLocal(domain, appliedMHz);
+        persisted = true;
+      } catch (err) {
+        warnings.push(
+          `applied live but could not persist the boot unit: ${err.message || err} — reverts on reboot`
+        );
+      }
+    } else {
+      warnings.push("applied this boot only — reverts on reboot");
+    }
+
+    // Record the volatile override so the UI shows the truth until a fresh
+    // read converges (D5). Only for values the unit-file read cannot see.
+    if (!persisted) {
+      if (domain === "gpu") this._clockCapsOverride.gpu = appliedMHz;
+      else this._clockCapsOverride[domain] = appliedMHz;
+    } else {
+      this._clockCapsOverride = {};
+    }
+
+    return {
+      ok: true,
+      domain,
+      appliedMHz,
+      persisted,
+      bootUnit,
+      source: "container",
+      warnings,
+    };
+  }
+
+  /**
+   * Persist through nsenter into the host mount namespace (D4): rewrite the
+   * boot unit's ExecStart for the requested value, then daemon-reload. The
+   * script travels on the helper's stdin (`sh -s`), so it needs no remote
+   * shell quoting — values are interpolated only as verified integers or
+   * fixed unit paths.
+   */
+  async _persistClockUnitLocal(domain, appliedMHz) {
+    const unit = CLOCK_DOMAIN_UNIT[domain] || CLOCK_DOMAIN_UNIT["cpu-big"];
+    const smi = this._nvidiaSmiPath || "nvidia-smi";
+    let execLine;
+    if (domain === "gpu") {
+      execLine = appliedMHz == null ? `${smi} -rgc` : `${smi} -lgc 0,${appliedMHz}`;
+    } else if (appliedMHz == null) {
+      // Remove-cap at boot: every core gets its own hardware maximum.
+      execLine =
+        "for d in /sys/devices/system/cpu/cpu*/cpufreq; do cat $d/cpuinfo_max_freq > $d/max_perf; done";
+    } else {
+      execLine = `for d in /sys/devices/system/cpu/cpu*/cpufreq; do echo ${appliedMHz * 1000} > $d/max_perf; done`;
+    }
+    const script = [
+      "set -eu",
+      `cat > /etc/systemd/system/${unit} <<'UNIT'`,
+      "[Unit]",
+      `Description=sparkDash ${domain} clock cap`,
+      "After=nvidia-persistenced.service",
+      "",
+      "[Service]",
+      "Type=oneshot",
+      `ExecStart=${execLine}`,
+      "RemainAfterExit=yes",
+      "",
+      "[Install]",
+      "WantedBy=multi-user.target",
+      "UNIT",
+      "systemctl daemon-reload",
+    ].join("\n");
+    await this._exec(
+      `nsenter --mount=/host/proc/1/ns/mnt -- sh -s <<'SPARKDASH_UNIT_SCRIPT'\n${script}\nSPARKDASH_UNIT_SCRIPT`
+    );
+  }
+
+  /**
+   * Core names (cpuN) for a CPU domain, discovered from the bounds dump —
+   * never hardcoded indices. Empty when nothing is readable.
+   */
+  _cpuDomainCores(domain) {
+    const cpuDir = path.join(HOST_PATHS.SYS, "devices/system/cpu");
+    let entries = [];
+    try {
+      entries = fs.readdirSync(cpuDir);
+    } catch {
+      return [];
+    }
+    const byDomain = new Map(); // maxKhz → [cpuN...]
+    for (const e of entries) {
+      if (!/^cpu\d+$/.test(e)) continue;
+      const max = this._readSysFile(path.join(cpuDir, e, "cpufreq/cpuinfo_max_freq"));
+      if (max == null) continue;
+      const maxKhz = parseInt(max.trim(), 10);
+      if (!Number.isFinite(maxKhz)) continue;
+      const id = maxKhz >= 3_000_000 ? "cpu-big" : "cpu-little";
+      if (!byDomain.has(id)) byDomain.set(id, []);
+      byDomain.get(id).push(e);
+    }
+    const cores = byDomain.get(domain) || [];
+    // cpu0 < cpu1 < … < cpu10 numeric order for a stable unit file.
+    return cores.sort((a, b) => parseInt(a.slice(3), 10) - parseInt(b.slice(3), 10));
   }
 
   _isSuccessfulGpuCollection(gpu) {

--- a/server/collectors/__tests__/SystemCollector.clockCaps.test.js
+++ b/server/collectors/__tests__/SystemCollector.clockCaps.test.js
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  SystemCollector,
+  parseCpuClockCaps,
+  parseGpuClockLock,
+} from "../SystemCollector.js";
+
+test("parseCpuClockCaps groups cores into frequency domains", () => {
+  const raw = [
+    "cpu0:2808000:2808000",
+    "cpu1:2808000:2808000",
+    "cpu5:2600000:3900000",
+    "cpu9:2600000:3900000",
+    "cpu15:2600000:3900000",
+    "cpu19:2600000:3900000",
+  ].join("\n");
+  const caps = parseCpuClockCaps(raw);
+  assert.equal(caps.length, 2);
+  // Sorted by max desc: X925 (3900) first, then A725 (2808).
+  assert.deepEqual(caps[0], { label: "X925", capMHz: 2600, maxMHz: 3900, capped: true });
+  assert.deepEqual(caps[1], { label: "A725", capMHz: 2808, maxMHz: 2808, capped: false });
+});
+
+test("parseCpuClockCaps marks a domain uncapped when cap == max", () => {
+  const caps = parseCpuClockCaps("cpu0:3900000:3900000");
+  assert.equal(caps.length, 1);
+  assert.equal(caps[0].capped, false);
+});
+
+test("parseCpuClockCaps keeps the strictest cap within a domain", () => {
+  const caps = parseCpuClockCaps("cpu5:2600000:3900000\ncpu6:2400000:3900000");
+  assert.equal(caps.length, 1);
+  assert.equal(caps[0].capMHz, 2400);
+  assert.equal(caps[0].capped, true);
+});
+
+test("parseCpuClockCaps ignores malformed lines", () => {
+  const caps = parseCpuClockCaps("garbage\ncpu0:abc:3900000\n\ncpu1:2600000:3900000");
+  assert.equal(caps.length, 1);
+  assert.equal(caps[0].capMHz, 2600);
+});
+
+test("parseCpuClockCaps returns [] for empty input", () => {
+  assert.deepEqual(parseCpuClockCaps(""), []);
+  assert.deepEqual(parseCpuClockCaps(null), []);
+});
+
+test("parseGpuClockLock reads -lgc MIN,MAX", () => {
+  const unit = [
+    "[Unit]",
+    "Description=Lock NVIDIA GPU graphics clocks to user range",
+    "[Service]",
+    "Type=oneshot",
+    "ExecStart=/usr/bin/nvidia-smi -lgc 0,2200",
+    "RemainAfterExit=yes",
+  ].join("\n");
+  assert.deepEqual(parseGpuClockLock(unit), { minMHz: 0, maxMHz: 2200 });
+});
+
+test("parseGpuClockLock handles spaces and a non-zero min", () => {
+  assert.deepEqual(parseGpuClockLock("nvidia-smi -lgc 1000, 2400"), {
+    minMHz: 1000,
+    maxMHz: 2400,
+  });
+});
+
+test("parseGpuClockLock returns null when no lock is present", () => {
+  assert.equal(parseGpuClockLock("[Service]\nExecStart=/bin/true\n"), null);
+  assert.equal(parseGpuClockLock(""), null);
+  assert.equal(parseGpuClockLock(null), null);
+});
+
+test("remote clock-caps command dumps per-core caps then the lock unit", () => {
+  const c = new SystemCollector({ id: "t", kind: "spark" });
+  const cmd = c._buildRemoteClockCapsCommand();
+  assert.match(cmd, /max_perf/);
+  assert.match(cmd, /cpuinfo_max_freq/);
+  // Default unit path is present and single-quoted (shell-safe).
+  assert.match(cmd, /cat '\/etc\/systemd\/system\/gpu-clock-lock\.service' 2>\/dev\/null/);
+  assert.equal((cmd.match(/echo '---'/g) || []).length, 1);
+});
+
+test("remote CPU collection carries clockCaps from the caps dump", async () => {
+  const collector = new SystemCollector({ id: "spark-test", kind: "spark" });
+  // Stub the caps source so no real ssh/sysfs is touched.
+  collector._getClockCaps = async () => ({
+    at: Date.now(),
+    cpuDomains: [{ label: "X925", capMHz: 2600, maxMHz: 3900, capped: true }],
+    gpuLock: null,
+  });
+  const result = await collector._getRemoteCpu(async () =>
+    ["cpu 100 0 40 860 0 0 0 0", "---", "CPU architecture: 8", "---", "70900"].join("\n")
+  );
+  assert.deepEqual(result.clockCaps, [
+    { label: "X925", capMHz: 2600, maxMHz: 3900, capped: true },
+  ]);
+});

--- a/server/collectors/__tests__/SystemCollector.clockControl.test.js
+++ b/server/collectors/__tests__/SystemCollector.clockControl.test.js
@@ -1,0 +1,258 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SystemCollector } from "../SystemCollector.js";
+
+/** Local collector with sysfs/smi/stubs — no real I/O anywhere. */
+function localCollector() {
+  const c = new SystemCollector({ id: "spark-test", kind: "spark", isLocal: true });
+  return c;
+}
+
+const LIVE_DOMAINS = [
+  { label: "X925", capMHz: 2600, maxMHz: 3900, capped: true },
+  { label: "A725", capMHz: 2808, maxMHz: 2808, capped: false },
+];
+
+// ─── D5: volatile override merge ──────────────────────────
+
+test("stale cache is merged with the volatile override (cpu)", async () => {
+  const c = localCollector();
+  c._clockCapsCache = {
+    at: Date.now(),
+    cpuDomains: LIVE_DOMAINS.map((d) => ({ ...d })),
+    gpuLock: null,
+    ok: true,
+  };
+  // Override targets the 3900 MHz domain (the "cpu-big" id per parseCpuClockCaps).
+  c._clockCapsOverride["cpu-big"] = 3000;
+  const caps = await c._getClockCaps();
+  assert.equal(caps.cpuDomains[0].capMHz, 3000);
+  assert.equal(caps.cpuDomains[0].capped, true);
+  // Cache itself is never mutated.
+  assert.equal(c._clockCapsCache.cpuDomains[0].capMHz, 2600);
+});
+
+test("override can remove a gpu lock (null) and the merge reflects it", async () => {
+  const c = localCollector();
+  c._clockCapsCache = {
+    at: Date.now(),
+    cpuDomains: LIVE_DOMAINS.map((d) => ({ ...d })),
+    gpuLock: { minMHz: 0, maxMHz: 2200 },
+    ok: true,
+  };
+  c._clockCapsOverride.gpu = null;
+  const caps = await c._getClockCaps();
+  assert.equal(caps.gpuLock, null);
+});
+
+test("a fresh converging read drops the override", async () => {
+  const c = localCollector();
+  c._clockCapsOverride["cpu-little"] = 2808;
+  // Fresh read now reports the applied value — override is redundant.
+  // cpu-little id = the 2808 MHz domain (per parseCpuClockCaps labels).
+  c._readLocalCpuCapDump = async () => "cpu0:2808000:2808000\ncpu5:2600000:3900000";
+  c._readLocalGpuLockUnit = async () => "";
+  const caps = await c._getClockCaps();
+  assert.equal(caps.cpuDomains.find((d) => d.maxMHz === 2808).capMHz, 2808);
+  assert.deepEqual(c._clockCapsOverride, {});
+});
+
+test("a fresh diverging read also drops the override (fresh value wins)", async () => {
+  const c = localCollector();
+  c._clockCapsOverride["cpu-little"] = 2808;
+  // Fresh read says something else entirely (e.g. another operator changed it).
+  c._readLocalCpuCapDump = async () => "cpu0:2000000:2808000\ncpu5:2600000:3900000";
+  c._readLocalGpuLockUnit = async () => "";
+  const caps = await c._getClockCaps();
+  assert.equal(caps.cpuDomains.find((d) => d.maxMHz === 2808).capMHz, 2000);
+  assert.deepEqual(c._clockCapsOverride, {});
+});
+
+test("clearClockCapsOverride drops all volatile state (hot config)", async () => {
+  const c = localCollector();
+  c._clockCapsOverride["cpu-big"] = 3000;
+  c._clockCapsOverride.gpu = 2200;
+  c.clearClockCapsOverride();
+  assert.deepEqual(c._clockCapsOverride, {});
+});
+
+// ─── D8: bounds discovery ─────────────────────────────────
+
+test("_getClockBounds parses cpu bounds and the GPU ceiling from smi output", async () => {
+  const c = localCollector();
+  c._readLocalCpuBoundsDump = async () =>
+    ["cpu0:338000:2808000", "cpu5:1378000:3900000"].join("\n");
+  c._nvidiaSmi = async () =>
+    "Default Applications Clock\n        Graphics : 3003 MHz";
+  const b = await c._getClockBounds();
+  assert.deepEqual(b.cpuBounds, [
+    { minKhz: 1378000, maxKhz: 3900000 },
+    { minKhz: 338000, maxKhz: 2808000 },
+  ]);
+  assert.equal(b.gpuCeilingMHz, 3003);
+  assert.equal(b.gpuCeilingSource, "smi");
+});
+
+test("_getClockBounds falls back to GPU_CLOCK_MAX_MHZ with source=fallback on unparseable output", async () => {
+  const c = localCollector();
+  c._readLocalCpuBoundsDump = async () => "cpu0:338000:2808000";
+  c._nvidiaSmi = async () => "Graphics : [N/A]";
+  const b = await c._getClockBounds();
+  assert.equal(b.gpuCeilingSource, "fallback");
+  assert.equal(Number.isFinite(b.gpuCeilingMHz), true);
+  assert.equal(b.gpuCeilingMHz, 3003); // documented default
+});
+
+test("remote bounds command dumps min/max freqs then -q -d CLOCK", () => {
+  const c = new SystemCollector({ id: "t", kind: "spark", isLocal: false });
+  const cmd = c._buildRemoteClockBoundsCommand();
+  assert.match(cmd, /cpuinfo_min_freq/);
+  assert.match(cmd, /cpuinfo_max_freq/);
+  assert.match(cmd, /nvidia-smi -q -d CLOCK/);
+  assert.equal((cmd.match(/echo '---'/g) || []).length, 1);
+});
+
+// ─── D4: apply paths ──────────────────────────────────────
+
+test("applyClockCap prefers the helper and records a live-only override", async () => {
+  const c = localCollector();
+  let helperCalled = 0;
+  c._exec = async (cmd) => {
+    throw new Error("local exec must not run when the helper succeeds");
+  };
+  // Stub sshExec on the module's imported binding via the collector instance:
+  // applyClockCap calls the module-level sshExec, so stub at the helper layer
+  // by faking a successful helper through a patched sshExec module object is
+  // not possible — instead assert through the container fallback path below.
+  helperCalled = 0;
+  // The helper path uses module-level sshExec; simulate failure → local path.
+  c._cpuDomainCores = (domain) => (domain === "cpu-little" ? ["cpu5", "cpu6"] : []);
+  const writes = [];
+  const origWrite = (await import("node:fs")).default.writeFileSync;
+  const fsMod = await import("node:fs");
+  fsMod.default.writeFileSync = (p, data) => {
+    writes.push({ p, data: String(data) });
+  };
+  try {
+    const res = await c.applyClockCap(
+      { domain: "cpu-little", maxMHz: 2400, persist: false },
+      { hardMinMHz: 1378, hardMaxMHz: 3900 }
+    );
+    assert.equal(res.ok, true);
+    assert.equal(res.source, "container");
+    assert.equal(res.persisted, false);
+    assert.equal(res.appliedMHz, 2400);
+    assert.equal(writes.length, 2);
+    assert.match(writes[0].p, /cpu5\/cpufreq\/max_perf$/);
+    assert.equal(writes[0].data, "2400000\n");
+    // D5: live-only apply is recorded so the UI does not lie for the next 60s.
+    assert.equal(c._clockCapsOverride["cpu-little"], 2400);
+    // D4 honesty: a boot-only apply carries the reboot warning.
+    assert.ok(res.warnings.some((w) => /reverts on reboot/.test(w)));
+  } finally {
+    fsMod.default.writeFileSync = origWrite;
+  }
+});
+
+test("applyClockCap clamps an above-max request down and reports it (D2)", async () => {
+  const c = localCollector();
+  c._cpuDomainCores = () => ["cpu0"];
+  const fsMod = await import("node:fs");
+  const origWrite = fsMod.default.writeFileSync;
+  const writes = [];
+  fsMod.default.writeFileSync = (p, data) => writes.push(String(data));
+  try {
+    const res = await c.applyClockCap(
+      { domain: "cpu-big", maxMHz: 9999, persist: false },
+      { hardMinMHz: 338, hardMaxMHz: 2808 }
+    );
+    assert.equal(res.appliedMHz, 2808);
+    assert.ok(res.warnings.some((w) => /clamped/.test(w)));
+    assert.equal(writes[0], "2808000\n");
+  } finally {
+    fsMod.default.writeFileSync = origWrite;
+  }
+});
+
+test("applyClockCap remove-cap writes each core's own hardware max (no 0 sentinel)", async () => {
+  const c = localCollector();
+  c._cpuDomainCores = () => ["cpu5", "cpu6"];
+  c._readSysFile = (p) => (/cpuinfo_max_freq/.test(p) ? "3900000" : null);
+  const fsMod = await import("node:fs");
+  const origWrite = fsMod.default.writeFileSync;
+  const writes = [];
+  fsMod.default.writeFileSync = (p, data) => writes.push({ p: String(p), data: String(data) });
+  try {
+    const res = await c.applyClockCap(
+      { domain: "cpu-little", maxMHz: null, persist: false },
+      { hardMinMHz: 1378, hardMaxMHz: 3900 }
+    );
+    assert.equal(res.appliedMHz, null);
+    assert.deepEqual(
+      writes.map((w) => w.data),
+      ["3900000\n", "3900000\n"]
+    );
+  } finally {
+    fsMod.default.writeFileSync = origWrite;
+  }
+});
+
+test("applyClockCap local persist failure reports persisted:false with the reboot warning", async () => {
+  const c = localCollector();
+  c._cpuDomainCores = () => ["cpu0"];
+  const fsMod = await import("node:fs");
+  const origWrite = fsMod.default.writeFileSync;
+  fsMod.default.writeFileSync = () => {};
+  try {
+    c._persistClockUnitLocal = async () => {
+      throw new Error("nsenter unavailable");
+    };
+    const res = await c.applyClockCap(
+      { domain: "cpu-big", maxMHz: 2600, persist: true },
+      { hardMinMHz: 338, hardMaxMHz: 2808 }
+    );
+    assert.equal(res.ok, true);
+    assert.equal(res.persisted, false);
+    assert.equal(res.source, "container");
+    assert.ok(res.warnings.some((w) => /reverts on reboot/.test(w)));
+    assert.equal(c._clockCapsOverride["cpu-big"], 2600);
+  } finally {
+    fsMod.default.writeFileSync = origWrite;
+  }
+});
+
+test("applyClockCap successful local persist clears volatile overrides", async () => {
+  const c = localCollector();
+  c._cpuDomainCores = () => ["cpu0"];
+  const fsMod = await import("node:fs");
+  const origWrite = fsMod.default.writeFileSync;
+  fsMod.default.writeFileSync = () => {};
+  try {
+    c._persistClockUnitLocal = async () => {};
+    const res = await c.applyClockCap(
+      { domain: "cpu-big", maxMHz: 2600, persist: true },
+      { hardMinMHz: 338, hardMaxMHz: 2808 }
+    );
+    assert.equal(res.ok, true);
+    assert.equal(res.persisted, true);
+    assert.equal(res.bootUnit, "cpu-clock-cap.service");
+    assert.deepEqual(c._clockCapsOverride, {});
+    assert.ok(!res.warnings.some((w) => /reverts on reboot/.test(w)));
+  } finally {
+    fsMod.default.writeFileSync = origWrite;
+  }
+});
+
+test("remote unit with no helper fails without attempting the container path", async () => {
+  const c = new SystemCollector({ id: "remote", kind: "spark", isLocal: false });
+  // sshExec (module-level) would fail on a non-existent host; assert the
+  // decision logic directly: only local units have the container fallback.
+  const res = await c.applyClockCap(
+    { domain: "gpu", maxMHz: 2200, persist: true },
+    { hardMinMHz: 0, hardMaxMHz: 3003 }
+  );
+  // On this host the ssh attempt fails fast (no route); whatever the exact
+  // transport error, a remote unit must never report source:"container".
+  assert.equal(res.ok, false);
+  assert.notEqual(res.source, "container");
+});

--- a/server/collectors/__tests__/SystemCollector.clockControl.test.js
+++ b/server/collectors/__tests__/SystemCollector.clockControl.test.js
@@ -124,13 +124,15 @@ test("_getClockBounds falls back to GPU_CLOCK_MAX_MHZ with source=fallback on un
   assert.equal(b.gpuCeilingMHz, 3003); // documented default
 });
 
-test("remote bounds command dumps min/max freqs then -q -d CLOCK", () => {
+test("remote bounds command dumps min/max freqs, -q -d CLOCK, then both boot units", () => {
   const c = new SystemCollector({ id: "t", kind: "spark", isLocal: false });
   const cmd = c._buildRemoteClockBoundsCommand();
   assert.match(cmd, /cpuinfo_min_freq/);
   assert.match(cmd, /cpuinfo_max_freq/);
   assert.match(cmd, /nvidia-smi -q -d CLOCK/);
-  assert.equal((cmd.match(/echo '---'/g) || []).length, 1);
+  assert.match(cmd, /cpu-clock-cap\.service/);
+  assert.match(cmd, /gpu-clock-lock\.service/);
+  assert.equal((cmd.match(/echo '---'/g) || []).length, 3);
 });
 
 // ─── D4: apply paths ──────────────────────────────────────

--- a/server/collectors/__tests__/SystemCollector.clockControl.test.js
+++ b/server/collectors/__tests__/SystemCollector.clockControl.test.js
@@ -76,6 +76,27 @@ test("clearClockCapsOverride drops all volatile state (hot config)", async () =>
   assert.deepEqual(c._clockCapsOverride, {});
 });
 
+test("a gpu live-only override survives a diverging unit-file read (D5)", async () => {
+  const c = localCollector();
+  // A live-only -lgc apply is invisible to the unit file: until a read
+  // actually reports the applied value, the override must keep the UI honest.
+  c._clockCapsOverride.gpu = 2400;
+  c._readLocalCpuCapDump = async () => "cpu0:2808000:2808000\ncpu5:2600000:3900000";
+  c._readLocalGpuLockUnit = async () => "-lgc 0,2200"; // unit still says 2200
+  await c._getClockCaps();
+  assert.equal(c._clockCapsOverride.gpu, 2400);
+});
+
+test("a gpu override drops once a fresh read converges to it", async () => {
+  const c = localCollector();
+  c._clockCapsOverride.gpu = 2400;
+  c._readLocalCpuCapDump = async () => "cpu0:2808000:2808000\ncpu5:2600000:3900000";
+  c._readLocalGpuLockUnit = async () => "-lgc 0,2400";
+  c._clockCapsCache = { at: 0, cpuDomains: null, gpuLock: null }; // force fresh read
+  await c._getClockCaps();
+  assert.ok(!Object.prototype.hasOwnProperty.call(c._clockCapsOverride, "gpu"));
+});
+
 // ─── D8: bounds discovery ─────────────────────────────────
 
 test("_getClockBounds parses cpu bounds and the GPU ceiling from smi output", async () => {
@@ -255,4 +276,76 @@ test("remote unit with no helper fails without attempting the container path", a
   // transport error, a remote unit must never report source:"container".
   assert.equal(res.ok, false);
   assert.notEqual(res.source, "container");
+});
+
+// ─── shared boot unit: a one-domain Save must preserve the sibling ─────────
+
+const BIG_CORES = ["cpu0", "cpu1"];
+const LITTLE_CORES = ["cpu5", "cpu6"];
+
+function persistCapturingCollector(overrides = {}, siblingReads = {}) {
+  const c = localCollector();
+  c._cpuDomainCores = (d) => (d === "cpu-big" ? BIG_CORES : LITTLE_CORES);
+  c._clockCapsOverride = { ...overrides };
+  c._readSysFile = (p) => {
+    for (const [cpuN, val] of Object.entries(siblingReads)) {
+      if (p.includes(`/${cpuN}/cpufreq/max_perf`)) return val;
+    }
+    return null;
+  };
+  let captured = "";
+  c._exec = async (cmd) => {
+    captured = cmd;
+    return "";
+  };
+  c._captured = () => captured;
+  return c;
+}
+
+test("persisting one CPU domain carries the sibling domain's live values", async () => {
+  // Both domains share cpu-clock-cap.service; saving only cpu-big must not
+  // clobber cpu-little's boot cap (2600000 kHz live right now).
+  const c = persistCapturingCollector({}, { cpu5: "2600000\n", cpu6: "2600000\n" });
+  await c._persistClockUnitLocal("cpu-big", 2808);
+  const cmd = c._captured();
+  assert.match(cmd, /echo 2808000 > \/sys\/devices\/system\/cpu\/cpu0\/cpufreq\/max_perf/);
+  assert.match(cmd, /echo 2808000 > \/sys\/devices\/system\/cpu\/cpu1\/cpufreq\/max_perf/);
+  assert.match(cmd, /echo 2600000 > \/sys\/devices\/system\/cpu\/cpu5\/cpufreq\/max_perf/);
+  assert.match(cmd, /echo 2600000 > \/sys\/devices\/system\/cpu\/cpu6\/cpufreq\/max_perf/);
+});
+
+test("persisted sibling value prefers its volatile override over the live read", async () => {
+  const c = persistCapturingCollector(
+    { "cpu-little": 2400 },
+    { cpu5: "2600000\n", cpu6: "2600000\n" }
+  );
+  await c._persistClockUnitLocal("cpu-big", 2808);
+  const cmd = c._captured();
+  assert.match(cmd, /echo 2400000 > \/sys\/devices\/system\/cpu\/cpu5\/cpufreq\/max_perf/);
+  assert.match(cmd, /echo 2400000 > \/sys\/devices\/system\/cpu\/cpu6\/cpufreq\/max_perf/);
+  assert.doesNotMatch(cmd, /echo 2600000 >/);
+});
+
+test("persisted sibling cores with unreadable max_perf are omitted (no guesses)", async () => {
+  const c = persistCapturingCollector({}, {});
+  await c._persistClockUnitLocal("cpu-big", 2808);
+  const cmd = c._captured();
+  assert.doesNotMatch(cmd, /cpu5/);
+  assert.doesNotMatch(cmd, /cpu6/);
+});
+
+test("persisted unit ExecStart contains no shell loop variables (systemd $ expansion)", async () => {
+  const c = persistCapturingCollector({}, { cpu5: "2600000\n", cpu6: "2600000\n" });
+  await c._persistClockUnitLocal("cpu-big", 2808);
+  assert.doesNotMatch(c._captured(), /\$c\b/);
+  await c._persistClockUnitLocal("cpu-big", null);
+  assert.doesNotMatch(c._captured(), /\$c\b/);
+});
+
+test("remove-cap persist writes each edited core's cpuinfo_max_freq and keeps the sibling", async () => {
+  const c = persistCapturingCollector({}, { cpu5: "2600000\n", cpu6: "2600000\n" });
+  await c._persistClockUnitLocal("cpu-big", null);
+  const cmd = c._captured();
+  assert.match(cmd, /cat \/sys\/devices\/system\/cpu\/cpu0\/cpufreq\/cpuinfo_max_freq > \/sys\/devices\/system\/cpu\/cpu0\/cpufreq\/max_perf/);
+  assert.match(cmd, /echo 2600000 > \/sys\/devices\/system\/cpu\/cpu5\/cpufreq\/max_perf/);
 });

--- a/server/collectors/__tests__/clockControl.test.js
+++ b/server/collectors/__tests__/clockControl.test.js
@@ -5,8 +5,11 @@ import {
   clampClockCap,
   buildClockCapDomains,
   buildClockHelperArgv,
+  expandCpuToken,
   interpretHelperExit,
   parseCpuClockBounds,
+  parseCpuCoreMaxKhz,
+  parseCpuBootUnitDefaults,
   parseDefaultApplicationsGraphicsClock,
   validateClockCapRequest,
 } from "../clockControl.js";
@@ -23,7 +26,7 @@ const CPU_DUMP_BOUNDS = [
   "cpu5:1378000:3900000",
   "cpu6:1378000:3900000",
   "cpu9:1378000:3900000",
-  "cpu10:1378000:3900000",
+  "cpu10:338000:2808000",
   "cpu15:1378000:3900000",
   "cpu19:1378000:3900000",
 ].join("\n");
@@ -253,4 +256,78 @@ test("buildClockCapDomains reports unwritable with a reason when the helper is m
     assert.equal(d.writable, false);
     assert.match(d.reason, /helper not installed/);
   }
+});
+
+// ─── D7: boot-default presets, parsed from the real boot units ─────────────
+
+test("expandCpuToken expands systemd brace ranges and passes single cores", () => {
+  assert.deepEqual(expandCpuToken("cpu5"), ["cpu5"]);
+  assert.deepEqual(expandCpuToken("cpu{5..9,15..19}"), [
+    "cpu5",
+    "cpu6",
+    "cpu7",
+    "cpu8",
+    "cpu9",
+    "cpu15",
+    "cpu16",
+    "cpu17",
+    "cpu18",
+    "cpu19",
+  ]);
+  assert.deepEqual(expandCpuToken("cpu{0..4,10..14}").length, 10);
+  assert.deepEqual(expandCpuToken("garbage"), []);
+  assert.deepEqual(expandCpuToken("cpu{20..5}"), []); // inverted range
+  assert.deepEqual(expandCpuToken("cpu{0..99999}"), []); // absurd range rejected
+});
+
+test("parseCpuBootUnitDefaults maps the measured boot unit onto the discovered domains", () => {
+  // The unit actually installed on spark-1 (brace ranges, kHz values).
+  const unit = [
+    "ExecStart=/bin/sh -c ' echo 2600000 > /sys/devices/system/cpu/cpu{5..9,15..19}/cpufreq/max_perf; echo 2808000 > /sys/devices/system/cpu/cpu{0..4,10..14}/cpufreq/max_perf'",
+  ].join("\n");
+  const defaults = parseCpuBootUnitDefaults(unit, parseCpuCoreMaxKhz(CPU_DUMP_BOUNDS));
+  // Domain ids follow the existing convention (≥3 MHz group = cpu-big): the
+  // 3900000 kHz cores (cpu5+) are cpu-big, the 2808000 kHz cores cpu-little.
+  assert.equal(defaults["cpu-big"], 2600);
+  assert.equal(defaults["cpu-little"], 2808);
+});
+
+test("parseCpuBootUnitDefaults also handles explicit per-core echoes and skips unknown cores", () => {
+  const unit = [
+    "ExecStart=/bin/sh -c 'echo 2600000 > /sys/devices/system/cpu/cpu5/cpufreq/max_perf; echo 2808000 > /sys/devices/system/cpu/cpu0/cpufreq/max_perf; echo 9999000 > /sys/devices/system/cpu/cpu42/cpufreq/max_perf'",
+  ].join("\n");
+  const defaults = parseCpuBootUnitDefaults(unit, parseCpuCoreMaxKhz(CPU_DUMP_BOUNDS));
+  // cpu42 is not in the discovered map → skipped, not guessed.
+  assert.deepEqual(defaults, { "cpu-big": 2600, "cpu-little": 2808 });
+});
+
+test("buildClockCapDomains exposes Boot default presets from the parsed units", () => {
+  const domains = buildClockCapDomains({
+    cpuDomains: [
+      { label: "X925", capMHz: 2808, maxMHz: 3900, capped: true },
+      { label: "A725", capMHz: 2600, maxMHz: 2808, capped: true },
+    ],
+    gpuLock: { minMHz: 0, maxMHz: 2200 },
+    cpuBounds: parseCpuClockBounds(CPU_DUMP_BOUNDS),
+    gpuCeilingMHz: 3003,
+    helperAvailable: true,
+    helperChecked: true,
+    cpuBootDefaults: { "cpu-big": 2808, "cpu-little": 2600 },
+    gpuBootDefaultMHz: 2200,
+  });
+  const big = domains.find((d) => d.id === "cpu-big");
+  assert.deepEqual(big.presets, [
+    { label: "Boot default", value: 2808 },
+    { label: "No cap", value: 3900 },
+  ]);
+  const little = domains.find((d) => d.id === "cpu-little");
+  assert.deepEqual(little.presets, [
+    { label: "Boot default", value: 2600 },
+    { label: "No cap", value: 2808 },
+  ]);
+  const gpu = domains.find((d) => d.id === "gpu");
+  assert.deepEqual(gpu.presets, [
+    { label: "Boot default", value: 2200 },
+    { label: "No cap", value: null },
+  ]);
 });

--- a/server/collectors/__tests__/clockControl.test.js
+++ b/server/collectors/__tests__/clockControl.test.js
@@ -1,0 +1,256 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  CLOCK_DOMAIN_IDS,
+  clampClockCap,
+  buildClockCapDomains,
+  buildClockHelperArgv,
+  interpretHelperExit,
+  parseCpuClockBounds,
+  parseDefaultApplicationsGraphicsClock,
+  validateClockCapRequest,
+} from "../clockControl.js";
+
+// ─── Fixtures: measured spark-1 values (trusting the orchestrator's probes) ──
+
+/** Real sysfs dump shape: cpuN:min_freq:max_freq (cppc_cpufreq, 2 domains). */
+const CPU_DUMP_BOUNDS = [
+  "cpu0:338000:2808000",
+  "cpu1:338000:2808000",
+  "cpu2:338000:2808000",
+  "cpu3:338000:2808000",
+  "cpu4:338000:2808000",
+  "cpu5:1378000:3900000",
+  "cpu6:1378000:3900000",
+  "cpu9:1378000:3900000",
+  "cpu10:1378000:3900000",
+  "cpu15:1378000:3900000",
+  "cpu19:1378000:3900000",
+].join("\n");
+
+/** Real `nvidia-smi -q -d CLOCK` transcript shape (GB10, driver 580.x). */
+const SMI_Q_CLOCK = [
+  "==============NVML Errors===============",
+  "",
+  "==============Device Keys===============",
+  "",
+  "==============Clocks==============",
+  "",
+  "    Clocks Event Reasons",
+  "        HW Thermal Slowdown            : Not Active",
+  "",
+  "    Max Clocks",
+  "        Graphics                       : 3003 MHz",
+  "        SM                             : 3003 MHz",
+  "",
+  "    Default Applications Clock",
+  "        Graphics                       : 3003 MHz",
+  "",
+  "    SM Clock",
+  "        Graphics                       : 1500 MHz",
+  "",
+].join("\n");
+
+test("parseCpuClockBounds groups cores into two hardware domains", () => {
+  const bounds = parseCpuClockBounds(CPU_DUMP_BOUNDS);
+  assert.equal(bounds.length, 2);
+  // Sorted max desc: little domain (3900) first, then big (2808).
+  assert.deepEqual(bounds[0], { minKhz: 1378000, maxKhz: 3900000 });
+  assert.deepEqual(bounds[1], { minKhz: 338000, maxKhz: 2808000 });
+});
+
+test("parseCpuClockBounds keeps the strictest (largest) min floor per domain", () => {
+  const bounds = parseCpuClockBounds("cpu0:338000:2808000\ncpu1:400000:2808000");
+  assert.equal(bounds.length, 1);
+  assert.equal(bounds[0].minKhz, 400000);
+});
+
+test("parseCpuClockBounds ignores malformed lines and empty input", () => {
+  assert.deepEqual(parseCpuClockBounds("garbage\ncpu0:abc:3900000\n\n"), []);
+  assert.deepEqual(parseCpuClockBounds(""), []);
+  assert.deepEqual(parseCpuClockBounds(null), []);
+});
+
+test("parseDefaultApplicationsGraphicsClock reads the Graphics value from the Default Applications Clock block", () => {
+  assert.equal(parseDefaultApplicationsGraphicsClock(SMI_Q_CLOCK), 3003);
+});
+
+test("parseDefaultApplicationsGraphicsClock is anchored to the Default Applications Clock block", () => {
+  // "Max Clocks / Graphics 9999" must not win over the Default block.
+  const t = [
+    "    Max Clocks",
+    "        Graphics                       : 9999 MHz",
+    "",
+    "    Default Applications Clock",
+    "        Graphics                       : 3003 MHz",
+  ].join("\n");
+  assert.equal(parseDefaultApplicationsGraphicsClock(t), 3003);
+});
+
+test("parseDefaultApplicationsGraphicsClock returns null on missing/garbage transcript", () => {
+  assert.equal(parseDefaultApplicationsGraphicsClock(""), null);
+  assert.equal(parseDefaultApplicationsGraphicsClock("no clocks here"), null);
+  assert.equal(parseDefaultApplicationsGraphicsClock(null), null);
+  // [N/A] platform case (query-supported-clocks returns N/A; -q parse fails too)
+  assert.equal(parseDefaultApplicationsGraphicsClock("Default Applications Clock\n        Graphics : N/A"), null);
+});
+
+// ─── Clamping (D2) ────────────────────────────────────────
+
+test("clampClockCap clamps above the hardware max and records a warning", () => {
+  const warnings = [];
+  const out = clampClockCap(4200, 1378, 3900, { warnings });
+  assert.equal(out, 3900);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /above the hardware maximum/);
+});
+
+test("clampClockCap clamps below the hardware min and records a warning", () => {
+  const warnings = [];
+  const out = clampClockCap(100, 1378, 3900, { warnings });
+  assert.equal(out, 1378);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /below the hardware minimum/);
+});
+
+test("clampClockCap passes null (remove cap) and in-range values through", () => {
+  assert.equal(clampClockCap(null, 0, 3003), null);
+  assert.equal(clampClockCap(2200, 0, 3003), 2200);
+});
+
+// ─── Request validation (D1/D2) ───────────────────────────
+
+const DOMAINS = [
+  { id: "cpu-big", hardMinMHz: 338, hardMaxMHz: 2808 },
+  { id: "cpu-little", hardMinMHz: 1378, hardMaxMHz: 3900 },
+  { id: "gpu", hardMinMHz: 0, hardMaxMHz: 3003 },
+];
+
+test("validateClockCapRequest accepts an in-range integer and normalizes persist", () => {
+  const out = validateClockCapRequest({ domain: "gpu", maxMHz: 2200 }, DOMAINS);
+  assert.deepEqual(out.value, { domain: "gpu", maxMHz: 2200, persist: false });
+  const out2 = validateClockCapRequest({ domain: "gpu", maxMHz: 2200, persist: true }, DOMAINS);
+  assert.equal(out2.value.persist, true);
+});
+
+test("validateClockCapRequest accepts maxMHz null as remove-the-cap", () => {
+  const out = validateClockCapRequest({ domain: "cpu-big", maxMHz: null }, DOMAINS);
+  assert.deepEqual(out.value, { domain: "cpu-big", maxMHz: null, persist: false });
+});
+
+test("validateClockCapRequest rejects out-of-range, float, string, and NaN maxMHz", () => {
+  assert.equal(validateClockCapRequest({ domain: "gpu", maxMHz: 3500 }, DOMAINS).ok, false);
+  assert.equal(validateClockCapRequest({ domain: "gpu", maxMHz: -1 }, DOMAINS).ok, false);
+  assert.equal(validateClockCapRequest({ domain: "gpu", maxMHz: 2200.5 }, DOMAINS).ok, false);
+  assert.equal(validateClockCapRequest({ domain: "gpu", maxMHz: "2200" }, DOMAINS).ok, false);
+  assert.equal(validateClockCapRequest({ domain: "gpu", maxMHz: Number.NaN }, DOMAINS).ok, false);
+});
+
+test("validateClockCapRequest rejects unknown domains and non-boolean persist", () => {
+  assert.equal(validateClockCapRequest({ domain: "mem", maxMHz: 100 }, DOMAINS).ok, false);
+  assert.equal(validateClockCapRequest({ domain: 7, maxMHz: 100 }, DOMAINS).ok, false);
+  assert.equal(validateClockCapRequest({ domain: "gpu", maxMHz: 100, persist: "yes" }, DOMAINS).ok, false);
+  // Valid enum id but not exposed on this unit (no cpu-little present):
+  const onlyBig = [{ id: "cpu-big", hardMinMHz: 338, hardMaxMHz: 2808 }];
+  assert.equal(validateClockCapRequest({ domain: "cpu-little", maxMHz: 2000 }, onlyBig).ok, false);
+});
+
+test("validateClockCapRequest tolerates a missing/undefined body", () => {
+  assert.equal(validateClockCapRequest(undefined, DOMAINS).ok, false);
+  assert.equal(validateClockCapRequest(null, DOMAINS).ok, false);
+});
+
+// ─── Helper argv (D4) ─────────────────────────────────────
+
+test("buildClockHelperArgv mirrors SHUTDOWN_REMOTE_CMD shape with distinct 127/126 exits", () => {
+  const cmd = buildClockHelperArgv({ domain: "gpu", maxMHz: 2200, persist: true });
+  assert.match(cmd, /^test -x \/usr\/local\/bin\/sparkdash-set-clock \|\| \{ echo "missing/);
+  assert.match(cmd, /exit 127; \}/);
+  assert.match(cmd, /sudo -n true \|\| \{ echo "sudo -n required/);
+  assert.match(cmd, /exit 126; \}/);
+  assert.match(cmd, /sudo -n \/usr\/local\/bin\/sparkdash-set-clock --domain 'gpu' --max-mhz 2200 --persist$/);
+});
+
+test("buildClockHelperArgv uses --unlock and --no-persist for a remove-cap request", () => {
+  const cmd = buildClockHelperArgv({ domain: "cpu-big", maxMHz: null, persist: false });
+  assert.match(cmd, /--domain 'cpu-big' --unlock --no-persist$/);
+});
+
+test("buildClockHelperArgv single-quotes the domain", () => {
+  const cmd = buildClockHelperArgv({ domain: "cpu-big", maxMHz: 2808, persist: true });
+  assert.match(cmd, /--domain 'cpu-big'/);
+});
+
+// ─── Exit-code interpretation (D4) ────────────────────────
+
+test("interpretHelperExit maps 127 to 423 with an install hint", () => {
+  const out = interpretHelperExit(new Error("SSH to 1.2.3.4 failed: missing /usr/local/bin/sparkdash-set-clock\nexit 127"));
+  assert.equal(out.status, 423);
+  assert.match(out.reason, /install-clock-helper\.sh/);
+});
+
+test("interpretHelperExit maps 126 to 423 with a sudoers hint", () => {
+  const out = interpretHelperExit(new Error("SSH to 1.2.3.4 failed: sudo -n required for /usr/local/bin/sparkdash-set-clock\nexit 126"));
+  assert.equal(out.status, 423);
+  assert.match(out.reason, /passwordless sudo/);
+});
+
+test("interpretHelperExit maps transport timeouts to 503 and anything else to 502", () => {
+  assert.equal(interpretHelperExit(new Error("SSH timed out after 12000ms")).status, 503);
+  assert.equal(interpretHelperExit(new Error("nvidia-smi refused")).status, 502);
+  assert.equal(interpretHelperExit(new Error("connection refused")).status, 503);
+});
+
+// ─── Client-facing domain shape (D1/D7) ───────────────────
+
+test("buildClockCapDomains exposes CPU bounds, GPU ceiling, presets, and writability", () => {
+  const domains = buildClockCapDomains({
+    cpuDomains: [
+      { label: "X925", capMHz: 2600, maxMHz: 3900, capped: true },
+      { label: "A725", capMHz: 2808, maxMHz: 2808, capped: false },
+    ],
+    gpuLock: { minMHz: 0, maxMHz: 2200 },
+    cpuBounds: parseCpuClockBounds(CPU_DUMP_BOUNDS),
+    gpuCeilingMHz: 3003,
+    helperAvailable: true,
+    helperChecked: true,
+  });
+  assert.deepEqual(
+    domains.map((d) => d.id),
+    // Existing convention (parseCpuClockCaps): the 3900 MHz group sorts first
+    // and is the "big" id; 2808 is the second domain.
+    ["cpu-big", "cpu-little", "gpu"]
+  );
+  const little = domains.find((d) => d.id === "cpu-little");
+  assert.equal(little.currentMHz, 2808); // uncapped: cap == hardware max
+  assert.equal(little.hardMinMHz, 338);
+  assert.equal(little.hardMaxMHz, 2808);
+  assert.deepEqual(little.presets, [{ label: "No cap", value: 2808 }]);
+  assert.equal(little.unitPath, "/etc/systemd/system/cpu-clock-cap.service");
+  assert.equal(little.writable, true);
+  const big = domains.find((d) => d.id === "cpu-big");
+  assert.equal(big.currentMHz, 2600); // capped below the 3900 hardware max
+  assert.equal(big.hardMinMHz, 1378);
+  assert.equal(big.hardMaxMHz, 3900);
+  assert.equal(big.capped, undefined); // server shape, not the read shape
+  const gpu = domains.find((d) => d.id === "gpu");
+  assert.equal(gpu.currentMHz, 2200);
+  assert.equal(gpu.hardMinMHz, 0);
+  assert.equal(gpu.hardMaxMHz, 3003);
+  assert.equal(gpu.unitPath, "/etc/systemd/system/gpu-clock-lock.service");
+});
+
+test("buildClockCapDomains reports unwritable with a reason when the helper is missing", () => {
+  const domains = buildClockCapDomains({
+    cpuDomains: null,
+    gpuLock: null,
+    cpuBounds: parseCpuClockBounds(CPU_DUMP_BOUNDS),
+    gpuCeilingMHz: 3003,
+    helperAvailable: false,
+    helperChecked: true,
+  });
+  for (const d of domains) {
+    assert.equal(d.writable, false);
+    assert.match(d.reason, /helper not installed/);
+  }
+});

--- a/server/collectors/__tests__/clockControl.test.js
+++ b/server/collectors/__tests__/clockControl.test.js
@@ -1,12 +1,22 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
   CLOCK_DOMAIN_IDS,
+  HELPER_PROBE_MISSING,
+  HELPER_PROBE_OK,
+  HELPER_PROBE_REFUSED,
+  HELPER_REFUSED_SENTINEL,
   clampClockCap,
   buildClockCapDomains,
   buildClockHelperArgv,
+  buildHelperProbeCommand,
   expandCpuToken,
   interpretHelperExit,
+  interpretHelperProbe,
   parseCpuClockBounds,
   parseCpuCoreMaxKhz,
   parseCpuBootUnitDefaults,
@@ -164,13 +174,21 @@ test("validateClockCapRequest tolerates a missing/undefined body", () => {
 });
 
 // ─── Helper argv (D4) ─────────────────────────────────────
+//
+// The shipped sudoers grant is ONE argumentless command
+// (`NOPASSWD: /usr/local/bin/sparkdash-set-clock`), so the chain must never
+// gate on `sudo -n true` — no scoped sudoers file permits it.
 
-test("buildClockHelperArgv mirrors SHUTDOWN_REMOTE_CMD shape with distinct 127/126 exits", () => {
+test("buildClockHelperArgv probes the granted binary argumentlessly with distinct 127/126 exits", () => {
   const cmd = buildClockHelperArgv({ domain: "gpu", maxMHz: 2200, persist: true });
   assert.match(cmd, /^test -x \/usr\/local\/bin\/sparkdash-set-clock \|\| \{ echo "missing/);
   assert.match(cmd, /exit 127; \}/);
-  assert.match(cmd, /sudo -n true \|\| \{ echo "sudo -n required/);
-  assert.match(cmd, /exit 126; \}/);
+  // Availability probe = the granted command itself, argumentless; a sudo
+  // refusal (no usage line, nonzero rc) hits the sentinel + exit 126.
+  assert.match(cmd, /out=\$\(sudo -n \/usr\/local\/bin\/sparkdash-set-clock 2>&1\); rc=\$\?/);
+  assert.doesNotMatch(cmd, /sudo -n true/);
+  assert.match(cmd, new RegExp(`echo "${HELPER_REFUSED_SENTINEL}: sudo -n refused`));
+  assert.match(cmd, /exit 126; fi/);
   assert.match(cmd, /sudo -n \/usr\/local\/bin\/sparkdash-set-clock --domain 'gpu' --max-mhz 2200 --persist$/);
 });
 
@@ -184,18 +202,105 @@ test("buildClockHelperArgv single-quotes the domain", () => {
   assert.match(cmd, /--domain 'cpu-big'/);
 });
 
+// ─── Availability probe (exercises exactly the scoped grant) ────────────────
+
+/** Usage-printing stub with the real helper's argv semantics (lines 27-30). */
+function makeFakeHelper(dir) {
+  const p = path.join(dir, "sparkdash-set-clock");
+  fs.writeFileSync(
+    p,
+    "#!/bin/sh\necho 'usage: sparkdash-set-clock --domain cpu-big|cpu-little|gpu (--max-mhz <int>|--unlock) (--persist|--no-persist)' >&2\nexit 1\n"
+  );
+  fs.chmodSync(p, 0o755);
+  return p;
+}
+
+/** sudo stub enforcing the SCOPED grant: only `-n <bin>` with no args. */
+function makeScopedSudo(dir, allowedBin, { alwaysRefuse = false } = {}) {
+  const p = path.join(dir, "sudo");
+  const body = alwaysRefuse
+    ? `#!/bin/sh\necho "sudo: a password is required" >&2\nexit 1\n`
+    : `#!/bin/sh
+[ "\$1" = "-n" ] || { echo "sudo: a password is required" >&2; exit 1; }
+[ "\$#" -eq 2 ] && [ "\$2" = "${allowedBin}" ] || { echo "sudo: a password is required" >&2; exit 1; }
+exec "\$2"
+`;
+  fs.writeFileSync(p, body);
+  fs.chmodSync(p, 0o755);
+  return p;
+}
+
+function runProbe(probeCmd, dir) {
+  return execFileSync("sh", ["-c", probeCmd], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+  });
+}
+
+test("probe reports available under ONLY the scoped grant (no unrestricted NOPASSWD true)", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-probe-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const helper = makeFakeHelper(dir);
+  makeScopedSudo(dir, helper); // refuses everything except the argumentless helper
+  const probeCmd = buildHelperProbeCommand({ helperBin: helper });
+  assert.ok(!probeCmd.includes("sudo -n true"), "the probe must not depend on `sudo -n true`");
+  assert.equal(runProbe(probeCmd, dir).trim(), HELPER_PROBE_OK);
+  assert.deepEqual(interpretHelperProbe(HELPER_PROBE_OK), {
+    available: true,
+    checked: true,
+  });
+});
+
+test("probe reports the provisioning hint when sudo refuses the granted command", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-probe-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const helper = makeFakeHelper(dir);
+  makeScopedSudo(dir, helper, { alwaysRefuse: true });
+  const out = runProbe(buildHelperProbeCommand({ helperBin: helper }), dir).trim();
+  assert.equal(out, HELPER_PROBE_REFUSED);
+  const state = interpretHelperProbe(out);
+  assert.equal(state.available, false);
+  assert.match(state.reason, /passwordless sudo/);
+  // ...and the apply-path classifier maps the refusal sentinel to the SAME cause.
+  const interpreted = interpretHelperExit(
+    new Error(`SSH to 1.2.3.4 failed: ${HELPER_REFUSED_SENTINEL}: sudo -n refused\nexit 126`)
+  );
+  assert.equal(interpreted.status, 423);
+  assert.match(interpreted.reason, /passwordless sudo/);
+});
+
+test("probe reports not-installed when the binary is absent", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-probe-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  makeScopedSudo(dir, path.join(dir, "nope")); // sudo present, helper missing
+  const out = runProbe(buildHelperProbeCommand({ helperBin: path.join(dir, "nope") }), dir).trim();
+  assert.equal(out, HELPER_PROBE_MISSING);
+  const state = interpretHelperProbe(out);
+  assert.equal(state.available, false);
+  assert.match(state.reason, /not installed/);
+});
+
 // ─── Exit-code interpretation (D4) ────────────────────────
 
-test("interpretHelperExit maps 127 to 423 with an install hint", () => {
-  const out = interpretHelperExit(new Error("SSH to 1.2.3.4 failed: missing /usr/local/bin/sparkdash-set-clock\nexit 127"));
+test("interpretHelperExit maps the missing-binary sentinel to 423 with an install hint", () => {
+  const out = interpretHelperExit(
+    new Error("SSH to 1.2.3.4 failed: missing /usr/local/bin/sparkdash-set-clock\nexit 127")
+  );
   assert.equal(out.status, 423);
   assert.match(out.reason, /install-clock-helper\.sh/);
 });
 
-test("interpretHelperExit maps 126 to 423 with a sudoers hint", () => {
-  const out = interpretHelperExit(new Error("SSH to 1.2.3.4 failed: sudo -n required for /usr/local/bin/sparkdash-set-clock\nexit 126"));
-  assert.equal(out.status, 423);
-  assert.match(out.reason, /passwordless sudo/);
+test("interpretHelperExit anchors on sentinels, never on bare numbers in the message", () => {
+  // A helper failure that merely MENTIONS 126/127 (a device id, a frequency)
+  // must NOT be mislabelled as not-installed / not-provisioned.
+  const noisy = new Error(
+    "SSH to 1.2.3.4 failed: nvidia-smi: GPU 127 at 126 MHz failed; exited with code 1"
+  );
+  const out = interpretHelperExit(noisy);
+  assert.equal(out.status, 502);
+  assert.doesNotMatch(out.reason, /not installed|passwordless sudo/);
+  // An external exit 126 with no sentinel is a generic 502, not a sudo claim.
+  assert.equal(interpretHelperExit(new Error("cmd exited with code 126")).status, 502);
 });
 
 test("interpretHelperExit maps transport timeouts to 503 and anything else to 502", () => {

--- a/server/collectors/__tests__/clockHelperScript.test.js
+++ b/server/collectors/__tests__/clockHelperScript.test.js
@@ -1,0 +1,228 @@
+// Helper-behaviour tests for scripts/sparkdash-set-clock (Gate 3).
+//
+// The helper is exercised with a stubbed sysfs tree under a temp dir (via the
+// SPARKDASH_CPU_SYS / SPARKDASH_UNIT_DIR test hooks; sudo's env reset means a
+// real remote invocation always uses the real /sys and /etc). The script file
+// is executed with `sh` — POSIX syntax only. Nothing here touches the real
+// /sys, /etc, or /usr/local.
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const HELPER = path.join(ROOT, "scripts", "sparkdash-set-clock");
+
+/** Build a stub sysfs tree: cores → {maxKhz (cpuinfo_max_freq), perf (max_perf)}. */
+function makeSysfs(root, cores) {
+  const cpuRoot = path.join(root, "sys");
+  for (const [cpuN, { maxKhz, perfKhz }] of Object.entries(cores)) {
+    const dir = path.join(cpuRoot, cpuN, "cpufreq");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "cpuinfo_max_freq"), `${maxKhz}\n`);
+    if (perfKhz != null) fs.writeFileSync(path.join(dir, "max_perf"), `${perfKhz}\n`);
+  }
+  return cpuRoot;
+}
+
+/**
+ * Run the helper against a stubbed tree.
+ * @param {string} cpuRoot stubbed sysfs cpu root
+ * @param {string[]} args helper argv after the program name
+ * @param {{ unitDir?: string }} [opts]
+ * @returns {{ stdout: string }} throws on nonzero exit (execFileSync default)
+ */
+function runHelper(cpuRoot, args, opts = {}) {
+  const unitDir = opts.unitDir ?? path.join(cpuRoot, "..", "units");
+  // Stub systemctl (the helper ends a persist with `daemon-reload`); the stub
+  // dir rides on PATH like the scoped-sudo fixtures in clockControl.test.js.
+  const stubDir = path.join(path.dirname(cpuRoot), "stub-bin");
+  fs.mkdirSync(stubDir, { recursive: true });
+  const systemctl = path.join(stubDir, "systemctl");
+  if (!fs.existsSync(systemctl)) {
+    fs.writeFileSync(systemctl, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(systemctl, 0o755);
+  }
+  const stdout = execFileSync("sh", [HELPER, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${stubDir}:${process.env.PATH}`,
+      SPARKDASH_CPU_SYS: cpuRoot,
+      SPARKDASH_UNIT_DIR: unitDir,
+    },
+  });
+  return { stdout };
+}
+
+// ─── The sibling must survive a single-domain persist ───────────────────────
+
+test("a cpu-big persist preserves the sibling little domain's max_perf lines", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const cpuRoot = makeSysfs(dir, {
+    cpu0: { maxKhz: 2808000, perfKhz: 2808000 },
+    cpu1: { maxKhz: 2808000, perfKhz: 2808000 },
+    cpu5: { maxKhz: 3900000, perfKhz: 2600000 }, // curated sibling cap
+    cpu6: { maxKhz: 3900000, perfKhz: 2600000 },
+  });
+  const unitDir = path.join(dir, "units");
+  fs.mkdirSync(unitDir);
+
+  runHelper(cpuRoot, ["--domain", "cpu-big", "--max-mhz", "2808", "--persist"]);
+
+  const unit = fs.readFileSync(path.join(unitDir, "cpu-clock-cap.service"), "utf8");
+  // Edited domain carries the requested value…
+  assert.match(unit, /echo 2808000 > \S*cpu0\/cpufreq\/max_perf/);
+  assert.match(unit, /echo 2808000 > \S*cpu1\/cpufreq\/max_perf/);
+  // …and the sibling's current live cap is NOT deleted.
+  assert.match(unit, /echo 2600000 > \S*cpu5\/cpufreq\/max_perf/);
+  assert.match(unit, /echo 2600000 > \S*cpu6\/cpufreq\/max_perf/);
+});
+
+test("a cpu-big persist with unreadable sibling max_perf omits those cores (no guesses)", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const cpuRoot = makeSysfs(dir, {
+    cpu0: { maxKhz: 2808000, perfKhz: 2808000 },
+    cpu5: { maxKhz: 3900000, perfKhz: null }, // unreadable sibling max_perf
+  });
+  const unitDir = path.join(dir, "units");
+  fs.mkdirSync(unitDir);
+
+  runHelper(cpuRoot, ["--domain", "cpu-big", "--max-mhz", "2600", "--persist"]);
+
+  const unit = fs.readFileSync(path.join(unitDir, "cpu-clock-cap.service"), "utf8");
+  assert.match(unit, /echo 2600000 > \S*cpu0\/cpufreq\/max_perf/);
+  assert.doesNotMatch(unit, /cpu5\/cpufreq\/max_perf/);
+});
+
+test("a remove-cap (unlock) persist keeps the sibling and restores own hardware max", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const cpuRoot = makeSysfs(dir, {
+    cpu0: { maxKhz: 2808000, perfKhz: 2200000 },
+    cpu5: { maxKhz: 3900000, perfKhz: 2600000 },
+  });
+  const unitDir = path.join(dir, "units");
+  fs.mkdirSync(unitDir);
+
+  runHelper(cpuRoot, ["--domain", "cpu-big", "--unlock", "--persist"]);
+
+  const unit = fs.readFileSync(path.join(unitDir, "cpu-clock-cap.service"), "utf8");
+  assert.match(unit, /cat \S*cpu0\/cpufreq\/cpuinfo_max_freq > \S*cpu0\/cpufreq\/max_perf/);
+  assert.match(unit, /echo 2600000 > \S*cpu5\/cpufreq\/max_perf/);
+});
+
+test("the helper and the container persist path emit the same CPU ExecStart for one request", (t) => {
+  // Same stub topology the SystemCollector persist tests use.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const cpuRoot = makeSysfs(dir, {
+    cpu0: { maxKhz: 2808000, perfKhz: 2808000 },
+    cpu1: { maxKhz: 2808000, perfKhz: 2808000 },
+    cpu10: { maxKhz: 2808000, perfKhz: 2808000 },
+    cpu5: { maxKhz: 3900000, perfKhz: 2600000 },
+    cpu6: { maxKhz: 3900000, perfKhz: 2600000 },
+  });
+  const unitDir = path.join(dir, "units");
+  fs.mkdirSync(unitDir);
+
+  // 1. Helper path: persist cpu-big 2808 while the sibling sits at 2600.
+  runHelper(cpuRoot, ["--domain", "cpu-big", "--max-mhz", "2808", "--persist"]);
+  const helperUnit = fs.readFileSync(path.join(unitDir, "cpu-clock-cap.service"), "utf8");
+  const helperExec = helperUnit.match(/^ExecStart=(.+)$/m)[1];
+
+  // 2. Container path: identical request, sibling values from live max_perf.
+  //    Mirror the collector's own command construction (the captured payload's
+  //    ExecStart) instead of stubbing node:fs module-wide.
+  const sibling = ["cpu5", "cpu6"]; // numeric order, as _cpuDomainCores returns
+  const parts = [
+    `echo 2808000 > /sys/devices/system/cpu/cpu0/cpufreq/max_perf`,
+    `echo 2808000 > /sys/devices/system/cpu/cpu1/cpufreq/max_perf`,
+    `echo 2808000 > /sys/devices/system/cpu/cpu10/cpufreq/max_perf`,
+    ...sibling.map((c) => `echo 2600000 > /sys/devices/system/cpu/${c}/cpufreq/max_perf`),
+  ];
+  const containerExec = `/bin/sh -c '${parts.join("; ")}'`;
+  assert.equal(helperExec, containerExec);
+
+  // 3. And the FULL unit bodies are byte-identical (what the collector writes
+  //    via its heredoc vs what the helper writes via its own heredoc).
+  const containerUnit = [
+    "[Unit]",
+    "Description=sparkDash CPU clock cap (big + little domains)",
+    "After=multi-user.target",
+    "",
+    "[Service]",
+    "Type=oneshot",
+    `ExecStart=${containerExec}`,
+    "RemainAfterExit=yes",
+    "",
+    "[Install]",
+    "WantedBy=multi-user.target",
+  ].join("\n");
+  assert.equal(helperUnit.trimEnd(), containerUnit);
+});
+
+test("cpu_apply writes max_perf for the edited domain only and returns success", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const cpuRoot = makeSysfs(dir, {
+    cpu0: { maxKhz: 2808000, perfKhz: 2808000 },
+    cpu5: { maxKhz: 3900000, perfKhz: 2600000 },
+  });
+
+  runHelper(cpuRoot, ["--domain", "cpu-little", "--max-mhz", "2400", "--no-persist"]);
+
+  assert.equal(fs.readFileSync(path.join(cpuRoot, "cpu5", "cpufreq", "max_perf"), "utf8").trim(), "2400000");
+  // Sibling untouched by the live apply.
+  assert.equal(fs.readFileSync(path.join(cpuRoot, "cpu0", "cpufreq", "max_perf"), "utf8").trim(), "2808000");
+});
+
+test("an argumentless invocation prints its usage and exits 1 (the probe contract)", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const cpuRoot = makeSysfs(dir, {});
+  let err = null;
+  try {
+    runHelper(cpuRoot, []);
+  } catch (e) {
+    err = e;
+  }
+  assert.ok(err, "argumentless run must exit nonzero");
+  assert.equal(err.status, 1);
+  assert.match(String(err.stderr), /^usage: /m);
+});
+
+test("a GPU persist emits the real gpu-clock-lock.service body", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const cpuRoot = makeSysfs(dir, { cpu0: { maxKhz: 2808000, perfKhz: 2808000 } });
+  const unitDir = path.join(dir, "units");
+  fs.mkdirSync(unitDir);
+
+  runHelper(cpuRoot, ["--domain", "gpu", "--max-mhz", "2200", "--persist"]);
+
+  const unit = fs.readFileSync(path.join(unitDir, "gpu-clock-lock.service"), "utf8");
+  assert.match(unit, /^ExecStart=\/usr\/bin\/nvidia-smi -lgc 0,2200$/m);
+  assert.match(unit, /^Description=Lock NVIDIA GPU graphics clocks to user range$/m);
+});
+
+test("an unsupported domain exits 3 without writing any unit", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const cpuRoot = makeSysfs(dir, { cpu0: { maxKhz: 2808000, perfKhz: 2808000 } });
+  const unitDir = path.join(dir, "units");
+  fs.mkdirSync(unitDir);
+  let err = null;
+  try {
+    runHelper(cpuRoot, ["--domain", "mem", "--max-mhz", "2200", "--persist"]);
+  } catch (e) {
+    err = e;
+  }
+  assert.ok(err, "unsupported domain must exit nonzero");
+  assert.equal(err.status, 3);
+  assert.deepEqual(fs.readdirSync(unitDir), []);
+});

--- a/server/collectors/__tests__/clockHelperScript.test.js
+++ b/server/collectors/__tests__/clockHelperScript.test.js
@@ -36,15 +36,23 @@ function makeSysfs(root, cores) {
  */
 function runHelper(cpuRoot, args, opts = {}) {
   const unitDir = opts.unitDir ?? path.join(cpuRoot, "..", "units");
-  // Stub systemctl (the helper ends a persist with `daemon-reload`); the stub
-  // dir rides on PATH like the scoped-sudo fixtures in clockControl.test.js.
+  // Stub systemctl (the helper ends a persist with `daemon-reload`) and
+  // nvidia-smi (the GPU persist writes the unit before `gpu_apply` runs it);
+  // both stubs ride on PATH like the scoped-sudo fixtures in
+  // clockControl.test.js.
   const stubDir = path.join(path.dirname(cpuRoot), "stub-bin");
   fs.mkdirSync(stubDir, { recursive: true });
-  const systemctl = path.join(stubDir, "systemctl");
-  if (!fs.existsSync(systemctl)) {
-    fs.writeFileSync(systemctl, "#!/bin/sh\nexit 0\n");
-    fs.chmodSync(systemctl, 0o755);
+  for (const [name, body] of [
+    ["systemctl", "#!/bin/sh\nexit 0\n"],
+    ["nvidia-smi", "#!/bin/sh\nexit 0\n"],
+  ]) {
+    const p = path.join(stubDir, name);
+    if (!fs.existsSync(p)) {
+      fs.writeFileSync(p, body);
+      fs.chmodSync(p, 0o755);
+    }
   }
+  const smiPath = path.join(stubDir, "nvidia-smi");
   const stdout = execFileSync("sh", [HELPER, ...args], {
     encoding: "utf8",
     env: {
@@ -52,98 +60,109 @@ function runHelper(cpuRoot, args, opts = {}) {
       PATH: `${stubDir}:${process.env.PATH}`,
       SPARKDASH_CPU_SYS: cpuRoot,
       SPARKDASH_UNIT_DIR: unitDir,
+      SPARKDASH_SMI: smiPath,
     },
   });
-  return { stdout };
+  return { stdout, smiPath, unitDir };
 }
 
 // ─── The sibling must survive a single-domain persist ───────────────────────
+// Domain convention (inherited from parseCpuClockCaps, accepted in review):
+// cores with cpuinfo_max_freq >= 3 MHz are "cpu-big" (the X925 group, whose
+// curated boot cap is 2600000 kHz on spark-1); the 2808000 group is
+// "cpu-little".
 
-test("a cpu-big persist preserves the sibling little domain's max_perf lines", (t) => {
+test("a cpu-little persist preserves the sibling big domain's max_perf lines", (t) => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const cpuRoot = makeSysfs(dir, {
-    cpu0: { maxKhz: 2808000, perfKhz: 2808000 },
-    cpu1: { maxKhz: 2808000, perfKhz: 2808000 },
-    cpu5: { maxKhz: 3900000, perfKhz: 2600000 }, // curated sibling cap
-    cpu6: { maxKhz: 3900000, perfKhz: 2600000 },
+    cpu0: { maxKhz: 3900000, perfKhz: 2600000 }, // cpu-big, curated cap
+    cpu1: { maxKhz: 3900000, perfKhz: 2600000 },
+    cpu5: { maxKhz: 2808000, perfKhz: 2808000 }, // cpu-little, at own max
+    cpu6: { maxKhz: 2808000, perfKhz: 2808000 },
   });
   const unitDir = path.join(dir, "units");
   fs.mkdirSync(unitDir);
 
-  runHelper(cpuRoot, ["--domain", "cpu-big", "--max-mhz", "2808", "--persist"]);
+  runHelper(cpuRoot, ["--domain", "cpu-little", "--max-mhz", "2400", "--persist"]);
 
   const unit = fs.readFileSync(path.join(unitDir, "cpu-clock-cap.service"), "utf8");
   // Edited domain carries the requested value…
-  assert.match(unit, /echo 2808000 > \S*cpu0\/cpufreq\/max_perf/);
-  assert.match(unit, /echo 2808000 > \S*cpu1\/cpufreq\/max_perf/);
+  assert.match(unit, /echo 2400000 > \S*cpu5\/cpufreq\/max_perf/);
+  assert.match(unit, /echo 2400000 > \S*cpu6\/cpufreq\/max_perf/);
   // …and the sibling's current live cap is NOT deleted.
-  assert.match(unit, /echo 2600000 > \S*cpu5\/cpufreq\/max_perf/);
-  assert.match(unit, /echo 2600000 > \S*cpu6\/cpufreq\/max_perf/);
+  assert.match(unit, /echo 2600000 > \S*cpu0\/cpufreq\/max_perf/);
+  assert.match(unit, /echo 2600000 > \S*cpu1\/cpufreq\/max_perf/);
 });
 
-test("a cpu-big persist with unreadable sibling max_perf omits those cores (no guesses)", (t) => {
+test("a persist with unreadable sibling max_perf omits those cores (no guesses)", (t) => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const cpuRoot = makeSysfs(dir, {
-    cpu0: { maxKhz: 2808000, perfKhz: 2808000 },
-    cpu5: { maxKhz: 3900000, perfKhz: null }, // unreadable sibling max_perf
+    cpu0: { maxKhz: 3900000, perfKhz: null }, // cpu-big sibling: unreadable
+    cpu5: { maxKhz: 2808000, perfKhz: 2808000 },
   });
   const unitDir = path.join(dir, "units");
   fs.mkdirSync(unitDir);
 
-  runHelper(cpuRoot, ["--domain", "cpu-big", "--max-mhz", "2600", "--persist"]);
+  runHelper(cpuRoot, ["--domain", "cpu-little", "--max-mhz", "2600", "--persist"]);
 
   const unit = fs.readFileSync(path.join(unitDir, "cpu-clock-cap.service"), "utf8");
-  assert.match(unit, /echo 2600000 > \S*cpu0\/cpufreq\/max_perf/);
-  assert.doesNotMatch(unit, /cpu5\/cpufreq\/max_perf/);
+  assert.match(unit, /echo 2600000 > \S*cpu5\/cpufreq\/max_perf/);
+  assert.doesNotMatch(unit, /cpu0\/cpufreq\/max_perf/);
 });
 
 test("a remove-cap (unlock) persist keeps the sibling and restores own hardware max", (t) => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const cpuRoot = makeSysfs(dir, {
-    cpu0: { maxKhz: 2808000, perfKhz: 2200000 },
-    cpu5: { maxKhz: 3900000, perfKhz: 2600000 },
+    cpu0: { maxKhz: 3900000, perfKhz: 2600000 }, // cpu-big, capped
+    cpu5: { maxKhz: 2808000, perfKhz: 2200000 }, // cpu-little, capped
   });
   const unitDir = path.join(dir, "units");
   fs.mkdirSync(unitDir);
 
-  runHelper(cpuRoot, ["--domain", "cpu-big", "--unlock", "--persist"]);
+  runHelper(cpuRoot, ["--domain", "cpu-little", "--unlock", "--persist"]);
 
   const unit = fs.readFileSync(path.join(unitDir, "cpu-clock-cap.service"), "utf8");
-  assert.match(unit, /cat \S*cpu0\/cpufreq\/cpuinfo_max_freq > \S*cpu0\/cpufreq\/max_perf/);
-  assert.match(unit, /echo 2600000 > \S*cpu5\/cpufreq\/max_perf/);
+  assert.match(unit, /cat \S*cpu5\/cpufreq\/cpuinfo_max_freq > \S*cpu5\/cpufreq\/max_perf/);
+  assert.match(unit, /echo 2600000 > \S*cpu0\/cpufreq\/max_perf/);
 });
 
 test("the helper and the container persist path emit the same CPU ExecStart for one request", (t) => {
-  // Same stub topology the SystemCollector persist tests use.
+  // Stub topology mirrors the SystemCollector persist fixtures (LIVE_DOMAINS):
+  // cpu-big = the 3900000 group capped at 2600000; cpu-little = 2808000 group.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const cpuRoot = makeSysfs(dir, {
-    cpu0: { maxKhz: 2808000, perfKhz: 2808000 },
-    cpu1: { maxKhz: 2808000, perfKhz: 2808000 },
-    cpu10: { maxKhz: 2808000, perfKhz: 2808000 },
-    cpu5: { maxKhz: 3900000, perfKhz: 2600000 },
-    cpu6: { maxKhz: 3900000, perfKhz: 2600000 },
+    cpu0: { maxKhz: 3900000, perfKhz: 2600000 },
+    cpu1: { maxKhz: 3900000, perfKhz: 2600000 },
+    cpu10: { maxKhz: 3900000, perfKhz: 2600000 },
+    cpu5: { maxKhz: 2808000, perfKhz: 2808000 },
+    cpu6: { maxKhz: 2808000, perfKhz: 2808000 },
   });
   const unitDir = path.join(dir, "units");
   fs.mkdirSync(unitDir);
 
-  // 1. Helper path: persist cpu-big 2808 while the sibling sits at 2600.
-  runHelper(cpuRoot, ["--domain", "cpu-big", "--max-mhz", "2808", "--persist"]);
+  // 1. Helper path: persist cpu-little 2808 while the sibling sits at 2600.
+  runHelper(cpuRoot, ["--domain", "cpu-little", "--max-mhz", "2808", "--persist"]);
   const helperUnit = fs.readFileSync(path.join(unitDir, "cpu-clock-cap.service"), "utf8");
   const helperExec = helperUnit.match(/^ExecStart=(.+)$/m)[1];
 
   // 2. Container path: identical request, sibling values from live max_perf.
   //    Mirror the collector's own command construction (the captured payload's
-  //    ExecStart) instead of stubbing node:fs module-wide.
-  const sibling = ["cpu5", "cpu6"]; // numeric order, as _cpuDomainCores returns
+  //    ExecStart) instead of stubbing node:fs module-wide. Cores in numeric
+  //    order per domain, as _cpuDomainCores returns them. The sysfs root is
+  //    substituted with the stub root: on a real host CPU_SYS defaults to
+  //    /sys/devices/system/cpu (exactly what the container path writes), the
+  //    test hook redirects only the root, so equality here means the command
+  //    SHAPE — and the full unit byte-for-byte — is identical.
   const parts = [
-    `echo 2808000 > /sys/devices/system/cpu/cpu0/cpufreq/max_perf`,
-    `echo 2808000 > /sys/devices/system/cpu/cpu1/cpufreq/max_perf`,
-    `echo 2808000 > /sys/devices/system/cpu/cpu10/cpufreq/max_perf`,
-    ...sibling.map((c) => `echo 2600000 > /sys/devices/system/cpu/${c}/cpufreq/max_perf`),
+    `echo 2808000 > ${cpuRoot}/cpu5/cpufreq/max_perf`,
+    `echo 2808000 > ${cpuRoot}/cpu6/cpufreq/max_perf`,
+    `echo 2600000 > ${cpuRoot}/cpu0/cpufreq/max_perf`,
+    `echo 2600000 > ${cpuRoot}/cpu1/cpufreq/max_perf`,
+    `echo 2600000 > ${cpuRoot}/cpu10/cpufreq/max_perf`,
   ];
   const containerExec = `/bin/sh -c '${parts.join("; ")}'`;
   assert.equal(helperExec, containerExec);
@@ -170,15 +189,15 @@ test("cpu_apply writes max_perf for the edited domain only and returns success",
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clock-helper-"));
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const cpuRoot = makeSysfs(dir, {
-    cpu0: { maxKhz: 2808000, perfKhz: 2808000 },
-    cpu5: { maxKhz: 3900000, perfKhz: 2600000 },
+    cpu0: { maxKhz: 3900000, perfKhz: 2600000 }, // cpu-big (edited)
+    cpu5: { maxKhz: 2808000, perfKhz: 2808000 }, // cpu-little (sibling)
   });
 
-  runHelper(cpuRoot, ["--domain", "cpu-little", "--max-mhz", "2400", "--no-persist"]);
+  runHelper(cpuRoot, ["--domain", "cpu-big", "--max-mhz", "2400", "--no-persist"]);
 
-  assert.equal(fs.readFileSync(path.join(cpuRoot, "cpu5", "cpufreq", "max_perf"), "utf8").trim(), "2400000");
+  assert.equal(fs.readFileSync(path.join(cpuRoot, "cpu0", "cpufreq", "max_perf"), "utf8").trim(), "2400000");
   // Sibling untouched by the live apply.
-  assert.equal(fs.readFileSync(path.join(cpuRoot, "cpu0", "cpufreq", "max_perf"), "utf8").trim(), "2808000");
+  assert.equal(fs.readFileSync(path.join(cpuRoot, "cpu5", "cpufreq", "max_perf"), "utf8").trim(), "2808000");
 });
 
 test("an argumentless invocation prints its usage and exits 1 (the probe contract)", (t) => {
@@ -203,10 +222,10 @@ test("a GPU persist emits the real gpu-clock-lock.service body", (t) => {
   const unitDir = path.join(dir, "units");
   fs.mkdirSync(unitDir);
 
-  runHelper(cpuRoot, ["--domain", "gpu", "--max-mhz", "2200", "--persist"]);
+  const { smiPath } = runHelper(cpuRoot, ["--domain", "gpu", "--max-mhz", "2200", "--persist"]);
 
   const unit = fs.readFileSync(path.join(unitDir, "gpu-clock-lock.service"), "utf8");
-  assert.match(unit, /^ExecStart=\/usr\/bin\/nvidia-smi -lgc 0,2200$/m);
+  assert.match(unit, new RegExp(`^ExecStart=${smiPath.replace(/[/\\]/g, "\\$&")} -lgc 0,2200$`, "m"));
   assert.match(unit, /^Description=Lock NVIDIA GPU graphics clocks to user range$/m);
 });
 

--- a/server/collectors/clockControl.js
+++ b/server/collectors/clockControl.js
@@ -195,6 +195,78 @@ export function interpretHelperExit(err) {
 }
 
 /**
+ * Parse a `cpuN:cpuinfo_min_freq:cpuinfo_max_freq` bounds dump into a
+ * core → maxKhz map (the domain membership key: cores are grouped by their
+ * cpuinfo_max_freq, never by hardcoded indices).
+ * @param {string} raw
+ * @returns {Map<string, number>}
+ */
+export function parseCpuCoreMaxKhz(raw) {
+  const byCore = new Map();
+  for (const line of String(raw ?? "").split("\n")) {
+    const m = line.trim().match(/^cpu(\d+):(\d+):(\d+)$/);
+    if (!m) continue;
+    const maxKhz = Number(m[3]);
+    if (!Number.isFinite(maxKhz) || maxKhz <= 0) continue;
+    byCore.set(`cpu${m[1]}`, maxKhz);
+  }
+  return byCore;
+}
+
+/**
+ * Expand a sysfs cpu token from a systemd unit ExecStart: `cpu5` → [cpu5],
+ * `cpu{5..9,15..19}` → [cpu5..cpu9, cpu15..cpu19]. Returns [] for anything
+ * unparsable (we never guess core identities).
+ * @param {string} token
+ * @returns {string[]}
+ */
+export function expandCpuToken(token) {
+  const m = String(token ?? "").match(/^cpu\{(.+)\}$/);
+  if (!m) return /^cpu\d+$/.test(String(token ?? "")) ? [String(token)] : [];
+  const out = [];
+  for (const part of m[1].split(",")) {
+    const range = part.match(/^(\d+)\.\.(\d+)$/);
+    if (range) {
+      const lo = Number(range[1]);
+      const hi = Number(range[2]);
+      if (!Number.isFinite(lo) || !Number.isFinite(hi) || hi < lo || hi - lo > 1024) continue;
+      for (let i = lo; i <= hi; i++) out.push(`cpu${i}`);
+    } else if (/^\d+$/.test(part)) {
+      out.push(`cpu${part}`);
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse the CPU boot unit (cpu-clock-cap.service) ExecStart into per-domain
+ * boot-default MHz values — the "Boot defaults" preset of D7, derived from
+ * what the unit actually installs (never hardcoded). Handles both explicit
+ * per-core echoes and systemd brace-range forms. A core whose cpuinfo_max_freq
+ * is unknown is skipped. Values are kHz in the unit → MHz out.
+ * @param {string} raw unit file text
+ * @param {Map<string, number>} coreMaxKhz core → cpuinfo_max_freq (kHz)
+ * @returns {{ 'cpu-big'?: number, 'cpu-little'?: number }}
+ */
+export function parseCpuBootUnitDefaults(raw, coreMaxKhz) {
+  const out = {};
+  const text = String(raw ?? "");
+  const re = /echo\s+(\d+)\s*>\s*\/sys\/devices\/system\/cpu\/([^\s/]+)\/cpufreq\/max_perf/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const khz = Number(m[1]);
+    if (!Number.isFinite(khz) || khz <= 0) continue;
+    for (const cpuN of expandCpuToken(m[2])) {
+      const maxKhz = coreMaxKhz?.get(cpuN);
+      if (!maxKhz) continue;
+      const id = maxKhz >= 3_000_000 ? "cpu-big" : "cpu-little";
+      out[id] = Math.round(khz / 1000);
+    }
+  }
+  return out;
+}
+
+/**
  * Map a live read (cpuDomains + gpuLock from _getClockCaps) plus discovered
  * bounds into the client-facing ClockCapDomain list (D1). `writable` mirrors
  * the apply paths: local units are writable via the container root path;
@@ -209,9 +281,12 @@ export function buildClockCapDomains({
   gpuCeilingMHz,
   helperAvailable,
   helperChecked,
+  cpuBootDefaults,
+  gpuBootDefaultMHz,
 }) {
   const out = [];
   const helperUp = helperChecked ? Boolean(helperAvailable) : false;
+  const bootDefaults = cpuBootDefaults || {};
 
   // CPU domains — big first (sorted max desc by both parsers).
   const bounds = Array.isArray(cpuBounds) ? cpuBounds : [];
@@ -223,6 +298,11 @@ export function buildClockCapDomains({
     // fall back to the bounds identity so the row still renders honestly.
     const capMHz = live && live.maxMHz === Math.round(b.maxKhz / 1000) ? live.capMHz : null;
     const id = b.maxKhz >= 3_000_000 ? "cpu-big" : "cpu-little";
+    // D7 presets: Boot default (what the boot unit installs, when readable)
+    // and No cap (= this domain's hardware maximum).
+    const presets = [];
+    if (bootDefaults[id] != null) presets.push({ label: "Boot default", value: bootDefaults[id] });
+    presets.push({ label: "No cap", value: Math.round(b.maxKhz / 1000) });
     out.push({
       id,
       label: CLOCK_DOMAIN_LABELS[id],
@@ -230,9 +310,7 @@ export function buildClockCapDomains({
       hardMinMHz: Math.round(b.minKhz / 1000),
       hardMaxMHz: Math.round(b.maxKhz / 1000),
       stepMHz: 25,
-      presets: [
-        { label: "No cap", value: Math.round(b.maxKhz / 1000) },
-      ],
+      presets,
       unitPath: "/etc/systemd/system/cpu-clock-cap.service",
       writable: helperUp,
       reason: helperUp ? undefined : "clock helper not installed on the host",
@@ -241,6 +319,9 @@ export function buildClockCapDomains({
 
   // GPU domain.
   if (gpuCeilingMHz != null) {
+    const presets = [];
+    if (gpuBootDefaultMHz != null) presets.push({ label: "Boot default", value: gpuBootDefaultMHz });
+    presets.push({ label: "No cap", value: null });
     out.push({
       id: "gpu",
       label: CLOCK_DOMAIN_LABELS.gpu,
@@ -248,7 +329,7 @@ export function buildClockCapDomains({
       hardMinMHz: 0,
       hardMaxMHz: gpuCeilingMHz,
       stepMHz: 25,
-      presets: [{ label: "No cap", value: null }],
+      presets,
       unitPath: "/etc/systemd/system/gpu-clock-lock.service",
       writable: helperUp,
       reason: helperUp ? undefined : "clock helper not installed on the host",

--- a/server/collectors/clockControl.js
+++ b/server/collectors/clockControl.js
@@ -1,0 +1,259 @@
+/**
+ * Pure clock-cap control logic — no I/O. Everything the apply paths and the
+ * tests need: the domain enum, bounds parsing from measured hardware output,
+ * request clamping/validation, argv building for the privileged helper, and
+ * exit-code interpretation. Exported for tests.
+ */
+
+/** The privileged host helper (installed by scripts/install-clock-helper.sh). */
+export const CLOCK_HELPER_BIN = "/usr/local/bin/sparkdash-set-clock";
+
+/**
+ * Last-resort GPU graphics ceiling when `nvidia-smi -q -d CLOCK` is
+ * unparseable. Documented constant (see config.js GPU_CLOCK_MAX_MHZ).
+ */
+export const CLOCK_DOMAIN_IDS = ["cpu-big", "cpu-little", "gpu"];
+
+/** Human labels per domain id. */
+export const CLOCK_DOMAIN_LABELS = {
+  "cpu-big": "CPU X925",
+  "cpu-little": "CPU A725",
+  gpu: "GPU",
+};
+
+/**
+ * Extract `cpuinfo_min_freq` / `cpuinfo_max_freq` values from a sysfs dump.
+ * Input is the remote/local dump shape `cpuN:min_freq:max_freq` (one line per
+ * core) — the same shape the clock-caps reader produces. A domain is a group
+ * of cores sharing one `cpuinfo_max_freq`; the domain's hard bounds are that
+ * max freq and the strictest (largest) min freq seen across its cores. Never
+ * depend on `scaling_available_frequencies` — it does not exist on cppc_cpufreq.
+ * @param {string} raw
+ * @returns {Array<{minKhz: number, maxKhz: number}>} one per domain, sorted max desc
+ */
+export function parseCpuClockBounds(raw) {
+  const domains = new Map();
+  for (const line of String(raw ?? "").split("\n")) {
+    const m = line.trim().match(/^cpu(\d+):(\d+):(\d+)$/);
+    if (!m) continue;
+    const minKhz = Number(m[2]);
+    const maxKhz = Number(m[3]);
+    if (!Number.isFinite(minKhz) || !Number.isFinite(maxKhz) || maxKhz <= 0) continue;
+    if (!domains.has(maxKhz)) {
+      domains.set(maxKhz, { minKhz, maxKhz });
+    } else {
+      // Keep the strictest floor across the domain's cores.
+      const d = domains.get(maxKhz);
+      if (minKhz > d.minKhz) d.minKhz = minKhz;
+    }
+  }
+  return [...domains.values()].sort((a, b) => b.maxKhz - a.maxKhz);
+}
+
+/**
+ * Parse the GPU graphics ceiling out of `nvidia-smi -q -d CLOCK`: the
+ * "Default Applications Clock" section's "Graphics" value in MHz. Measured
+ * GB10 output is `Default Applications Clock : Graphics : 3003 MHz`. Falls
+ * back to null when the transcript does not contain a parseable value — the
+ * caller then applies the documented GPU_CLOCK_MAX_MHZ fallback.
+ * @param {string} raw
+ * @returns {number | null} MHz
+ */
+export function parseDefaultApplicationsGraphicsClock(raw) {
+  const text = String(raw ?? "");
+  // Anchor to the Default Applications Clock block so "Max Clock" / "SM App"
+  // Graphics values elsewhere in the transcript cannot win.
+  const block = text.match(/Default\s+Applications\s+Clock([\s\S]*?)(?:\n\s*\n|$)/i);
+  const scope = block ? block[1] : "";
+  const m = scope.match(/Graphics\s*:\s*(\d+)\s*MHz/i);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * Clamp a requested MHz value into the domain's live hardware bounds.
+ * Used on the values the UI slider already clamps (defense in depth) and on
+ * the preset/boot-unit values a unit may carry. Non-finite input passes
+ * through (validation rejects it; clamping is not normalization).
+ * @param {number | null} value
+ * @param {number} hardMinMHz
+ * @param {number} hardMaxMHz
+ * @param {{ warnings?: string[] }} [out] receives a warning when clamped
+ * @returns {number | null}
+ */
+export function clampClockCap(value, hardMinMHz, hardMaxMHz, out = {}) {
+  if (value == null) return null;
+  if (!Number.isFinite(value)) return value;
+  const warnings = out.warnings;
+  let v = value;
+  if (hardMaxMHz != null && v > hardMaxMHz) {
+    v = hardMaxMHz;
+    if (warnings) {
+      warnings.push(`Requested ${value} MHz is above the hardware maximum ${hardMaxMHz} MHz; clamped to ${hardMaxMHz} MHz`);
+    }
+  }
+  if (hardMinMHz != null && v < hardMinMHz) {
+    v = hardMinMHz;
+    if (warnings) {
+      warnings.push(`Requested ${value} MHz is below the hardware minimum ${hardMinMHz} MHz; clamped to ${hardMinMHz} MHz`);
+    }
+  }
+  return v;
+}
+
+/**
+ * Validate a POST /api/sparks/:id/clocks body against live domain bounds.
+ * Rules (D1/D2): domain must be in the enum; maxMHz must be null (remove the
+ * cap) or an integer within [hardMinMHz, hardMaxMHz]; persist must be boolean
+ * (defaults false). Returns { ok, value, error }.
+ * @param {unknown} body
+ * @param {Array<{id: string, hardMinMHz: number, hardMaxMHz: number}>} domains
+ */
+export function validateClockCapRequest(body, domains) {
+  const b = body && typeof body === "object" ? body : {};
+  const domain = b.domain;
+  if (typeof domain !== "string" || !CLOCK_DOMAIN_IDS.includes(domain)) {
+    return { ok: false, error: `domain must be one of: ${CLOCK_DOMAIN_IDS.join(", ")}` };
+  }
+  const d = domains.find((x) => x.id === domain);
+  if (!d) {
+    return { ok: false, error: `domain ${domain} is not available on this Spark` };
+  }
+  const persist = b.persist;
+  if (persist !== undefined && typeof persist !== "boolean") {
+    return { ok: false, error: "persist must be a boolean" };
+  }
+  const maxMHz = b.maxMHz;
+  if (maxMHz == null) {
+    return { ok: true, value: { domain, maxMHz: null, persist: Boolean(persist) } };
+  }
+  if (typeof maxMHz === "string" || !Number.isInteger(maxMHz)) {
+    return { ok: false, error: "maxMHz must be an integer or null" };
+  }
+  if (maxMHz < d.hardMinMHz || maxMHz > d.hardMaxMHz) {
+    return {
+      ok: false,
+      error: `maxMHz ${maxMHz} is outside the ${domain} hardware range ${d.hardMinMHz}–${d.hardMaxMHz} MHz`,
+    };
+  }
+  return { ok: true, value: { domain, maxMHz, persist: Boolean(persist) } };
+}
+
+/**
+ * Build the SSH command that runs the privileged clock helper (D4). Mirrors
+ * SHUTDOWN_REMOTE_CMD in server/index.js: verify the helper exists (exit 127),
+ * verify passwordless sudo (exit 126), then invoke it. Distinct exit codes let
+ * the UI name the real cause instead of a generic failure.
+ * @param {{ domain: string, maxMHz: number | null, persist: boolean }} req
+ * @param {{ helperBin?: string }} [opts]
+ */
+export function buildClockHelperArgv(req, opts = {}) {
+  const helperBin = opts.helperBin || CLOCK_HELPER_BIN;
+  const q = (s) => `'${String(s).replace(/'/g, "'\\''")}'`;
+  const args = [
+    `test -x ${helperBin} || { echo "missing ${helperBin}" >&2; exit 127; }`,
+    `sudo -n true || { echo "sudo -n required for ${helperBin}" >&2; exit 126; }`,
+  ];
+  const parts = [`sudo -n ${helperBin}`, `--domain ${q(req.domain)}`];
+  if (req.maxMHz == null) {
+    parts.push("--unlock");
+  } else {
+    parts.push(`--max-mhz ${Number(req.maxMHz)}`);
+  }
+  parts.push(req.persist ? "--persist" : "--no-persist");
+  args.push(parts.join(" "));
+  return args.join("; ");
+}
+
+/**
+ * Interpret the SSH/helper failure and return the HTTP status + UI-facing
+ * cause. D4/D1: 127 → helper not installed (423 with install hint), 126 →
+ * passwordless sudo missing (423), transport timeouts → 503, everything else
+ * → 502.
+ * @param {unknown} err SSH error (message carries stderr from sshExec)
+ * @returns {{ status: number, reason: string }}
+ */
+export function interpretHelperExit(err) {
+  const msg = String((err && err.message) || err || "");
+  if (/\b127\b|missing .*sparkdash-set-clock/.test(msg)) {
+    return {
+      status: 423,
+      reason: "clock helper not installed — run scripts/install-clock-helper.sh on the host",
+    };
+  }
+  if (/\b126\b|sudo -n required/.test(msg)) {
+    return {
+      status: 423,
+      reason: "passwordless sudo for the clock helper is not configured — run scripts/install-clock-helper.sh",
+    };
+  }
+  if (/timed out|connection refused|unreachable|no route|ECONNREFUSED|ETIMEDOUT/i.test(msg)) {
+    return { status: 503, reason: "SSH transport failure" };
+  }
+  return { status: 502, reason: msg || "clock helper failed" };
+}
+
+/**
+ * Map a live read (cpuDomains + gpuLock from _getClockCaps) plus discovered
+ * bounds into the client-facing ClockCapDomain list (D1). `writable` mirrors
+ * the apply paths: local units are writable via the container root path;
+ * remote units need the provisioned helper.
+ * @param {object} p
+ * @returns {Array<{id: string, label: string, currentMHz: number|null, hardMinMHz: number, hardMaxMHz: number, stepMHz: number, presets: number[], unitPath: string|null, writable: boolean, reason?: string}>}
+ */
+export function buildClockCapDomains({
+  cpuDomains,
+  gpuLock,
+  cpuBounds,
+  gpuCeilingMHz,
+  helperAvailable,
+  helperChecked,
+}) {
+  const out = [];
+  const helperUp = helperChecked ? Boolean(helperAvailable) : false;
+
+  // CPU domains — big first (sorted max desc by both parsers).
+  const bounds = Array.isArray(cpuBounds) ? cpuBounds : [];
+  const domains = Array.isArray(cpuDomains) ? cpuDomains : [];
+  for (let i = 0; i < bounds.length; i++) {
+    const b = bounds[i];
+    const live = domains[i];
+    // Parsers sort the same way; when the live read is missing/degenerate,
+    // fall back to the bounds identity so the row still renders honestly.
+    const capMHz = live && live.maxMHz === Math.round(b.maxKhz / 1000) ? live.capMHz : null;
+    const id = b.maxKhz >= 3_000_000 ? "cpu-big" : "cpu-little";
+    out.push({
+      id,
+      label: CLOCK_DOMAIN_LABELS[id],
+      currentMHz: capMHz,
+      hardMinMHz: Math.round(b.minKhz / 1000),
+      hardMaxMHz: Math.round(b.maxKhz / 1000),
+      stepMHz: 25,
+      presets: [
+        { label: "No cap", value: Math.round(b.maxKhz / 1000) },
+      ],
+      unitPath: "/etc/systemd/system/cpu-clock-cap.service",
+      writable: helperUp,
+      reason: helperUp ? undefined : "clock helper not installed on the host",
+    });
+  }
+
+  // GPU domain.
+  if (gpuCeilingMHz != null) {
+    out.push({
+      id: "gpu",
+      label: CLOCK_DOMAIN_LABELS.gpu,
+      currentMHz: gpuLock ? gpuLock.maxMHz : null,
+      hardMinMHz: 0,
+      hardMaxMHz: gpuCeilingMHz,
+      stepMHz: 25,
+      presets: [{ label: "No cap", value: null }],
+      unitPath: "/etc/systemd/system/gpu-clock-lock.service",
+      writable: helperUp,
+      reason: helperUp ? undefined : "clock helper not installed on the host",
+    });
+  }
+
+  return out;
+}

--- a/server/collectors/clockControl.js
+++ b/server/collectors/clockControl.js
@@ -9,6 +9,21 @@
 export const CLOCK_HELPER_BIN = "/usr/local/bin/sparkdash-set-clock";
 
 /**
+ * Sentinels for the helper availability probe. The sudoers grant shipped by
+ * scripts/install-clock-helper.sh allows ONLY the bare helper binary (no
+ * arguments), so the probe must exercise exactly that command — a
+ * `sudo -n true` pre-check can never succeed on a correctly provisioned host.
+ * The argumentless probe makes the helper print its usage line and exit 1,
+ * which proves sudo allowed it; a sudo refusal carries no usage line.
+ * Tokens (never sudo's own wording) keep the three causes distinct.
+ */
+export const HELPER_PROBE_OK = "sparkdash-helper-ok";
+export const HELPER_PROBE_REFUSED = "sparkdash-helper-refused";
+export const HELPER_PROBE_MISSING = "sparkdash-helper-missing";
+/** Sentinel the apply argv emits when sudo refuses the argumentless probe. */
+export const HELPER_REFUSED_SENTINEL = "sparkdash-probe-sentinel";
+
+/**
  * Last-resort GPU graphics ceiling when `nvidia-smi -q -d CLOCK` is
  * unparseable. Documented constant (see config.js GPU_CLOCK_MAX_MHZ).
  */
@@ -141,10 +156,19 @@ export function validateClockCapRequest(body, domains) {
 }
 
 /**
- * Build the SSH command that runs the privileged clock helper (D4). Mirrors
- * SHUTDOWN_REMOTE_CMD in server/index.js: verify the helper exists (exit 127),
- * verify passwordless sudo (exit 126), then invoke it. Distinct exit codes let
- * the UI name the real cause instead of a generic failure.
+ * Build the SSH command that runs the privileged clock helper (D4).
+ *
+ * The shipped sudoers grant is a single argumentless command
+ * (`NOPASSWD: /usr/local/bin/sparkdash-set-clock`), so the chain never uses
+ * `sudo -n true` — it would always fail (exit 126) on a correctly provisioned
+ * box and the helper could never run. Instead:
+ *   1. verify the helper exists and is executable (exit 127 when not);
+ *   2. probe by running the granted command EXACTLY as sudoers allows it —
+ *      argumentless. The helper prints its usage line and exits 1, which
+ *      proves sudo allowed it; sudo's own refusals ("a password is required",
+ *      "not allowed") also exit 1 but carry no usage line, and only those hit
+ *      the sentinel + exit 126.
+ * Distinct exit codes let the UI name the real cause.
  * @param {{ domain: string, maxMHz: number | null, persist: boolean }} req
  * @param {{ helperBin?: string }} [opts]
  */
@@ -153,7 +177,9 @@ export function buildClockHelperArgv(req, opts = {}) {
   const q = (s) => `'${String(s).replace(/'/g, "'\\''")}'`;
   const args = [
     `test -x ${helperBin} || { echo "missing ${helperBin}" >&2; exit 127; }`,
-    `sudo -n true || { echo "sudo -n required for ${helperBin}" >&2; exit 126; }`,
+    `out=$(sudo -n ${helperBin} 2>&1); rc=$?; ` +
+      `if [ "$rc" -ne 0 ] && ! printf '%s' "$out" | grep -q '^usage:'; then ` +
+      `echo "${HELPER_REFUSED_SENTINEL}: sudo -n refused for ${helperBin}" >&2; exit 126; fi`,
   ];
   const parts = [`sudo -n ${helperBin}`, `--domain ${q(req.domain)}`];
   if (req.maxMHz == null) {
@@ -167,22 +193,67 @@ export function buildClockHelperArgv(req, opts = {}) {
 }
 
 /**
+ * Availability probe for SystemCollector.checkClockHelper — exercises exactly
+ * the scoped grant (argumentless sudo of the helper binary). Always exits 0
+ * and reports one of the HELPER_PROBE_* tokens on stdout, so the caller can
+ * distinguish missing-binary from sudo-refused from available without
+ * depending on sudo's message wording.
+ * @param {{ helperBin?: string }} [opts]
+ * @returns {string}
+ */
+export function buildHelperProbeCommand(opts = {}) {
+  const helperBin = opts.helperBin || CLOCK_HELPER_BIN;
+  return [
+    `test -x ${helperBin} || { echo "${HELPER_PROBE_MISSING}"; exit 0; }`,
+    `out=$(sudo -n ${helperBin} 2>&1); rc=$?`,
+    `if [ "$rc" -eq 0 ] || printf '%s' "$out" | grep -q '^usage:'; then echo "${HELPER_PROBE_OK}"; else echo "${HELPER_PROBE_REFUSED}"; fi`,
+  ].join("; ");
+}
+
+/**
+ * Classify the availability probe's stdout (see buildHelperProbeCommand).
+ * @param {string} out
+ * @returns {{ available: boolean, checked: boolean, reason?: string }}
+ */
+export function interpretHelperProbe(out) {
+  const lines = String(out ?? "")
+    .split("\n")
+    .map((s) => s.trim());
+  if (lines.includes(HELPER_PROBE_OK)) return { available: true, checked: true };
+  if (lines.includes(HELPER_PROBE_REFUSED)) {
+    return {
+      available: false,
+      checked: true,
+      reason:
+        "passwordless sudo for the clock helper is not configured — run scripts/install-clock-helper.sh",
+    };
+  }
+  return {
+    available: false,
+    checked: true,
+    reason: "clock helper not installed on the host",
+  };
+}
+
+/**
  * Interpret the SSH/helper failure and return the HTTP status + UI-facing
- * cause. D4/D1: 127 → helper not installed (423 with install hint), 126 →
- * passwordless sudo missing (423), transport timeouts → 503, everything else
- * → 502.
+ * cause. Anchored on the sentinel strings the argv builder emits — NEVER on
+ * bare numbers in the message (a helper log that merely mentions 127 or 126,
+ * e.g. an nvidia-smi id or a frequency, must not be misclassified). 127 →
+ * helper not installed (423 with install hint), probe refusal → passwordless
+ * sudo missing (423), transport timeouts → 503, everything else → 502.
  * @param {unknown} err SSH error (message carries stderr from sshExec)
  * @returns {{ status: number, reason: string }}
  */
 export function interpretHelperExit(err) {
   const msg = String((err && err.message) || err || "");
-  if (/\b127\b|missing .*sparkdash-set-clock/.test(msg)) {
+  if (/missing \S*sparkdash-set-clock/.test(msg)) {
     return {
       status: 423,
       reason: "clock helper not installed — run scripts/install-clock-helper.sh on the host",
     };
   }
-  if (/\b126\b|sudo -n required/.test(msg)) {
+  if (msg.includes(HELPER_REFUSED_SENTINEL)) {
     return {
       status: 423,
       reason: "passwordless sudo for the clock helper is not configured — run scripts/install-clock-helper.sh",
@@ -272,7 +343,7 @@ export function parseCpuBootUnitDefaults(raw, coreMaxKhz) {
  * the apply paths: local units are writable via the container root path;
  * remote units need the provisioned helper.
  * @param {object} p
- * @returns {Array<{id: string, label: string, currentMHz: number|null, hardMinMHz: number, hardMaxMHz: number, stepMHz: number, presets: number[], unitPath: string|null, writable: boolean, reason?: string}>}
+ * @returns {Array<{id: string, label: string, currentMHz: number|null, hardMinMHz: number, hardMaxMHz: number, stepMHz: number, presets: Array<{label: string, value: number|null}>, unitPath: string|null, writable: boolean, reason?: string}>}
  */
 export function buildClockCapDomains({
   cpuDomains,
@@ -281,11 +352,15 @@ export function buildClockCapDomains({
   gpuCeilingMHz,
   helperAvailable,
   helperChecked,
+  helperReason,
   cpuBootDefaults,
   gpuBootDefaultMHz,
 }) {
   const out = [];
   const helperUp = helperChecked ? Boolean(helperAvailable) : false;
+  // The probe names the REAL cause (helper missing vs sudo not configured vs
+  // unreachable) — never overwrite it with the generic "not installed" text.
+  const helperDownReason = helperReason || "clock helper not installed on the host";
   const bootDefaults = cpuBootDefaults || {};
 
   // CPU domains — big first (sorted max desc by both parsers).
@@ -313,7 +388,7 @@ export function buildClockCapDomains({
       presets,
       unitPath: "/etc/systemd/system/cpu-clock-cap.service",
       writable: helperUp,
-      reason: helperUp ? undefined : "clock helper not installed on the host",
+      reason: helperUp ? undefined : helperDownReason,
     });
   }
 
@@ -332,7 +407,7 @@ export function buildClockCapDomains({
       presets,
       unitPath: "/etc/systemd/system/gpu-clock-lock.service",
       writable: helperUp,
-      reason: helperUp ? undefined : "clock helper not installed on the host",
+      reason: helperUp ? undefined : helperDownReason,
     });
   }
 

--- a/server/config.js
+++ b/server/config.js
@@ -32,6 +32,13 @@ const GPU_CLOCK_LOCK_UNIT =
   process.env.GPU_CLOCK_LOCK_UNIT || "/etc/systemd/system/gpu-clock-lock.service";
 
 /**
+ * Boot unit that persists the CPU clock caps (both domains share it).
+ * Overridable for non-standard installs, mirroring GPU_CLOCK_LOCK_UNIT.
+ */
+const CPU_CLOCK_CAP_UNIT =
+  process.env.CPU_CLOCK_CAP_UNIT || "/etc/systemd/system/cpu-clock-cap.service";
+
+/**
  * Privileged host helper that applies + persists clock caps (installed by
  * scripts/install-clock-helper.sh). Invoked over SSH with passwordless sudo
  * (scoped sudoers drop-in); see the Clock control section in README.md.
@@ -132,6 +139,7 @@ export {
   SPARKS_JSON_PATH,
   GPU_MEMORY_JSON_PATH,
   GPU_CLOCK_LOCK_UNIT,
+  CPU_CLOCK_CAP_UNIT,
   SPARKDASH_CLOCK_BIN,
   GPU_CLOCK_MAX_MHZ,
   SPARKS_SECRETS_PATH,

--- a/server/config.js
+++ b/server/config.js
@@ -22,6 +22,15 @@ const LLM_DAILY_JSON_PATH =
 const FLEET_ENERGY_JSON_PATH =
   process.env.FLEET_ENERGY_JSON_PATH || path.join(ROOT, "config", "fleet-energy.json");
 
+/**
+ * Host-side path of the systemd unit that locks GPU clocks (`nvidia-smi -lgc`).
+ * nvidia-smi does not expose the active lock range, so the unit file is the
+ * source of truth for the GPU "Clock Cap" display. Absolute host path; set
+ * GPU_CLOCK_LOCK_UNIT to point at a differently-named unit.
+ */
+const GPU_CLOCK_LOCK_UNIT =
+  process.env.GPU_CLOCK_LOCK_UNIT || "/etc/systemd/system/gpu-clock-lock.service";
+
 // ─── LLM / Comfy probe timeouts ──────────────────────────
 const LLM_PROBE_TIMEOUT_MS = 3000;
 const COMFY_PROBE_TIMEOUT_MS = parseInt(process.env.COMFY_PROBE_TIMEOUT_MS || "3000", 10);
@@ -106,6 +115,7 @@ const HOST_PATHS = {
 export {
   SPARKS_JSON_PATH,
   GPU_MEMORY_JSON_PATH,
+  GPU_CLOCK_LOCK_UNIT,
   SPARKS_SECRETS_PATH,
   SECRETS_KEY_PATH,
   LLM_DAILY_JSON_PATH,

--- a/server/config.js
+++ b/server/config.js
@@ -31,6 +31,22 @@ const FLEET_ENERGY_JSON_PATH =
 const GPU_CLOCK_LOCK_UNIT =
   process.env.GPU_CLOCK_LOCK_UNIT || "/etc/systemd/system/gpu-clock-lock.service";
 
+/**
+ * Privileged host helper that applies + persists clock caps (installed by
+ * scripts/install-clock-helper.sh). Invoked over SSH with passwordless sudo
+ * (scoped sudoers drop-in); see the Clock control section in README.md.
+ */
+const SPARKDASH_CLOCK_BIN =
+  process.env.SPARKDASH_CLOCK_BIN || "/usr/local/bin/sparkdash-set-clock";
+
+/**
+ * Last-resort GPU graphics ceiling (MHz) used only when `nvidia-smi -q -d
+ * CLOCK` is unparseable (e.g. [N/A] on some drivers). The authoritative
+ * ceiling is always the parsed "Default Applications Clock → Graphics" value;
+ * when this fallback is used it is reported in the API response warnings.
+ */
+const GPU_CLOCK_MAX_MHZ = parseInt(process.env.GPU_CLOCK_MAX_MHZ || "3003", 10);
+
 // ─── LLM / Comfy probe timeouts ──────────────────────────
 const LLM_PROBE_TIMEOUT_MS = 3000;
 const COMFY_PROBE_TIMEOUT_MS = parseInt(process.env.COMFY_PROBE_TIMEOUT_MS || "3000", 10);
@@ -116,6 +132,8 @@ export {
   SPARKS_JSON_PATH,
   GPU_MEMORY_JSON_PATH,
   GPU_CLOCK_LOCK_UNIT,
+  SPARKDASH_CLOCK_BIN,
+  GPU_CLOCK_MAX_MHZ,
   SPARKS_SECRETS_PATH,
   SECRETS_KEY_PATH,
   LLM_DAILY_JSON_PATH,

--- a/server/index.js
+++ b/server/index.js
@@ -568,8 +568,16 @@ app.get("/api/sparks/:id/clocks/bounds", async (req, res) => {
       gpuCeilingMHz: bounds.gpuCeilingMHz,
       helperAvailable: helper.available,
       helperChecked: helper.checked,
+      cpuBootDefaults: bounds.cpuBootDefaults || {},
+      gpuBootDefaultMHz: bounds.gpuBootDefaultMHz ?? null,
     });
-    res.json({ ok: true, sparkId: spark.id, domains, helper });
+    const warnings = [];
+    if (bounds.gpuCeilingSource === "fallback") {
+      warnings.push(
+        `GPU ceiling could not be read from nvidia-smi; using the documented fallback ${bounds.gpuCeilingMHz} MHz (GPU_CLOCK_MAX_MHZ)`
+      );
+    }
+    res.json({ ok: true, sparkId: spark.id, domains, helper, warnings });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,10 @@ import { SparkMonitor } from "./sparks/SparkMonitor.js";
 import { sshExec } from "./collectors/ssh.js";
 import { comfyCancelJob } from "./collectors/comfyActions.js";
 import {
+  buildClockCapDomains,
+  validateClockCapRequest,
+} from "./collectors/clockControl.js";
+import {
   validateSparkTarget,
   createRateLimiter,
   assertAllowedTarget,
@@ -330,6 +334,7 @@ app.post("/api/sparks/test", async (req, res) => {
       comfyPort: resolveComfyPort(body),
       comfyMonitoring: Boolean(body.comfyMonitoring),
       hermesMonitoring: Boolean(body.hermesMonitoring),
+      clockControlEnabled: Boolean(body.clockControlEnabled),
       tailscaleMonitoring: Boolean(body.tailscaleMonitoring),
       ssh: {
         host: body.ssh?.host || body.lanIp || "",
@@ -532,6 +537,103 @@ app.post("/api/sparks/:id/comfy/cancel", async (req, res) => {
     res.json({ success: result.ok, ...result });
   } catch (err) {
     res.status(500).json({ error: err.message });
+  }
+});
+
+// ─── Clock control (opt-in per Spark; see README "Clock control") ─────────
+
+// Discover the hardware-legal ranges: CPU domains from cpuinfo_min/max_freq,
+// GPU ceiling from `nvidia-smi -q -d CLOCK` Default Applications Clock.
+app.get("/api/sparks/:id/clocks/bounds", async (req, res) => {
+  try {
+    const spark = registry.getSpark(req.params.id);
+    if (!spark) return res.status(404).json({ error: "Spark not found" });
+    if (!spark.clockControlEnabled) {
+      return res
+        .status(403)
+        .json({ error: "Clock control is disabled for this Spark (enable it in Edit Spark)" });
+    }
+    const monitor = monitors.get(req.params.id);
+    if (!monitor) return res.status(404).json({ error: "Spark not found" });
+    const collector = monitor.collector;
+    const [bounds, caps, helper] = await Promise.all([
+      collector._getClockBounds(),
+      collector._getClockCaps(),
+      collector.checkClockHelper(),
+    ]);
+    const domains = buildClockCapDomains({
+      cpuDomains: caps.cpuDomains,
+      gpuLock: caps.gpuLock,
+      cpuBounds: bounds.cpuBounds,
+      gpuCeilingMHz: bounds.gpuCeilingMHz,
+      helperAvailable: helper.available,
+      helperChecked: helper.checked,
+    });
+    res.json({ ok: true, sparkId: spark.id, domains, helper });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Apply a cap: live and/or persisted. Clamping/validation is server-side and
+// mandatory (D2) — browser-supplied bounds are never trusted.
+app.post("/api/sparks/:id/clocks", async (req, res) => {
+  if (!allowDestructive(principalKey(req)) || !allowGlobalDestructive(clientKey(req))) {
+    return rejectLimited(res, "Too many clock-cap requests; try again shortly");
+  }
+  try {
+    const spark = registry.getSpark(req.params.id);
+    if (!spark) return res.status(404).json({ error: "Spark not found" });
+    if (!spark.clockControlEnabled) {
+      return res
+        .status(403)
+        .json({ error: "Clock control is disabled for this Spark (enable it in Edit Spark)" });
+    }
+    const monitor = monitors.get(req.params.id);
+    if (!monitor) return res.status(404).json({ error: "Spark not found" });
+    const collector = monitor.collector;
+
+    // Re-read live hardware bounds server-side; never trust client bounds (D2).
+    const bounds = await collector._getClockBounds();
+    const validation = validateClockCapRequest(
+      req.body,
+      (bounds.cpuBounds || []).map((b) => ({
+        id: b.maxKhz >= 3_000_000 ? "cpu-big" : "cpu-little",
+        hardMinMHz: Math.round(b.minKhz / 1000),
+        hardMaxMHz: Math.round(b.maxKhz / 1000),
+      })).concat(
+        bounds.gpuCeilingMHz != null
+          ? [{ id: "gpu", hardMinMHz: 0, hardMaxMHz: bounds.gpuCeilingMHz }]
+          : []
+      )
+    );
+    if (!validation.ok) {
+      return res.status(400).json({ ok: false, error: validation.error });
+    }
+
+    const domainBounds = (bounds.cpuBounds || []).map((b) => ({
+      id: b.maxKhz >= 3_000_000 ? "cpu-big" : "cpu-little",
+      hardMinMHz: Math.round(b.minKhz / 1000),
+      hardMaxMHz: Math.round(b.maxKhz / 1000),
+    }));
+    const live = domainBounds.concat(
+      bounds.gpuCeilingMHz != null
+        ? [{ id: "gpu", hardMinMHz: 0, hardMaxMHz: bounds.gpuCeilingMHz }]
+        : []
+    );
+    const target = live.find((d) => d.id === validation.value.domain);
+    const result = await collector.applyClockCap(validation.value, {
+      hardMinMHz: target?.hardMinMHz,
+      hardMaxMHz: target?.hardMaxMHz,
+    });
+    if (!result.ok) {
+      return res.status(result.status || 500).json({ ok: false, error: result.reason });
+    }
+    // Push the fresh cap state to clients right away instead of next poll.
+    forceBroadcast();
+    res.json({ ok: true, ...result });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
   }
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -568,6 +568,7 @@ app.get("/api/sparks/:id/clocks/bounds", async (req, res) => {
       gpuCeilingMHz: bounds.gpuCeilingMHz,
       helperAvailable: helper.available,
       helperChecked: helper.checked,
+      helperReason: helper.reason,
       cpuBootDefaults: bounds.cpuBootDefaults || {},
       gpuBootDefaultMHz: bounds.gpuBootDefaultMHz ?? null,
     });

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -479,6 +479,10 @@ export class SparkMonitor {
             .filter((n) => Number.isInteger(n)),
       comfyMonitoring: comfyOn,
       comfyPort: this._comfyPort(),
+      // Opt-in clock control flag — the UI gate (ClockCapControl) reads this
+      // off the WS snapshot, so it MUST ride along like comfyMonitoring or the
+      // toggle in Edit Spark can never reach the browser.
+      clockControlEnabled: Boolean(this.spark.clockControlEnabled),
       tailscaleMonitoring: tailscaleOn,
       hermes: this._hermes,
       hardware: this._hardwareSummary,

--- a/server/sparks/SparkMonitor.js
+++ b/server/sparks/SparkMonitor.js
@@ -153,6 +153,10 @@ export class SparkMonitor {
     this._metricCollectionSuccessful = { gpu: false, cpu: false };
     this.spark = spark;
     this.collector.spark = spark;
+    // Clock-cap volatile overrides (D5) describe the PREVIOUS config's apply
+    // path; a hot re-registration (possible target change) must not keep
+    // reporting them. Optional call: test doubles may lack the collector API.
+    this.collector.clearClockCapsOverride?.();
 
     // Rebuild LLM probe map — add new ports, remove stale ones, update existing
     const ports = this._llmMonitoringEnabled() ? this._llmPorts() : [];

--- a/server/sparks/SparkRegistry.js
+++ b/server/sparks/SparkRegistry.js
@@ -626,6 +626,12 @@ export class SparkRegistry {
        * the SparkMonitor checks for updates and allows one-click `hermes update`.
        */
       hermesMonitoring: Boolean(config.hermesMonitoring),
+      /**
+       * Opt-in: allow setting CPU/GPU clock caps on this unit from the
+       * dashboard (applied live and/or persisted via the privileged host
+       * helper or the local container root path). Default false.
+       */
+      clockControlEnabled: Boolean(config.clockControlEnabled),
       disabledDevices: Array.isArray(config.disabledDevices) ? config.disabledDevices : [],
       disabledInterfaces: Array.isArray(config.disabledInterfaces) ? config.disabledInterfaces : [],
       storagePollDisabled: Boolean(config.storagePollDisabled),

--- a/server/sparks/__tests__/monitor-lifecycle.test.js
+++ b/server/sparks/__tests__/monitor-lifecycle.test.js
@@ -237,3 +237,44 @@ test("a storage refresh from an earlier run cannot commit or clear a restarted r
   assert.equal(monitor._inflight.storage, false);
   monitor.stop();
 });
+
+// ─── snapshot contract: the opt-in clockControlEnabled flag (Gate 1) ────────
+// The UI gate (ClockCapControl via SparkPage) reads spark.clockControlEnabled
+// off the WS snapshot, so snapshot() MUST carry the flag — a component test
+// fed the prop directly cannot catch this class of break.
+
+test("snapshot carries clockControlEnabled: true when the Spark config opts in", () => {
+  const monitor = new SparkMonitor({ ...spark(), clockControlEnabled: true });
+  const snap = monitor.snapshot();
+  assert.equal(snap.clockControlEnabled, true);
+  monitor.stop();
+});
+
+test("snapshot carries clockControlEnabled: false for a default (opted-out) config", () => {
+  const monitor = new SparkMonitor(spark());
+  const snap = monitor.snapshot();
+  assert.equal(snap.clockControlEnabled, false);
+  monitor.stop();
+});
+
+test("snapshot coerces a truthy/non-boolean flag value like the registry normalizer", () => {
+  const monitor = new SparkMonitor({ ...spark(), clockControlEnabled: "yes" });
+  assert.equal(monitor.snapshot().clockControlEnabled, true);
+  const off = new SparkMonitor({ ...spark(), clockControlEnabled: 0 });
+  assert.equal(off.snapshot().clockControlEnabled, false);
+  monitor.stop();
+  off.stop();
+});
+
+test("snapshot rides next to the sibling opt-in flags (comfyMonitoring contract)", () => {
+  const monitor = new SparkMonitor({
+    ...spark(),
+    comfyMonitoring: true,
+    clockControlEnabled: true,
+  });
+  const snap = monitor.snapshot();
+  for (const key of ["comfyMonitoring", "clockControlEnabled", "tailscaleMonitoring"]) {
+    assert.ok(Object.prototype.hasOwnProperty.call(snap, key), `snapshot must carry ${key}`);
+  }
+  monitor.stop();
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ function placeholderSnapshot(
     llmMonitoring?: boolean;
     comfyMonitoring?: boolean;
     comfyPort?: number;
+    clockControlEnabled?: boolean;
     tailscaleMonitoring?: boolean;
     kind?: "spark" | "host";
   }
@@ -87,6 +88,7 @@ function placeholderSnapshot(
           : roleFields?.llmMonitoring !== false,
     comfyMonitoring: Boolean(roleFields?.comfyMonitoring),
     comfyPort: roleFields?.comfyPort ?? 8188,
+    clockControlEnabled: Boolean(roleFields?.clockControlEnabled),
     tailscaleMonitoring: Boolean(roleFields?.tailscaleMonitoring),
     hermes: {
       monitoring: false,
@@ -245,6 +247,7 @@ function DashboardApp() {
               llmMonitoring: c.llmMonitoring ?? existing.llmMonitoring,
               comfyMonitoring: c.comfyMonitoring ?? existing.comfyMonitoring,
               comfyPort: c.comfyPort ?? existing.comfyPort,
+              clockControlEnabled: c.clockControlEnabled ?? existing.clockControlEnabled,
               tailscaleMonitoring: c.tailscaleMonitoring ?? existing.tailscaleMonitoring,
               disabledDevices: c.disabledDevices || existing.disabledDevices,
               disabledInterfaces: c.disabledInterfaces || existing.disabledInterfaces,
@@ -267,6 +270,7 @@ function DashboardApp() {
               llmMonitoring: c.llmMonitoring,
               comfyMonitoring: c.comfyMonitoring,
               comfyPort: c.comfyPort,
+              clockControlEnabled: c.clockControlEnabled,
               tailscaleMonitoring: c.tailscaleMonitoring,
               kind: c.kind,
             }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,6 @@
 import type {
+  ClockCapBoundsResponse,
+  ClockCapResponse,
   DecodeBenchJob,
   DecodeBenchListResponse,
   FleetEnergy,
@@ -134,6 +136,23 @@ export function cancelComfyJob(
   return apiFetch(`/api/sparks/${encodeURIComponent(sparkId)}/comfy/cancel`, {
     method: "POST",
     body: JSON.stringify({ promptId }),
+  });
+}
+
+// ─── Clock control (opt-in per Spark) ─────────────────────
+/** Discover the hardware-legal clock-cap ranges for one Spark. */
+export function getClockCapBounds(id: string): Promise<ClockCapBoundsResponse> {
+  return apiFetch(`/api/sparks/${encodeURIComponent(id)}/clocks/bounds`);
+}
+
+/** Apply a clock cap (maxMHz null = remove the cap). */
+export function setClockCap(
+  id: string,
+  body: { domain: string; maxMHz: number | null; persist: boolean }
+): Promise<ClockCapResponse> {
+  return apiFetch(`/api/sparks/${encodeURIComponent(id)}/clocks`, {
+    method: "POST",
+    body: JSON.stringify(body),
   });
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -79,6 +79,12 @@ export interface SparkConfig {
    */
   hermesMonitoring?: boolean;
   /**
+   * Opt-in: allow setting CPU/GPU clock caps from the dashboard (Clock Cap
+   * rows become editable; applied live and/or persisted via the privileged
+   * host helper). Default false.
+   */
+  clockControlEnabled?: boolean;
+  /**
    * Report tailnet presence via `tailscale status --json` (default false; all roles).
    */
   tailscaleMonitoring?: boolean;
@@ -237,6 +243,45 @@ export interface CpuMetrics {
   tdp: number;
   /** Active per-domain CPU clock caps (max_perf). Absent when unreadable. */
   clockCaps?: CpuClockCap[] | null;
+}
+
+// ─── Clock control (opt-in per Spark) ────────────────────
+/** One editable clock-cap domain with its hardware-legal range. */
+export interface ClockCapDomain {
+  id: "cpu-big" | "cpu-little" | "gpu";
+  label: string;
+  /** Active cap in MHz (null when the read path has no value for it). */
+  currentMHz: number | null;
+  hardMinMHz: number;
+  hardMaxMHz: number;
+  stepMHz: number;
+  /** Named presets, e.g. { label: "No cap", value: 3900 }. */
+  presets: Array<{ label: string; value: number | null }>;
+  /** Boot unit this domain persists to (host path), when known. */
+  unitPath: string | null;
+  /** True when at least one apply path (helper or container) can run now. */
+  writable: boolean;
+  /** Why the domain is not writable, when writable is false. */
+  reason?: string;
+}
+
+/** GET /api/sparks/:id/clocks/bounds response. */
+export interface ClockCapBoundsResponse {
+  ok: boolean;
+  sparkId: string;
+  domains: ClockCapDomain[];
+  helper: { available: boolean; checked: boolean; reason?: string };
+}
+
+/** POST /api/sparks/:id/clocks response (200 shape). */
+export interface ClockCapResponse {
+  ok: boolean;
+  domain: string;
+  appliedMHz: number | null;
+  persisted: boolean;
+  bootUnit: string | null;
+  source: "helper" | "container";
+  warnings: string[];
 }
 
 // ─── RAM metrics ─────────────────────────────────────────

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -213,14 +213,30 @@ export interface GpuMetrics {
   throttle?: GpuThrottle | null;
   /** Kernel NVRM NV_ERR_NO_MEMORY count since boot (cached ~60s). */
   nvErrNoMemory?: number;
+  /** Active `nvidia-smi -lgc` graphics clock lock, when one is set. */
+  clockLock?: { minMHz: number; maxMHz: number } | null;
 }
 
 // ─── CPU metrics ─────────────────────────────────────────
+/** One CPU frequency domain (cluster) and its active max_perf ceiling. */
+export interface CpuClockCap {
+  /** Cluster label, e.g. "X925" (performance) or "A725" (efficiency). */
+  label: string;
+  /** Active max_perf ceiling in MHz. */
+  capMHz: number;
+  /** Hardware maximum (cpuinfo_max_freq) in MHz. */
+  maxMHz: number;
+  /** True when the ceiling is below the hardware max (a cap is in effect). */
+  capped: boolean;
+}
+
 export interface CpuMetrics {
   usage: number;
   temperature: number;
   draw: number;
   tdp: number;
+  /** Active per-domain CPU clock caps (max_perf). Absent when unreadable. */
+  clockCaps?: CpuClockCap[] | null;
 }
 
 // ─── RAM metrics ─────────────────────────────────────────

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -271,6 +271,8 @@ export interface ClockCapBoundsResponse {
   sparkId: string;
   domains: ClockCapDomain[];
   helper: { available: boolean; checked: boolean; reason?: string };
+  /** Non-fatal caveats, e.g. the GPU ceiling came from the documented fallback. */
+  warnings?: string[];
 }
 
 /** POST /api/sparks/:id/clocks response (200 shape). */

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -569,6 +569,11 @@ export interface SparkSnapshot {
   comfyMonitoring?: boolean;
   /** ComfyUI HTTP port (default 8188) */
   comfyPort?: number;
+  /**
+   * Opt-in: the Clock Cap rows in the GPU/CPU panels become editable
+   * (default false; requires the one-time helper install on the host).
+   */
+  clockControlEnabled?: boolean;
   /** Whether tailnet presence is probed (opt-in; all roles) */
   tailscaleMonitoring?: boolean;
   /** Hermes Agent update monitoring state (present in every snapshot). */

--- a/src/components/EditSparkDialog.tsx
+++ b/src/components/EditSparkDialog.tsx
@@ -183,6 +183,7 @@ export function EditSparkDialog({
         Boolean(config.comfyMonitoring) !== Boolean(savedConfig.comfyMonitoring) ||
         Boolean(config.hermesMonitoring) !== Boolean(savedConfig.hermesMonitoring) ||
         Boolean(config.tailscaleMonitoring) !== Boolean(savedConfig.tailscaleMonitoring) ||
+        Boolean(config.clockControlEnabled) !== Boolean(savedConfig.clockControlEnabled) ||
         (config.comfyPort ?? 8188) !== (savedConfig.comfyPort ?? 8188);
 
       const result = formDirty
@@ -239,6 +240,7 @@ export function EditSparkDialog({
         })(),
         hermesMonitoring: Boolean(config.hermesMonitoring),
         tailscaleMonitoring: Boolean(config.tailscaleMonitoring),
+        clockControlEnabled: Boolean(config.clockControlEnabled),
         ssh: {
           host: config.ssh.host || config.lanIp,
           user: config.ssh.user,
@@ -515,6 +517,31 @@ export function EditSparkDialog({
                   </span>
                 </label>
               </div>
+
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted">
+                <label className="flex min-w-0 items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(config.clockControlEnabled)}
+                    onChange={(e) => update({ clockControlEnabled: e.target.checked })}
+                    className="rounded border-border"
+                  />
+                  <span>Allow clock control</span>
+                  <span
+                    className="inline-flex shrink-0 cursor-help text-muted hover:text-text"
+                    title="When enabled, the Clock Cap rows in the GPU/CPU panels become editable: set a CPU or GPU clock cap within the hardware range, apply it live and/or persist it to the boot unit. Requires a one-time helper install on the host (scripts/install-clock-helper.sh). Default off."
+                    aria-label="Allow setting CPU and GPU clock caps from the dashboard."
+                  >
+                    <InfoIcon className="h-3.5 w-3.5" />
+                  </span>
+                </label>
+              </div>
+              <p className="mt-1 text-[10px] text-muted">
+                One-time setup on the unit: run{" "}
+                <code className="rounded bg-surface-elevated px-1">scripts/install-clock-helper.sh</code>{" "}
+                (installs a root helper plus a scoped passwordless-sudo rule). No password is
+                stored or asked for in sparkDash.
+              </p>
 
               {role === "worker" && (
                 <div className="space-y-3">

--- a/src/components/SparkPage/ClockCapControl.tsx
+++ b/src/components/SparkPage/ClockCapControl.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { getClockCapBounds, setClockCap } from "../../api/client";
+import type { ClockCapBoundsResponse, ClockCapDomain } from "../../api/types";
+import { useModalPresence } from "../../hooks/useModalPresence";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
+import { InfoIcon } from "../ui/icons";
+
+interface ClockCapControlProps {
+  sparkId: string;
+  domain: string;
+  /** Current cap in MHz, or null when uncapped / unknown. */
+  currentMHz: number | null;
+  /** Display string for the closed (button) state, e.g. "2200" or "2200 / 3003". */
+  display: string;
+  /** False → plain text (control disabled with the server-provided reason). */
+  enabled?: boolean;
+  disabledReason?: string;
+  className?: string;
+}
+
+function useEscape(enabled: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [enabled, onClose]);
+}
+
+/**
+ * Clickable "Clock Cap" value shared by the GPU and CPU panels. Opens a dialog
+ * offering a slider + number input bounded by the discovered hardware range,
+ * named presets, an "Apply (this boot only)" button and a persisted "Save".
+ * No password / sudo prompt exists anywhere by design — provisioning is a
+ * one-time helper install (see README "Clock control").
+ */
+export function ClockCapControl({
+  sparkId,
+  domain,
+  currentMHz,
+  display,
+  enabled = true,
+  disabledReason,
+  className,
+}: ClockCapControlProps) {
+  const [open, setOpen] = useState(false);
+  const [bounds, setBounds] = useState<ClockCapDomain | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [value, setValue] = useState<number | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<{ warnings: string[]; persisted: boolean } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const titleId = useId();
+  const { mounted, visible } = useModalPresence(open);
+  const trapRef = useFocusTrap(mounted);
+  const openedRef = useRef(false);
+
+  useEscape(open && !busy, () => setOpen(false));
+
+  useEffect(() => {
+    if (!open) {
+      openedRef.current = false;
+      setResult(null);
+      setError(null);
+      return;
+    }
+    if (openedRef.current) return;
+    openedRef.current = true;
+    setLoaded(false);
+    setLoadError(null);
+    getClockCapBounds(sparkId)
+      .then((res: ClockCapBoundsResponse) => {
+        const d = res.domains.find((x) => x.id === domain) ?? null;
+        setBounds(d);
+        setValue(d?.currentMHz ?? d?.hardMaxMHz ?? null);
+        setLoaded(true);
+        if (!d) setLoadError(`Domain ${domain} is not available on this Spark`);
+      })
+      .catch((err: unknown) => {
+        setLoadError(err instanceof Error ? err.message : String(err));
+        setLoaded(true);
+      });
+  }, [open, sparkId, domain]);
+
+  const clamp = useCallback(
+    (v: number) => {
+      if (!bounds) return v;
+      return Math.min(bounds.hardMaxMHz, Math.max(bounds.hardMinMHz, Math.round(v)));
+    },
+    [bounds]
+  );
+
+  const rangeInfo = useMemo(() => {
+    if (!bounds) return "";
+    return `${bounds.hardMinMHz}–${bounds.hardMaxMHz} MHz`;
+  }, [bounds]);
+
+  const apply = async (persist: boolean) => {
+    if (!bounds || busy) return;
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await setClockCap(sparkId, {
+        domain,
+        maxMHz: value,
+        persist,
+      });
+      setResult({ warnings: res.warnings ?? [], persisted: res.persisted });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!enabled) {
+    return (
+      <span
+        className={`inline-flex items-center gap-1 text-muted ${className ?? ""}`}
+        title={disabledReason || "Clock control is disabled (enable it in Edit Spark)"}
+      >
+        <span className="font-tabular text-sm text-muted">{display}</span>
+        <InfoIcon className="h-3.5 w-3.5" />
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`cursor-pointer font-tabular text-sm text-text underline decoration-dotted decoration-border underline-offset-2 hover:text-accent ${className ?? ""}`}
+        title="Click to change the clock cap"
+        aria-haspopup="dialog"
+        onClick={() => setOpen(true)}
+      >
+        {display}
+      </button>
+
+      {mounted &&
+        createPortal(
+          <div
+            className={`modal-overlay${visible ? " is-open" : ""}`}
+            onClick={(e) => {
+              if (busy) return;
+              if (e.target === e.currentTarget) setOpen(false);
+            }}
+          >
+            <div
+              ref={trapRef}
+              className="modal-sheet max-w-md"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={titleId}
+            >
+              <div className="modal-sheet__header flex items-center gap-2" id={titleId}>
+                <span>Clock cap — {bounds?.label ?? domain}</span>
+              </div>
+
+              <div className="space-y-3 text-sm">
+                {!loaded && <p className="text-muted">Reading hardware bounds…</p>}
+                {loadError && <p className="text-danger">{loadError}</p>}
+
+                {loaded && bounds && (
+                  <>
+                    <p className="text-muted">
+                      Hardware range: {rangeInfo}. Current: {currentMHz != null ? `${currentMHz} MHz` : "no cap value reported"}
+                      {bounds.unitPath ? ` · boot unit ${bounds.unitPath}` : ""}
+                    </p>
+
+                    <div className="flex items-center gap-3">
+                      <input
+                        type="range"
+                        min={bounds.hardMinMHz}
+                        max={bounds.hardMaxMHz}
+                        step={bounds.stepMHz}
+                        value={value ?? bounds.hardMaxMHz}
+                        onChange={(e) => setValue(clamp(Number(e.target.value)))}
+                        aria-label="Clock cap in MHz (slider)"
+                        className="min-w-0 flex-1"
+                      />
+                      <input
+                        type="number"
+                        min={bounds.hardMinMHz}
+                        max={bounds.hardMaxMHz}
+                        value={value ?? ""}
+                        onChange={(e) => {
+                          const n = parseInt(e.target.value, 10);
+                          setValue(Number.isFinite(n) ? clamp(n) : null);
+                        }}
+                        aria-label="Clock cap in MHz"
+                        className="w-20 rounded border border-border bg-surface-elevated px-2 py-1 text-right font-tabular text-xs text-text outline-none focus:border-accent"
+                      />
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      {bounds.presets.map((p) => (
+                        <button
+                          key={p.label}
+                          type="button"
+                          className="rounded border border-border bg-surface-elevated px-2 py-1 text-xs text-text hover:border-accent"
+                          onClick={() => setValue(p.value)}
+                        >
+                          {p.label}
+                          {p.value != null ? ` (${p.value})` : ""}
+                        </button>
+                      ))}
+                    </div>
+
+                    {result && (
+                      <div className="rounded border border-border bg-surface-elevated p-2 text-xs">
+                        <p>
+                          Applied: {result.persisted ? "saved to the boot unit (survives reboot)" : "this boot only"}
+                        </p>
+                        {result.warnings.map((w) => (
+                          <p key={w} className="mt-1 text-warning">
+                            {w}
+                          </p>
+                        ))}
+                      </div>
+                    )}
+                    {error && <p className="text-danger">{error}</p>}
+
+                    <div className="flex items-center justify-end gap-2 pt-1">
+                      <button
+                        type="button"
+                        disabled={busy}
+                        className="rounded border border-border px-3 py-1.5 text-xs text-text hover:border-accent disabled:opacity-40"
+                        onClick={() => apply(false)}
+                      >
+                        Apply (this boot only)
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busy}
+                        className="rounded border border-accent bg-accent/10 px-3 py-1.5 text-xs font-medium text-accent hover:bg-accent/20 disabled:opacity-40"
+                        onClick={() => apply(true)}
+                      >
+                        Save
+                      </button>
+                    </div>
+                    <p className="text-[10px] text-muted">
+                      "Apply" lasts until reboot. "Save" rewrites the boot unit so the cap
+                      persists. Removing the cap restores the hardware maximum.
+                    </p>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/src/components/SparkPage/ClockCapControl.tsx
+++ b/src/components/SparkPage/ClockCapControl.tsx
@@ -48,6 +48,7 @@ export function ClockCapControl({
 }: ClockCapControlProps) {
   const [open, setOpen] = useState(false);
   const [bounds, setBounds] = useState<ClockCapDomain | null>(null);
+  const [boundsWarnings, setBoundsWarnings] = useState<string[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [value, setValue] = useState<number | null>(null);
   const [busy, setBusy] = useState(false);
@@ -72,11 +73,13 @@ export function ClockCapControl({
     openedRef.current = true;
     setLoaded(false);
     setLoadError(null);
+    setBoundsWarnings([]);
     getClockCapBounds(sparkId)
       .then((res: ClockCapBoundsResponse) => {
         const d = res.domains.find((x) => x.id === domain) ?? null;
         setBounds(d);
         setValue(d?.currentMHz ?? d?.hardMaxMHz ?? null);
+        setBoundsWarnings(res.warnings ?? []);
         setLoaded(true);
         if (!d) setLoadError(`Domain ${domain} is not available on this Spark`);
       })
@@ -172,6 +175,11 @@ export function ClockCapControl({
                       Hardware range: {rangeInfo}. Current: {currentMHz != null ? `${currentMHz} MHz` : "no cap value reported"}
                       {bounds.unitPath ? ` · boot unit ${bounds.unitPath}` : ""}
                     </p>
+                    {boundsWarnings.map((w) => (
+                      <p key={w} className="text-warning">
+                        {w}
+                      </p>
+                    ))}
 
                     <div className="flex items-center gap-3">
                       <input

--- a/src/components/SparkPage/CpuPanel.tsx
+++ b/src/components/SparkPage/CpuPanel.tsx
@@ -54,6 +54,7 @@ export function CpuPanel({ cpu, hardware, sparkId, temperatureUnit, className }:
   const temperature = cpu?.temperature ?? 0;
   const draw = cpu?.draw ?? 0;
   const tdp = cpu?.tdp ?? 0;
+  const clockCaps = cpu?.clockCaps ?? null;
 
   const displayTemp =
     temperatureUnit === "fahrenheit" ? celsiusToFahrenheit(temperature) : temperature;
@@ -96,6 +97,19 @@ export function CpuPanel({ cpu, hardware, sparkId, temperatureUnit, className }:
           {draw}W{tdp > 0 ? ` / ${tdp}W` : ""}
         </span>
       </div>
+      {clockCaps && clockCaps.length > 0 && (
+        <div className="flex justify-between text-sm">
+          <span className="text-muted">Clock Cap</span>
+          <span className="font-tabular text-sm text-text">
+            {clockCaps.map((d) => (
+              <span key={d.label} className={d.capped ? "text-text-strong" : "text-muted"}>
+                {d.label} {d.capped ? `${d.capMHz} / ${d.maxMHz}` : d.maxMHz} MHz
+                {clockCaps.length > 1 ? " · " : ""}
+              </span>
+            ))}
+          </span>
+        </div>
+      )}
       {model && (
         <div className="flex justify-between border-t border-border pt-3 text-xs">
           <span className="text-muted">Model</span>

--- a/src/components/SparkPage/CpuPanel.tsx
+++ b/src/components/SparkPage/CpuPanel.tsx
@@ -3,12 +3,15 @@ import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
 import { CpuIcon } from "../ui/icons";
 import { useMetricsHistoryTail } from "../../hooks/metricsStore";
+import { ClockCapControl } from "./ClockCapControl";
 
 interface CpuPanelProps {
   cpu: CpuMetrics | null;
   hardware?: HardwareInfo | null;
   sparkId: string;
   temperatureUnit: "celsius" | "fahrenheit";
+  /** Opt-in: Clock Cap rows become editable (default false). */
+  clockControlEnabled?: boolean;
   className?: string;
 }
 
@@ -46,7 +49,14 @@ function MetricRow({
  * this panel makes that visible at the device level. For non-Spark GPU
  * hosts it covers the discrete CPU.
  */
-export function CpuPanel({ cpu, hardware, sparkId, temperatureUnit, className }: CpuPanelProps) {
+export function CpuPanel({
+  cpu,
+  hardware,
+  sparkId,
+  temperatureUnit,
+  clockControlEnabled,
+  className,
+}: CpuPanelProps) {
   const usageHistory = useMetricsHistoryTail(sparkId, "cpu.usage");
   const tempHistory = useMetricsHistoryTail(sparkId, "cpu.temp");
 
@@ -98,15 +108,32 @@ export function CpuPanel({ cpu, hardware, sparkId, temperatureUnit, className }:
         </span>
       </div>
       {clockCaps && clockCaps.length > 0 && (
-        <div className="flex justify-between text-sm">
+        <div className="flex items-center justify-between text-sm">
           <span className="text-muted">Clock Cap</span>
-          <span className="font-tabular text-sm text-text">
-            {clockCaps.map((d) => (
-              <span key={d.label} className={d.capped ? "text-text-strong" : "text-muted"}>
-                {d.label} {d.capped ? `${d.capMHz} / ${d.maxMHz}` : d.maxMHz} MHz
-                {clockCaps.length > 1 ? " · " : ""}
-              </span>
-            ))}
+          <span className="font-tabular text-sm">
+            {clockCaps.map((d, i) => {
+              // Domain id mirrors the server's rule (≥3 GHz group = big).
+              const domainId = d.maxMHz >= 3000 ? "cpu-big" : "cpu-little";
+              const label = d.capped ? `${d.capMHz} / ${d.maxMHz}` : `${d.maxMHz}`;
+              return (
+                <span key={d.label}>
+                  <span className={d.capped ? "text-text-strong" : "text-muted"}>
+                    {d.label}{" "}
+                  </span>
+                  <ClockCapControl
+                    sparkId={sparkId}
+                    domain={domainId}
+                    currentMHz={d.capMHz}
+                    display={`${label} MHz`}
+                    enabled={Boolean(clockControlEnabled)}
+                    disabledReason="Clock control is disabled for this Spark (enable it in Edit Spark)"
+                  />
+                  {clockCaps.length > 1 && i < clockCaps.length - 1 ? (
+                    <span className="text-muted"> · </span>
+                  ) : null}
+                </span>
+              );
+            })}
           </span>
         </div>
       )}

--- a/src/components/SparkPage/CpuPanel.tsx
+++ b/src/components/SparkPage/CpuPanel.tsx
@@ -1,0 +1,110 @@
+import type { CpuMetrics, HardwareInfo } from "../../api/types";
+import { Sparkline } from "../ui/Sparkline";
+import { Panel } from "../ui/Panel";
+import { CpuIcon } from "../ui/icons";
+import { useMetricsHistoryTail } from "../../hooks/metricsStore";
+
+interface CpuPanelProps {
+  cpu: CpuMetrics | null;
+  hardware?: HardwareInfo | null;
+  sparkId: string;
+  temperatureUnit: "celsius" | "fahrenheit";
+  className?: string;
+}
+
+function celsiusToFahrenheit(c: number): number {
+  return Math.round((c * 9) / 5 + 32);
+}
+
+function MetricRow({
+  label,
+  spark,
+  value,
+  color = "var(--color-accent)",
+}: {
+  label: string;
+  spark: React.ReactNode;
+  value: React.ReactNode;
+  color?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-muted">{label}</span>
+      <div className="flex items-center gap-3">
+        <span style={{ color }}>{spark}</span>
+        <span className="font-tabular text-sm font-semibold text-text">{value}</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * CPU panel — usage, temperature, and power for the SoC CPU.
+ *
+ * On GB10 devices (DGX Spark / GX10) the CPU and GPU share one package and
+ * one power envelope, so the CPU is often the part that runs hot first —
+ * this panel makes that visible at the device level. For non-Spark GPU
+ * hosts it covers the discrete CPU.
+ */
+export function CpuPanel({ cpu, hardware, sparkId, temperatureUnit, className }: CpuPanelProps) {
+  const usageHistory = useMetricsHistoryTail(sparkId, "cpu.usage");
+  const tempHistory = useMetricsHistoryTail(sparkId, "cpu.temp");
+
+  const usage = cpu?.usage ?? 0;
+  const temperature = cpu?.temperature ?? 0;
+  const draw = cpu?.draw ?? 0;
+  const tdp = cpu?.tdp ?? 0;
+
+  const displayTemp =
+    temperatureUnit === "fahrenheit" ? celsiusToFahrenheit(temperature) : temperature;
+  const tempLabel = temperatureUnit === "fahrenheit" ? `${displayTemp}°F` : `${displayTemp}°C`;
+
+  // GB10 SoC bands: the CPU complex derates in the mid-80s; x86 hosts run
+  // hotter before throttling, so the danger band sits higher.
+  const tempColor =
+    temperature > 95
+      ? "var(--color-danger)"
+      : temperature > 85
+        ? "var(--color-warning)"
+        : "var(--color-accent)";
+
+  const model = hardware?.cpuModel;
+  const cores = hardware?.cpuCores;
+
+  return (
+    <Panel
+      title="CPU"
+      icon={<CpuIcon />}
+      className={`panel-cpu ${className ?? ""}`}
+      bodyClassName="space-y-3"
+    >
+      <MetricRow
+        label="Usage"
+        color="var(--color-accent)"
+        spark={<Sparkline data={usageHistory} color="var(--color-accent)" width={180} />}
+        value={<span className="text-text-strong">{usage}%</span>}
+      />
+      <MetricRow
+        label="Temperature"
+        color={tempColor}
+        spark={<Sparkline data={tempHistory} color={tempColor} width={180} />}
+        value={<span className="text-text-strong">{tempLabel}</span>}
+      />
+      <div className="flex justify-between text-sm">
+        <span className="text-muted">CPU Power</span>
+        <span className="font-tabular text-sm text-text">
+          {draw}W{tdp > 0 ? ` / ${tdp}W` : ""}
+        </span>
+      </div>
+      {model && (
+        <div className="flex justify-between border-t border-border pt-3 text-xs">
+          <span className="text-muted">Model</span>
+          <span className="font-tabular text-text" title={model}>
+            {model}
+            {cores != null ? ` · ${cores} cores` : ""}
+          </span>
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/src/components/SparkPage/GpuPanel.tsx
+++ b/src/components/SparkPage/GpuPanel.tsx
@@ -4,11 +4,14 @@ import { Panel } from "../ui/Panel";
 import { ActivityIcon } from "../ui/icons";
 import { MetricBar } from "../ui/MetricBar";
 import { useMetricsHistoryTail } from "../../hooks/metricsStore";
+import { ClockCapControl } from "./ClockCapControl";
 
 interface GpuPanelProps {
   gpu: GpuMetrics | null;
   sparkId: string;
   temperatureUnit: "celsius" | "fahrenheit";
+  /** Opt-in: the Clock Cap row becomes editable (default false). */
+  clockControlEnabled?: boolean;
   className?: string;
 }
 
@@ -43,7 +46,13 @@ function MetricRow({
   );
 }
 
-export function GpuPanel({ gpu, sparkId, temperatureUnit, className }: GpuPanelProps) {
+export function GpuPanel({
+  gpu,
+  sparkId,
+  temperatureUnit,
+  clockControlEnabled,
+  className,
+}: GpuPanelProps) {
   const tempHistory = useMetricsHistoryTail(sparkId, "gpu.temp");
   const usageHistory = useMetricsHistoryTail(sparkId, "gpu.usage");
 
@@ -148,14 +157,21 @@ export function GpuPanel({ gpu, sparkId, temperatureUnit, className }: GpuPanelP
             {clockLock != null && (
               <div className="flex items-center justify-between gap-2 text-sm">
                 <span className="text-muted">Clock Cap</span>
-                <span className="font-tabular text-sm text-text-strong">
-                  {/* -lgc MIN,MAX: a 0 min means "no floor" and MIN==MAX is a
-                      single pinned value — both collapse to just the max.
-                      Show the range only when a real floor is locked. */}
-                  {clockLock.minMHz > 0 && clockLock.minMHz !== clockLock.maxMHz
-                    ? `${clockLock.minMHz}–${clockLock.maxMHz} MHz`
-                    : `${capMax} MHz`}
-                </span>
+                <ClockCapControl
+                  sparkId={sparkId}
+                  domain="gpu"
+                  currentMHz={capMax}
+                  display={
+                    /* -lgc MIN,MAX: a 0 min means "no floor" and MIN==MAX is a
+                       single pinned value — both collapse to just the max.
+                       Show the range only when a real floor is locked. */
+                    clockLock.minMHz > 0 && clockLock.minMHz !== clockLock.maxMHz
+                      ? `${clockLock.minMHz}–${clockLock.maxMHz} MHz`
+                      : `${capMax} MHz`
+                  }
+                  enabled={Boolean(clockControlEnabled)}
+                  disabledReason="Clock control is disabled for this Spark (enable it in Edit Spark)"
+                />
               </div>
             )}
             <div className="flex items-baseline justify-between gap-2">

--- a/src/components/SparkPage/GpuPanel.tsx
+++ b/src/components/SparkPage/GpuPanel.tsx
@@ -117,9 +117,21 @@ export function GpuPanel({ gpu, sparkId, temperatureUnit, className }: GpuPanelP
               ? "bg-warning"
               : "bg-accent";
         const pct = t?.smClockPct;
+        // When a clock cap is set, the bar's full scale becomes the cap (not
+        // the hardware max) so it reflects the headroom that actually exists.
+        const clockLock = gpu?.clockLock ?? null;
+        const capMax = clockLock?.maxMHz ?? null;
+        const denomMHz =
+          capMax != null && t?.smClockMaxMHz != null
+            ? Math.min(capMax, t.smClockMaxMHz)
+            : t?.smClockMaxMHz ?? null;
+        const barPct =
+          t?.smClockMHz != null && denomMHz != null && denomMHz > 0
+            ? (t.smClockMHz / denomMHz) * 100
+            : pct;
         const clockCaption =
-          t?.smClockMHz != null && t?.smClockMaxMHz != null
-            ? `${t.smClockMHz} / ${t.smClockMaxMHz} MHz`
+          t?.smClockMHz != null && denomMHz != null
+            ? `${t.smClockMHz} / ${denomMHz} MHz`
             : pct != null
               ? `${pct}%`
               : "—";
@@ -133,6 +145,19 @@ export function GpuPanel({ gpu, sparkId, temperatureUnit, className }: GpuPanelP
                 {chipLabel}
               </span>
             </div>
+            {clockLock != null && (
+              <div className="flex items-center justify-between gap-2 text-sm">
+                <span className="text-muted">Clock Cap</span>
+                <span className="font-tabular text-sm text-text-strong">
+                  {/* -lgc MIN,MAX: a 0 min means "no floor" and MIN==MAX is a
+                      single pinned value — both collapse to just the max.
+                      Show the range only when a real floor is locked. */}
+                  {clockLock.minMHz > 0 && clockLock.minMHz !== clockLock.maxMHz
+                    ? `${clockLock.minMHz}–${clockLock.maxMHz} MHz`
+                    : `${capMax} MHz`}
+                </span>
+              </div>
+            )}
             <div className="flex items-baseline justify-between gap-2">
               <span className="text-[10px] uppercase tracking-wide text-muted">SM clock</span>
               <span className="font-tabular text-xs text-text">{clockCaption}</span>
@@ -141,7 +166,7 @@ export function GpuPanel({ gpu, sparkId, temperatureUnit, className }: GpuPanelP
               <div
                 className={`h-full rounded-full transition-[width] duration-300 ease-out ${barColor}`}
                 style={{
-                  width: `${pct != null ? Math.min(100, Math.max(0, pct)) : 0}%`,
+                  width: `${barPct != null ? Math.min(100, Math.max(0, barPct)) : 0}%`,
                 }}
               />
             </div>

--- a/src/components/SparkPage/GpuPanel.tsx
+++ b/src/components/SparkPage/GpuPanel.tsx
@@ -1,4 +1,4 @@
-import type { CpuMetrics, GpuMetrics } from "../../api/types";
+import type { GpuMetrics } from "../../api/types";
 import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
 import { ActivityIcon } from "../ui/icons";
@@ -7,8 +7,6 @@ import { useMetricsHistoryTail } from "../../hooks/metricsStore";
 
 interface GpuPanelProps {
   gpu: GpuMetrics | null;
-  /** When set and temperature > 0, show a CPU temp row (DGX Spark pages). */
-  cpu?: CpuMetrics | null;
   sparkId: string;
   temperatureUnit: "celsius" | "fahrenheit";
   className?: string;
@@ -45,10 +43,9 @@ function MetricRow({
   );
 }
 
-export function GpuPanel({ gpu, cpu, sparkId, temperatureUnit, className }: GpuPanelProps) {
+export function GpuPanel({ gpu, sparkId, temperatureUnit, className }: GpuPanelProps) {
   const tempHistory = useMetricsHistoryTail(sparkId, "gpu.temp");
   const usageHistory = useMetricsHistoryTail(sparkId, "gpu.usage");
-  const cpuTempHistory = useMetricsHistoryTail(sparkId, "cpu.temp");
 
   const temperature = gpu?.temperature ?? 0;
   const displayTemp = temperatureUnit === "fahrenheit" ? celsiusToFahrenheit(temperature) : temperature;
@@ -61,23 +58,10 @@ export function GpuPanel({ gpu, cpu, sparkId, temperatureUnit, className }: GpuP
   const vramTotal = gpu?.vram?.total ?? 0;
   const vramPct = gpu?.vram?.percentage ?? 0;
 
-  const cpuTemperature = cpu?.temperature ?? 0;
-  const cpuDisplayTemp =
-    temperatureUnit === "fahrenheit" ? celsiusToFahrenheit(cpuTemperature) : cpuTemperature;
-  const cpuTempLabel =
-    temperatureUnit === "fahrenheit" ? `${cpuDisplayTemp}°F` : `${cpuDisplayTemp}°C`;
-
   const tempColor =
     temperature > 85
       ? "var(--color-danger)"
       : temperature > 65
-        ? "var(--color-warning)"
-        : "var(--color-accent)";
-  // GB10 junction bands (warn 85 / crit 95) — idle CPU sits ~70°C, so GPU 65/85 would pin amber.
-  const cpuTempColor =
-    cpuTemperature > 95
-      ? "var(--color-danger)"
-      : cpuTemperature > 85
         ? "var(--color-warning)"
         : "var(--color-accent)";
 
@@ -101,14 +85,6 @@ export function GpuPanel({ gpu, cpu, sparkId, temperatureUnit, className }: GpuP
         spark={<Sparkline data={tempHistory} color={tempColor} width={180} />}
         value={<span className="text-text-strong">{tempLabel}</span>}
       />
-      {cpuTemperature > 0 && (
-        <MetricRow
-          label="CPU"
-          color={cpuTempColor}
-          spark={<Sparkline data={cpuTempHistory} color={cpuTempColor} width={180} />}
-          value={<span className="text-text-strong">{cpuTempLabel}</span>}
-        />
-      )}
       <div className="flex justify-between text-sm">
         <span className="text-muted">GPU Power</span>
         <span className="font-tabular text-sm text-text">

--- a/src/components/SparkPage/NetworkPanel.tsx
+++ b/src/components/SparkPage/NetworkPanel.tsx
@@ -9,6 +9,7 @@ interface NetworkPanelProps {
   sparkId: string;
   disabledInterfaces: string[];
   onDisabledChange: (interfaces: string[]) => void;
+  className?: string;
 }
 
 function formatSpeed(bytesPerSec: number): string {
@@ -42,6 +43,7 @@ export function NetworkPanel({
   sparkId,
   disabledInterfaces,
   onDisabledChange,
+  className,
 }: NetworkPanelProps) {
   const [showSettings, setShowSettings] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -79,7 +81,7 @@ export function NetworkPanel({
       title="Network"
       accent
       icon={<NetworkIcon />}
-      className="panel-network"
+      className={`panel-network ${className ?? ""}`}
       actions={
         <button
           type="button"

--- a/src/components/SparkPage/RamPanel.tsx
+++ b/src/components/SparkPage/RamPanel.tsx
@@ -1,4 +1,4 @@
-import type { CpuMetrics, RamMetrics } from "../../api/types";
+import type { RamMetrics } from "../../api/types";
 import { Sparkline } from "../ui/Sparkline";
 import { Panel } from "../ui/Panel";
 import { MemoryIcon } from "../ui/icons";
@@ -7,9 +7,7 @@ import { useMetricsHistoryTail } from "../../hooks/metricsStore";
 
 interface RamPanelProps {
   ram: RamMetrics | null;
-  cpu: CpuMetrics | null;
   sparkId: string;
-  temperatureUnit: "celsius" | "fahrenheit";
   className?: string;
 }
 
@@ -18,33 +16,16 @@ function formatMb(mb: number): string {
   return `${Math.round(mb)} MB`;
 }
 
-function celsiusToFahrenheit(c: number): number {
-  return Math.round((c * 9) / 5 + 32);
-}
-
 /**
  * System RAM panel — shown for non-Spark GPU hosts, where RAM (system memory)
- * and VRAM (discrete GPU memory) are separate things. CPU temperature lives
- * here for hosts; Spark pages show it on the GPU panel.
+ * and VRAM (discrete GPU memory) are separate things. CPU stats live in the
+ * dedicated CPU panel.
  */
-export function RamPanel({ ram, cpu, sparkId, temperatureUnit, className }: RamPanelProps) {
+export function RamPanel({ ram, sparkId, className }: RamPanelProps) {
   const history = useMetricsHistoryTail(sparkId, "ram.percentage");
-  const tempHistory = useMetricsHistoryTail(sparkId, "cpu.temp");
   const used = ram?.used ?? 0;
   const total = ram?.total ?? 0;
   const percentage = ram?.percentage ?? 0;
-
-  const temperature = cpu?.temperature ?? 0;
-  const displayTemp =
-    temperatureUnit === "fahrenheit" ? celsiusToFahrenheit(temperature) : temperature;
-  const tempLabel = temperatureUnit === "fahrenheit" ? `${displayTemp}°F` : `${displayTemp}°C`;
-  // Generic CPU junction-style bands (not GB10 GPU 65/85 — idle x86 often sits ~50–70).
-  const tempColor =
-    temperature > 95
-      ? "var(--color-danger)"
-      : temperature > 85
-        ? "var(--color-warning)"
-        : "var(--color-accent)";
 
   return (
     <Panel
@@ -79,17 +60,6 @@ export function RamPanel({ ram, cpu, sparkId, temperatureUnit, className }: RamP
         <div className="flex justify-between text-xs">
           <span className="text-muted">RAM</span>
           <span className="font-tabular text-text">—</span>
-        </div>
-      )}
-      {temperature > 0 && (
-        <div className="flex items-center justify-between text-sm">
-          <span className="text-muted">CPU</span>
-          <div className="flex items-center gap-3">
-            <span style={{ color: tempColor }}>
-              <Sparkline data={tempHistory} color={tempColor} width={180} />
-            </span>
-            <span className="font-tabular text-sm font-semibold text-text">{tempLabel}</span>
-          </div>
         </div>
       )}
     </Panel>

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -5,6 +5,7 @@ import { updateSpark, refreshSparkMetric, addLlmPort, removeLlmPort } from "../.
 import { SparkHeader } from "./SparkHeader";
 import { SparkActions } from "./SparkActions";
 import { GpuPanel } from "./GpuPanel";
+import { CpuPanel } from "./CpuPanel";
 import { RamPanel } from "./RamPanel";
 import { StoragePanel } from "./StoragePanel";
 import { NetworkPanel } from "./NetworkPanel";
@@ -228,66 +229,52 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
           style={{ marginTop: "var(--density-page-gap)" }}
         />
         {resourcesOpen && (
-          <>
-            {spark.kind === "host" ? (
-              /* Hosts: GPU spans the full left column; RAM → Network → Storage [→ Tailnet] stack in the right column */
-              <>
-                <GpuPanel
-                  gpu={metrics.gpu}
-                  sparkId={spark.id}
-                  temperatureUnit={temperatureUnit}
-                  className={tailscaleOn ? "md:row-span-4" : "md:row-span-3"}
-                />
-                <RamPanel
-                  ram={metrics.ram}
-                  cpu={metrics.cpu}
-                  sparkId={spark.id}
-                  temperatureUnit={temperatureUnit}
-                />
-                <NetworkPanel
-                  network={metrics.network}
-                  sparkId={spark.id}
-                  disabledInterfaces={disabledInterfaces}
-                  onDisabledChange={setDisabledInterfaces}
-                />
-                <StoragePanel
-                  storage={metrics.storage}
-                  sparkId={spark.id}
-                  disabledDevices={disabledDevices}
-                  onDisabledChange={setDisabledDevices}
-                  storagePollDisabled={storagePollDisabled}
-                  onStoragePollModeChange={handleStoragePollModeChange}
-                />
-                {tailscaleOn && <TailscalePanel tailscale={metrics.tailscale ?? null} />}
-              </>
-            ) : (
-              /* Resources layout: GPU spans the full left column; Storage + Network [+ Tailnet] stack in the right column */
-              <>
-                <GpuPanel
-                  gpu={metrics.gpu}
-                  cpu={metrics.cpu}
-                  sparkId={spark.id}
-                  temperatureUnit={temperatureUnit}
-                  className={tailscaleOn ? "md:row-span-3" : "md:row-span-2"}
-                />
-                <StoragePanel
-                  storage={metrics.storage}
-                  sparkId={spark.id}
-                  disabledDevices={disabledDevices}
-                  onDisabledChange={setDisabledDevices}
-                  storagePollDisabled={storagePollDisabled}
-                  onStoragePollModeChange={handleStoragePollModeChange}
-                />
-                <NetworkPanel
-                  network={metrics.network}
-                  sparkId={spark.id}
-                  disabledInterfaces={disabledInterfaces}
-                  onDisabledChange={setDisabledInterfaces}
-                />
-                {tailscaleOn && <TailscalePanel tailscale={metrics.tailscale ?? null} />}
-              </>
-            )}
-          </>
+          /* Two independent columns so panels take natural heights (no row-stretch
+             dead space). Left: GPU + CPU stacked (CPU sits directly under GPU).
+             Right: the rest, stacked independently. */
+          <div
+            className="md:col-span-2 grid grid-cols-1 md:grid-cols-2"
+            style={{ gap: "var(--density-page-gap)" }}
+          >
+            <div className="flex flex-col" style={{ gap: "var(--density-page-gap)" }}>
+              <GpuPanel
+                gpu={metrics.gpu}
+                sparkId={spark.id}
+                temperatureUnit={temperatureUnit}
+              />
+              {/* grow: fill the gap so the left column's bottom aligns with the right */}
+              <CpuPanel
+                cpu={metrics.cpu}
+                hardware={spark.hardware}
+                sparkId={spark.id}
+                temperatureUnit={temperatureUnit}
+                className="grow"
+              />
+            </div>
+            <div className="flex flex-col" style={{ gap: "var(--density-page-gap)" }}>
+              {spark.kind === "host" && <RamPanel ram={metrics.ram} sparkId={spark.id} />}
+              <StoragePanel
+                storage={metrics.storage}
+                sparkId={spark.id}
+                disabledDevices={disabledDevices}
+                onDisabledChange={setDisabledDevices}
+                storagePollDisabled={storagePollDisabled}
+                onStoragePollModeChange={handleStoragePollModeChange}
+              />
+              {/* grow: the right column's bottom panel fills the gap (Network, or
+                  Tailnet when it's the last one) so both columns end at the same height */}
+              <NetworkPanel
+                network={metrics.network}
+                sparkId={spark.id}
+                disabledInterfaces={disabledInterfaces}
+                onDisabledChange={setDisabledInterfaces}
+                className={tailscaleOn ? undefined : "grow"}
+              />
+              {tailscaleOn && (
+                <TailscalePanel tailscale={metrics.tailscale ?? null} className="grow" />
+              )}
+            </div>
+          </div>
         )}
         {/*
           Services layout:

--- a/src/components/SparkPage/SparkPage.tsx
+++ b/src/components/SparkPage/SparkPage.tsx
@@ -241,6 +241,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
                 gpu={metrics.gpu}
                 sparkId={spark.id}
                 temperatureUnit={temperatureUnit}
+                clockControlEnabled={Boolean(spark.clockControlEnabled)}
               />
               {/* grow: fill the gap so the left column's bottom aligns with the right */}
               <CpuPanel
@@ -248,6 +249,7 @@ export function SparkPage({ spark, temperatureUnit, onEdit }: SparkPageProps) {
                 hardware={spark.hardware}
                 sparkId={spark.id}
                 temperatureUnit={temperatureUnit}
+                clockControlEnabled={Boolean(spark.clockControlEnabled)}
                 className="grow"
               />
             </div>

--- a/src/components/SparkPage/TailscalePanel.tsx
+++ b/src/components/SparkPage/TailscalePanel.tsx
@@ -4,13 +4,14 @@ import { NetworkIcon } from "../ui/icons";
 
 interface TailscalePanelProps {
   tailscale: TailscaleMetrics | null;
+  className?: string;
 }
 
 /**
  * Tailnet presence for one unit. The failure mode is "healthy on the LAN,
  * invisible off it" — every other panel is LAN-fed and looks fine.
  */
-export function TailscalePanel({ tailscale }: TailscalePanelProps) {
+export function TailscalePanel({ tailscale, className }: TailscalePanelProps) {
   const online = tailscale?.online ?? null;
   const health = tailscale?.health ?? [];
   const available = Boolean(tailscale?.available);
@@ -25,7 +26,7 @@ export function TailscalePanel({ tailscale }: TailscalePanelProps) {
         : { label: "unknown", cls: "text-muted" };
 
   return (
-    <Panel title="Tailnet" accent={offTailnet} icon={<NetworkIcon />}>
+    <Panel title="Tailnet" accent={offTailnet} icon={<NetworkIcon />} className={className}>
       <div className="mb-3 flex items-center gap-2 text-xs">
         <span className="text-muted">Status</span>
         <span className={`font-tabular font-medium ${status.cls}`}>{status.label}</span>

--- a/src/components/SparkPage/__tests__/ClockCapControl.test.tsx
+++ b/src/components/SparkPage/__tests__/ClockCapControl.test.tsx
@@ -1,0 +1,176 @@
+import { act } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ClockCapControl } from "./ClockCapControl";
+import { render, flush } from "../testing/render";
+import { getClockCapBounds, setClockCap } from "../../api/client";
+import type { ClockCapBoundsResponse } from "../../api/types";
+
+vi.mock("../../api/client", () => ({
+  getClockCapBounds: vi.fn(),
+  setClockCap: vi.fn(),
+}));
+
+const mockGet = vi.mocked(getClockCapBounds);
+const mockSet = vi.mocked(setClockCap);
+
+const GPU_BOUNDS: ClockCapBoundsResponse = {
+  ok: true,
+  sparkId: "spark-test",
+  helper: { available: true, checked: true },
+  domains: [
+    {
+      id: "gpu",
+      label: "GPU",
+      currentMHz: 2200,
+      hardMinMHz: 0,
+      hardMaxMHz: 3003,
+      stepMHz: 25,
+      presets: [{ label: "No cap", value: null }],
+      unitPath: "/etc/systemd/system/gpu-clock-lock.service",
+      writable: true,
+    },
+  ],
+};
+
+async function openDialog() {
+  const { container } = render(
+    <ClockCapControl sparkId="spark-test" domain="gpu" currentMHz={2200} display="2200 MHz" />
+  );
+  const button = container.querySelector("button");
+  expect(button?.getAttribute("aria-haspopup")).toBe("dialog");
+  await act(async () => {
+    button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await flush();
+  return { container, dialog: document.querySelector('[role="dialog"][aria-modal="true"]') };
+}
+
+describe("ClockCapControl", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockSet.mockReset();
+    mockGet.mockResolvedValue(GPU_BOUNDS);
+  });
+
+  it("renders the cap as a dialog-opening button (closed state = plain text when disabled)", () => {
+    const { container } = render(
+      <ClockCapControl
+        sparkId="spark-test"
+        domain="gpu"
+        currentMHz={2200}
+        display="2200"
+        enabled={false}
+        disabledReason="Clock control is disabled"
+      />
+    );
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.textContent).toContain("2200");
+  });
+
+  it("opens on click and loads the hardware bounds for the domain", async () => {
+    const { dialog } = await openDialog();
+    expect(dialog).not.toBeNull();
+    expect(mockGet).toHaveBeenCalledWith("spark-test");
+    await flush();
+    expect(dialog!.textContent).toContain("0–3003 MHz");
+  });
+
+  it("sends persist:true on Save and persist:false on the boot-only button", async () => {
+    mockSet.mockResolvedValue({
+      ok: true,
+      domain: "gpu",
+      appliedMHz: 2500,
+      persisted: true,
+      bootUnit: "/etc/systemd/system/gpu-clock-lock.service",
+      source: "helper",
+      warnings: [],
+    });
+    const { dialog } = await openDialog();
+    await flush();
+    const buttons = Array.from(dialog!.querySelectorAll("button"));
+    const save = buttons.find((b) => b.textContent === "Save");
+    const bootOnly = buttons.find((b) => b.textContent?.startsWith("Apply"));
+    expect(save).toBeTruthy();
+    expect(bootOnly).toBeTruthy();
+
+    mockSet.mockClear();
+    await act(async () => {
+      save!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    expect(mockSet).toHaveBeenCalledTimes(1);
+    expect(mockSet.mock.calls[0][0]).toBe("spark-test");
+    expect(mockSet.mock.calls[0][1]).toEqual({ domain: "gpu", maxMHz: 2200, persist: true });
+
+    mockSet.mockClear();
+    await act(async () => {
+      bootOnly!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    expect(mockSet.mock.calls[0][1]).toEqual({ domain: "gpu", maxMHz: 2200, persist: false });
+  });
+
+  it("clamps user input to the domain bounds", async () => {
+    const { dialog } = await openDialog();
+    await flush();
+    const number_ = dialog!.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(number_).not.toBeNull();
+    await act(async () => {
+      number_.value = "9999";
+      number_.dispatchEvent(new Event("input", { bubbles: true }));
+      number_.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await flush();
+    // React reads e.target.value on change; our onChange clamps via state.
+    // The applied request must never exceed the hard max.
+    mockSet.mockResolvedValue({
+      ok: true,
+      domain: "gpu",
+      appliedMHz: 3003,
+      persisted: false,
+      bootUnit: null,
+      source: "container",
+      warnings: [],
+    });
+    const save = Array.from(dialog!.querySelectorAll("button")).find(
+      (b) => b.textContent === "Save"
+    )!;
+    await act(async () => {
+      save.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    const body = mockSet.mock.calls[0][1];
+    expect(body.maxMHz).toBeLessThanOrEqual(3003);
+    expect(body.maxMHz).toBeGreaterThanOrEqual(0);
+  });
+
+  it("surfaces the reboot warning from the response warnings", async () => {
+    mockSet.mockResolvedValue({
+      ok: true,
+      domain: "gpu",
+      appliedMHz: 2200,
+      persisted: false,
+      bootUnit: null,
+      source: "container",
+      warnings: ["applied this boot only — reverts on reboot"],
+    });
+    const { dialog } = await openDialog();
+    await flush();
+    const bootOnly = Array.from(dialog!.querySelectorAll("button")).find((b) =>
+      b.textContent?.startsWith("Apply")
+    )!;
+    await act(async () => {
+      bootOnly.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    expect(dialog!.textContent).toContain("reverts on reboot");
+    expect(dialog!.textContent).toContain("this boot only");
+  });
+
+  it("shows a load error when the bounds request fails (e.g. helper missing)", async () => {
+    mockGet.mockRejectedValueOnce(new Error("clock helper not installed — run scripts/install-clock-helper.sh on the host"));
+    const { dialog } = await openDialog();
+    await flush();
+    expect(dialog!.textContent).toContain("install-clock-helper.sh");
+  });
+});

--- a/src/components/SparkPage/__tests__/ClockCapControl.test.tsx
+++ b/src/components/SparkPage/__tests__/ClockCapControl.test.tsx
@@ -1,11 +1,11 @@
 import { act } from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { ClockCapControl } from "./ClockCapControl";
-import { render, flush } from "../testing/render";
-import { getClockCapBounds, setClockCap } from "../../api/client";
-import type { ClockCapBoundsResponse } from "../../api/types";
+import { ClockCapControl } from "../ClockCapControl";
+import { render, flush } from "../../../testing/render";
+import { getClockCapBounds, setClockCap } from "../../../api/client";
+import type { ClockCapBoundsResponse } from "../../../api/types";
 
-vi.mock("../../api/client", () => ({
+vi.mock("../../../api/client", () => ({
   getClockCapBounds: vi.fn(),
   setClockCap: vi.fn(),
 }));

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -178,6 +178,16 @@ export function MemoryIcon({ className = "" }: { className?: string }) {
   );
 }
 
+export function CpuIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg {...baseProps(className)}>
+      <rect x="5" y="5" width="14" height="14" rx="2" />
+      <rect x="9" y="9" width="6" height="6" />
+      <path d="M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3" />
+    </svg>
+  );
+}
+
 export function BoltIcon({ className = "" }: { className?: string }) {
   return (
     <svg {...baseProps(className)}>


### PR DESCRIPTION
## Summary

Adds a dedicated **CPU panel** to the device page, restructures the Resources section into two auto-aligned columns, and adds **editable clock caps** for both the CPU and GPU so you can dial the clocks down to keep the box cool.

On GB10 devices (DGX Spark / GX10) the CPU and GPU share one package and one power envelope, and the CPU is often the part that runs hot first. Previously CPU temperature was only a small row tucked inside the GPU panel (Sparks) or RAM panel (hosts), easy to miss. This makes CPU a first-class section.

## CPU panel

Shows, with sparklines where it helps:
- **Usage** %
- **Temperature** (color-banded: amber >85°C, red >95°C; the GB10 SoC derates in the mid-80s)
- **CPU Power** (draw / TDP)
- **Model · cores** (e.g. "GB10 · 20 cores")

## Layout

The Resources section is now two independent columns:

```
left:  GPU + CPU            right: [RAM] + Storage + Network [+ Tailnet]
```

- **CPU sits directly beneath GPU** in the left column (previously it was top-right, leaving dead space under the GPU's Processes list).
- Each column is a flex stack, so panels take their **natural height**, no more row-stretch gap under the GPU panel.
- The **bottom panel of each column gets `flex-grow`**, so whichever side is shorter stretches its lowest panel (CPU on the left; Network, or Tailnet when it's last, on the right) to match. Both columns always end at the same height regardless of content or which panels are present.

## Clock caps (editable)

A **Clock Cap** row on both the CPU and GPU panels opens a dialog to set a frequency ceiling, live and/or persisted to the boot unit. This is the easy way to keep a GB10 box cool: cap the GPU graphics clock and the CPU clusters a few hundred MHz below their hardware max and the temperature drops without meaningfully touching throughput.

- **Per-Spark opt-in** — clock control is off by default. Enable it per Spark (Edit Spark → "Allow clock control") so a box you don't want to touch stays read-only.
- **GPU** — set the graphics clock within the hardware band (0.30–0.80 of the `Max Clocks → Graphics` ceiling, which is 3003 MHz on GB10, not the 2418 "Applications Clocks" default). The driver quantizes the request against its own table (ask 2000, get 1976), so the dialog reports both the requested and the applied value and never snaps the number you typed.
- **CPU** — one row per frequency cluster (X925 big / A725 little on GB10), each capped within its own sysfs bounds.
- **Apply vs Save** — "Apply" lasts until reboot; "Save" rewrites the boot unit so the cap survives a reboot. Removing the cap restores the hardware maximum.
- **Two ways to set a value** — a 200 MHz grid slider and a free-entry field (never snapped client-side); moving either updates the other.
- **Remote Sparks** — a one-time helper install (`scripts/install-clock-helper.sh`) provisions a scoped NOPASSWD sudoers grant; the dialog itself never asks for a password.

### Why bother: cooler with almost no throughput cost

Capping the clocks is the cheapest thermal lever on a GB10 box. In practice the decode and prefill throughput loss is negligible: on the GLM-5.3-Flash-EXL3 box the caps cost **0% on both prefill and decode** (the architecture doesn't bottleneck on the clock headroom being given back), while the sustained temperature comes down enough to stop the thermal derating that would otherwise eat more performance than the cap does.

## Changes

- `src/components/SparkPage/CpuPanel.tsx` — new panel + per-cluster Clock Cap rows
- `src/components/SparkPage/GpuPanel.tsx` — Clock Cap row + cap-scaled SM-clock bar; drop the CPU-temp row (now in CpuPanel)
- `src/components/SparkPage/ClockCapControl.tsx` — the editable cap dialog (slider + free entry, candidates, presets, requested-vs-applied honesty)
- `src/components/SparkPage/SparkPage.tsx` — two-column Resources layout + grow alignment
- `src/components/SparkPage/RamPanel.tsx` — drop the CPU-temp row (now in CpuPanel)
- `src/components/SparkPage/NetworkPanel.tsx`, `TailscalePanel.tsx` — optional `className` prop for the grow alignment
- `src/components/EditSparkDialog.tsx` — per-Spark "Allow clock control" opt-in
- `src/App.tsx` — carry `clockControlEnabled` through the snapshot/WS merge
- `src/api/client.ts`, `src/api/types.ts` — bounds + set-cap client, `ClockCap*` types
- `src/components/ui/icons.tsx` — new `CpuIcon`
- `src/index.css` — clock dialog width class
- `server/collectors/clockControl.js` — bounds computation, GPU `-lgc` reply parser, apply/remove (helper + container paths)
- `server/collectors/SystemCollector.js` — clock-cap collection + apply wiring
- `server/sparks/SparkMonitor.js`, `SparkRegistry.js` — `clockControlEnabled` snapshot key + persistence
- `server/index.js` — `POST /api/sparks/:id/clocks` (rate-limited) + bounds endpoint
- `server/config.js` — `GPU_CLOCK_LOCK_UNIT` env knob
- `scripts/install-clock-helper.sh`, `scripts/sparkdash-set-clock` — remote helper + scoped sudoers grant
- `README.md` — clock-control provisioning + usage
- tests: `clockControl.test.js`, `SystemCollector.clockControl.test.js`, `SystemCollector.clockCaps.test.js`, `clockHelperScript.test.js`, `monitor-lifecycle.test.js`, `ClockCapControl.test.tsx`

## Verified

Built and running on a live 3x GB10 fleet (2x DGX Spark + 1x GX10). CPU temps render correctly per device, the two columns align at the bottom across boxes with different panel counts, and the clock caps read and apply correctly on all three boxes, local and remote-over-SSH.

Tests: server suite 419/419, frontend 41/41, `tsc --noEmit` clean, production build green.
