### PR TITLE
fix: honor SSH connection settings consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,8 +426,10 @@ Copy `.env.example` to `.env` if needed:
 | `HOST_SYS_PATH` | `/host/sys` | Host sys mount |
 | `HOST_ROOT_PATH` | `/host/root` | Host root mount |
 | `SSH_IDENTITY_FILE` | _(unset)_ | Path **inside the process** to a private key (`ssh -i`). Use when the bind-mount is not a default OpenSSH name. |
-| `SSH_CONTROL_PERSIST_SECONDS` | `60` | Reuse authenticated SSH transports for remote collectors. Set to `0` to disable multiplexing. |
+| `SSH_CONTROL_PERSIST_SECONDS` | `60` | Idle SSH transport persistence in seconds, capped at `3600`. Set to `0` to disable multiplexing. |
 | `FLEET_ENERGY_JSON_PATH` | `config/fleet-energy.json` | Rolling fleet-energy persistence path |
+
+For compatibility, `SSH_CONTROL_PERSIST` is accepted as a seconds-based fallback when `SSH_CONTROL_PERSIST_SECONDS` is unset. The existing `SSH_MULTIPLEX=0` switch also disables reuse. SSH tunnels always use an independent connection.
 
 > The listener and both Compose files default to `127.0.0.1`. Existing Docker users who opened
 > `http://<host-ip>:5555` must migrate to an SSH tunnel, authenticated reverse proxy, Tailscale
@@ -507,6 +509,12 @@ Choice is stored in `localStorage`.
 ### Local vs remote Sparks
 
 One `SystemCollector` path for both modes. When `spark.isLocal` is true, metrics come from host sysfs/proc and `nvidia-smi` (often via nsenter into the host namespace). Remote Sparks wrap the same commands in a shared `sshExec()` helper (key agent or `sshpass`). The helper reuses an authenticated OpenSSH transport by default so frequent metric polls do not create a new SSH/PAM login lifecycle each time. Set `SSH_CONTROL_PERSIST_SECONDS=0` to disable reuse. For `kind: "host"` units, actual hardware (GPU model, driver version, CPU, RAM) is detected once and cached in place of the static DGX Spark specs, and GPU VRAM comes straight from `nvidia-smi` while system RAM is read from `/proc/meminfo`.
+
+### Remote SSH sessions and host memory
+
+Older sparkDash versions could create hundreds of SSH/PAM login sessions per minute on each remote host. [Issue #73](https://github.com/MiaAI-Lab/sparkDash/issues/73) documents the resulting session churn and observed `polkitd` memory growth. Connection reuse reduces this churn while retaining the collector refresh cadence. After updating, verify that metrics keep advancing and that new SSH authentications/PAM session opens fall after the initial connection; a new SSH client process for each collector command is still expected.
+
+If host memory remains low, compare Linux `MemAvailable` and per-process resident/swap usage. Memory retained by `polkitd` requires separate OS investigation: [polkit PR #653](https://github.com/polkit-org/polkit/pull/653) fixes a reference leak in `NoNewPrivileges` queries. Check whether your distribution's polkit package includes that fix. SSH reuse neither applies the OS patch nor releases memory already retained by another process.
 
 ### Graceful degradation
 

--- a/server/collectors/__tests__/ssh.test.js
+++ b/server/collectors/__tests__/ssh.test.js
@@ -1,6 +1,23 @@
-import { test } from "node:test";
+import { beforeEach, test } from "node:test";
 import { strict as assert } from "node:assert";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { sshCommandSpec } from "../ssh.js";
+
+beforeEach((t) => {
+  for (const name of ["SSH_CONTROL_PERSIST_SECONDS", "SSH_CONTROL_PERSIST", "SSH_IDENTITY_FILE"]) {
+    const previous = process.env[name];
+    delete process.env[name];
+    t.after(() => {
+      if (previous === undefined) delete process.env[name];
+      else process.env[name] = previous;
+    });
+  }
+});
+
+const controlOptions = (spec) => spec.args.filter((arg) => /^Control/.test(arg));
+const controlPath = (spec) => spec.args.find((arg) => arg.startsWith("ControlPath="));
 
 const keySpark = {
   id: "s1",
@@ -41,21 +58,24 @@ test("sshCommandSpec: missing user throws", () => {
   );
 });
 
-test("sshCommandSpec: commands share one master connection", () => {
+test("sshCommandSpec: commands use the private socket and persistence from their readiness config", () => {
   const spec = sshCommandSpec(keySpark, { remoteArgv: ["cat /proc/uptime"] });
   const dash = spec.args.indexOf("--");
   const master = spec.args.indexOf("ControlMaster=auto");
   const controlPath = spec.args.find((a) => a.startsWith("ControlPath="));
   const persist = spec.args.find((a) => a.startsWith("ControlPersist="));
   assert.ok(master >= 0 && master < dash);
-  // The literal must be a SHORT already-expanded path: execFile hands the
-  // value to ssh without shell/template expansion, and the LOCAL socket name
-  // must fit sun_path (~104 bytes on macOS). %C stays expanded-by-hand.
+  // Include OpenSSH's temporary socket suffix and the terminating NUL in
+  // macOS's 104-byte limit. A long per-user TMPDIR must not affect this path.
   const cpValue = controlPath?.slice("ControlPath=".length);
   assert.ok(cpValue && cpValue.startsWith("/tmp/sparkdash-"), `controlPath: ${controlPath}`);
   assert.ok(!cpValue.includes("%"));
-  assert.ok(cpValue.length < 104, `control path too long: ${cpValue.length}`);
-  assert.equal(persist, "ControlPersist=300");
+  assert.ok(Buffer.byteLength(cpValue) + 18 <= 104, `control path too long: ${cpValue.length}`);
+  assert.equal(fs.statSync(path.dirname(cpValue)).mode & 0o777, 0o700);
+  assert.equal(persist, "ControlPersist=60");
+  assert.deepEqual(controlOptions(spec), spec.multiplex.args.filter((arg) => /^Control/.test(arg)));
+  const next = sshCommandSpec(keySpark, { remoteArgv: ["cat /proc/meminfo"] });
+  assert.deepEqual(controlOptions(next), controlOptions(spec));
 });
 
 test("sshCommandSpec: multiplex:false opts out (tunnels own their connection)", () => {
@@ -63,4 +83,90 @@ test("sshCommandSpec: multiplex:false opts out (tunnels own their connection)", 
   assert.ok(spec.args.includes("ControlMaster=no"));
   assert.ok(spec.args.includes("ControlPath=none"));
   assert.ok(!spec.args.includes("ControlMaster=auto"));
+  assert.equal(spec.multiplex, null);
+});
+
+test("sshCommandSpec: documented zero persistence disables both reuse and the readiness probe", () => {
+  process.env.SSH_CONTROL_PERSIST_SECONDS = "0";
+  process.env.SSH_CONTROL_PERSIST = "300";
+  const spec = sshCommandSpec(keySpark);
+  assert.deepEqual(controlOptions(spec), ["ControlMaster=no", "ControlPath=none"]);
+  assert.equal(spec.multiplex, null);
+});
+
+test("sshCommandSpec: configured persistence reaches the actual SSH command", () => {
+  process.env.SSH_CONTROL_PERSIST_SECONDS = "120";
+  process.env.SSH_CONTROL_PERSIST = "300";
+  const spec = sshCommandSpec(keySpark);
+  assert.ok(spec.args.includes("ControlPersist=120"));
+  assert.equal(spec.multiplex.persistSeconds, 120);
+});
+
+test("sshCommandSpec: legacy persistence is a fallback for the documented setting", () => {
+  process.env.SSH_CONTROL_PERSIST = "180";
+  const spec = sshCommandSpec(keySpark);
+  assert.ok(spec.args.includes("ControlPersist=180"));
+  assert.equal(spec.multiplex.persistSeconds, 180);
+});
+
+test("sshCommandSpec: persistence bounds apply to the command as well as readiness", () => {
+  process.env.SSH_CONTROL_PERSIST_SECONDS = "99999";
+  const spec = sshCommandSpec(keySpark);
+  assert.ok(spec.args.includes("ControlPersist=3600"));
+  assert.equal(spec.multiplex.persistSeconds, 3600);
+  process.env.SSH_CONTROL_PERSIST_SECONDS = "invalid";
+  assert.ok(sshCommandSpec(keySpark).args.includes("ControlPersist=60"));
+});
+
+test("sshCommandSpec: changing the key identity changes the socket passed to SSH", () => {
+  process.env.SSH_IDENTITY_FILE = "/example/first-key";
+  const first = sshCommandSpec(keySpark);
+  process.env.SSH_IDENTITY_FILE = "/example/second-key";
+  const second = sshCommandSpec(keySpark);
+  assert.notEqual(controlPath(first), controlPath(second));
+  assert.ok(first.args.includes("/example/first-key"));
+  assert.ok(second.args.includes("/example/second-key"));
+});
+
+test("sshCommandSpec: password changes select a different socket without exposing the password", (t) => {
+  const existsSync = fs.existsSync;
+  const statSync = fs.statSync;
+  t.mock.method(fs, "existsSync", (p) => p === "/usr/bin/sshpass" || existsSync(p));
+  t.mock.method(fs, "statSync", (p) => p === "/usr/bin/sshpass" ? { isFile: () => true } : statSync(p));
+  const spark = { ...keySpark, ssh: { ...keySpark.ssh, auth: "pass", password: "test-password-one" } };
+  const first = sshCommandSpec(spark);
+  const second = sshCommandSpec({ ...spark, ssh: { ...spark.ssh, password: "test-password-two" } });
+  assert.equal(first.file, "sshpass");
+  assert.equal(first.env.SSHPASS, "test-password-one");
+  assert.equal(second.env.SSHPASS, "test-password-two");
+  assert.notEqual(controlPath(first), controlPath(second));
+  assert.ok(!first.args.join(" ").includes("test-password-one"));
+  assert.ok(!second.args.join(" ").includes("test-password-two"));
+});
+
+test("sshCommandSpec: different records and authentication modes do not share a socket", (t) => {
+  const existsSync = fs.existsSync;
+  const statSync = fs.statSync;
+  t.mock.method(fs, "existsSync", (p) => p === "/usr/bin/sshpass" || existsSync(p));
+  t.mock.method(fs, "statSync", (p) => p === "/usr/bin/sshpass" ? { isFile: () => true } : statSync(p));
+  const key = sshCommandSpec(keySpark);
+  const otherRecord = sshCommandSpec({ ...keySpark, id: "other-record" });
+  const password = sshCommandSpec({ ...keySpark, ssh: { ...keySpark.ssh, auth: "pass", password: "test-only" } });
+  assert.notEqual(controlPath(key), controlPath(otherRecord));
+  assert.notEqual(controlPath(key), controlPath(password));
+});
+
+test("sshCommandSpec: the legacy global switch still disables reuse", () => {
+  const moduleUrl = new URL("../ssh.js", import.meta.url).href;
+  const script = `
+    import { sshCommandSpec } from ${JSON.stringify(moduleUrl)};
+    const spec = sshCommandSpec(${JSON.stringify(keySpark)});
+    console.log(JSON.stringify({ args: spec.args, multiplex: spec.multiplex }));
+  `;
+  const spec = JSON.parse(execFileSync(process.execPath, ["--input-type=module", "-e", script], {
+    env: { ...process.env, SSH_MULTIPLEX: "0", SSH_CONTROL_PERSIST_SECONDS: "60" },
+    encoding: "utf8",
+  }));
+  assert.deepEqual(controlOptions(spec), ["ControlMaster=no", "ControlPath=none"]);
+  assert.equal(spec.multiplex, null);
 });

--- a/server/collectors/ssh.js
+++ b/server/collectors/ssh.js
@@ -8,13 +8,10 @@
 import { execFile } from "child_process";
 import crypto from "crypto";
 import fs from "fs";
-import os from "os";
-import path from "path";
 import {
   COMFY_PORT,
   COMFY_PROBE_TIMEOUT_MS,
   SSH_CONNECT_TIMEOUT,
-  SSH_CONTROL_PERSIST,
   SSH_MULTIPLEX,
 } from "../config.js";
 import { isAllowedTargetHost, isValidSshUser } from "../validate.js";
@@ -24,12 +21,17 @@ import { llmProbeHost } from "./llmHost.js";
 // checking PATH entries directly is faster and avoids spawning a shell.
 let _sshpassAvailable = null;
 const _multiplexStates = new Map();
+// Keep the private directory short even on macOS, where TMPDIR can already
+// consume most of a Unix socket's 104-byte path limit.
 const _controlDir = fs.mkdtempSync("/tmp/sparkdash-ssh-");
 const _controlSalt = crypto.randomBytes(32);
 fs.chmodSync(_controlDir, 0o700);
 
 function controlPersistSeconds() {
-  const configured = Number.parseInt(process.env.SSH_CONTROL_PERSIST_SECONDS ?? "60", 10);
+  const configured = Number.parseInt(
+    process.env.SSH_CONTROL_PERSIST_SECONDS ?? process.env.SSH_CONTROL_PERSIST ?? "60",
+    10
+  );
   return Number.isFinite(configured) ? Math.min(3600, Math.max(0, configured)) : 60;
 }
 
@@ -151,51 +153,6 @@ function sshpassAvailable() {
 }
 
 /**
- * `-o` flags that let every poll ride an already-authenticated connection.
- *
- * Without them each collector tick pays for a fresh TCP connect, key exchange
- * and authentication. At the default cadence a single remote Spark takes 217
- * of those per minute, and on password auth the KDF alone dominates the cost —
- * the login is far more expensive than the `cat /proc/meminfo` it carries.
- * With a shared master, the first command connects and the rest open a channel
- * on the socket that is already up.
- *
- * Control-path length is the trap: the socket name is created LOCALLY, so the
- * whole literal (directory + expanded hash) must stay under the ~104-byte
- * sun_path limit (108 on Linux). macOS hands every process a ~60-char
- * per-user $TMPDIR, so os.tmpdir() + the literal `%C` template — which execFile
- * passes to ssh WITHOUT shell expansion, quotes and all — blew past the limit
- * and every remote collector died with `unix_listener: path ... too long`.
- *
- * Fix: expand %C ourselves — same formula OpenSSH uses (SHA1 of
- * "local host:user:remote host:port", hex) — and hang the socket off a short
- * fixed /tmp dir instead of $TMPDIR. A master that died leaves a stale socket
- * behind; `ControlMaster=auto` notices, reconnects, and replaces it.
- *
- * @param {{ targetHost: string, user: string }} remote
- * @returns {string[]}
- */
-function multiplexOpts({ targetHost, user }) {
-  if (!SSH_MULTIPLEX) return ["-o", "ControlMaster=no", "-o", "ControlPath=none"];
-  const localHost = os.hostname();
-  const hash = crypto
-    .createHash("sha1")
-    .update(`${localHost}:${user}:${targetHost}:22`)
-    .digest("hex");
-  // /tmp/sparkdash-<40 hex> = 60 chars — under the limit on every platform,
-  // including macOS's short-sun_path world.
-  const controlPath = path.join("/tmp", `sparkdash-${hash}`);
-  return [
-    "-o",
-    "ControlMaster=auto",
-    "-o",
-    `ControlPath=${controlPath}`,
-    "-o",
-    `ControlPersist=${SSH_CONTROL_PERSIST}`,
-  ];
-}
-
-/**
  * Build file/args/env for an ssh (or sshpass) invocation. No shell interpolation.
  *
  * `extraSshArgs` sit after the shared ConnectTimeout / StrictHostKeyChecking
@@ -241,17 +198,11 @@ export function sshCommandSpec(spark, opts = {}) {
     opts.multiplex === false || !SSH_MULTIPLEX
       ? null
       : sshMultiplexConfig(spark, targetHost, user, auth, password);
-  // ControlPath selection (three tiers):
-  //   - multiplex:false / SSH_MULTIPLEX=0 (tunnels, picky sshd): own connection.
-  //   - #83 global master: %C-hashed socket shared per host/user/port, so
-  //     different sparks and collectors on the same Spark share one login.
-  //   - credential-isolated digest socket (main): only when the global master
-  //     is off but a control-persist was configured — password records with the
-  //     same host/user must never share an authenticated transport.
+  // The readiness gate and command must use the same socket and persistence.
+  // Explicitly disable both creating and joining a master when reuse is off,
+  // including when a user's ssh_config enables multiplexing independently.
   const controlOpts =
-    opts.multiplex === false || !SSH_MULTIPLEX
-      ? ["-o", "ControlMaster=no", "-o", "ControlPath=none"]
-      : multiplexOpts({ targetHost, user });
+    multiplex?.args ?? ["-o", "ControlMaster=no", "-o", "ControlPath=none"];
   // `--` stops option parsing before destination.
   let file;
   let args;

--- a/server/config.js
+++ b/server/config.js
@@ -31,11 +31,6 @@ const SSH_CONNECT_TIMEOUT = 5; // seconds
 // for every collector tick. Set SSH_MULTIPLEX=0 to go back to one connection
 // per command (e.g. an sshd with `MaxSessions 1`).
 const SSH_MULTIPLEX = process.env.SSH_MULTIPLEX !== "0";
-// How long an idle master connection lingers, in seconds. Long enough that the
-// slowest loop (Hermes, 10 min) still finds it up would keep a socket open for
-// hours; 5 minutes covers every metric domain and lets a rebooted Spark drop
-// its socket quickly.
-const SSH_CONTROL_PERSIST = process.env.SSH_CONTROL_PERSIST || "300";
 
 // ─── Poll intervals (milliseconds) ───────────────────────
 const POLL_INTERVAL_GPU = parseInt(process.env.POLL_INTERVAL_GPU || "2000", 10);
@@ -115,7 +110,6 @@ export {
   TAILSCALE_PROBE_TIMEOUT_MS,
   SSH_CONNECT_TIMEOUT,
   SSH_MULTIPLEX,
-  SSH_CONTROL_PERSIST,
   POLL_INTERVAL_GPU,
   POLL_INTERVAL_CPU,
   POLL_INTERVAL_NETWORK,


### PR DESCRIPTION
Remote collector commands currently use different SSH options from their readiness configuration. As a result, `SSH_CONTROL_PERSIST_SECONDS=0` still enables a 300-second master, and changes to the configured key or password do not change the socket passed to SSH.

Use the existing private control-socket configuration for both readiness and command execution. The documented persistence value and its bounds now reach SSH, zero disables both creating and joining a master, and the existing global switch and independent tunnel behavior remain supported. Retain `SSH_CONTROL_PERSIST` as a numeric fallback when the documented setting is unset. Add a host-memory troubleshooting note linking the separate upstream polkit fix.

Follow-up to #84 and #85; related to #73.

Validation:

- Expanded SSH suite: 18/18 pass; eight cases failed against unchanged main.
- `npm test`: 325 server tests and 23 frontend tests pass.
- `npm run typecheck`, `npm run build`, and `git diff --check` pass.
- Live read-only check using Node 22 and the Docker OpenSSH client against a DGX Spark: three concurrent reads plus a later read shared one Linux login session; master check passed, socket path was 50 bytes, and idle persistence was 60 seconds. The test closed its own master afterward.
