### PR TITLE
fix: gitignore config/settings.json (runtime-mutated, like its siblings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 node_modules/
 dist/
 .env
+docker-compose.override.yml
+ssh-config-local
 sparks.json
+config/settings.json
 config/sparks-secrets.json
 config/.secrets-key
 config/bench-history.json

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,8 +1,0 @@
-{
-  "pollIntervalMs": 1000,
-  "defaultLlmPort": 8888,
-  "autoHideOffline": false,
-  "temperatureUnit": "celsius",
-  "benchDebugTraces": false,
-  "density": "compact"
-}


### PR DESCRIPTION
## Summary
- `config/settings.json` is rewritten in place by the running server for live UI settings, exactly like the other `config/*.json` files (`sparks-secrets.json`, `bench-history.json`, `gpu-memory.json`, etc.) that are already gitignored.
- It was the one file in that family still tracked, so a local settings change shows up as a dirty tracked file, and a future `git pull` could conflict with or clobber a deployment's live settings.
- Adds it to `.gitignore` and untracks it (`git rm --cached`) — no behavior change, the server already writes its own copy on first run.

## Test plan
- [x] Confirmed the server recreates `config/settings.json` on startup when absent (existing behavior, unrelated to this change)
- [x] Verified the file is no longer reported by `git status` after a local edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)